### PR TITLE
Invalid pom.xml when using the Karaf Blueprint archetype

### DIFF
--- a/archetypes/blueprint/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/blueprint/src/main/resources/archetype-resources/pom.xml
@@ -19,14 +19,16 @@
                 <version>^felix.plugin.version^</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                    <Bundle-Version>${project.version}</Bundle-Version>
-                    <Export-Package>
-                        ${package}*;version=${project.version}
-                    </Export-Package>
-                    <Import-Package>
-                        *
-                    </Import-Package>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                        <Export-Package>
+                            ${package}*;version=${project.version}
+                        </Export-Package>
+                        <Import-Package>
+                            *
+                        </Import-Package>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The pom.xml created by the blueprint archetype is marked as incorrect by my IDE. The code in question is :

``` xml
<configuration>
    <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
    <Bundle-Version>${project.version}</Bundle-Version>
    <Export-Package>
        ${package}*;version=${project.version}
    </Export-Package>
    <Import-Package>
        *
    </Import-Package>
</configuration>
```

If I enclose all the elements of `<configuration>` within the `<instructions>` elements, it is working fine.
