### PR TITLE
[KARAF-2124] - extending-console synced with KARAF-1001

### DIFF
--- a/manual/src/main/webapp/developers-guide/extending-console.conf
+++ b/manual/src/main/webapp/developers-guide/extending-console.conf
@@ -166,7 +166,7 @@ Inside this directory, create the {{OSGI-INF/blueprint/}} directory and put the 
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
     <command-bundle xmlns="http://karaf.apache.org/xmlns/shell/v1.1.0">
-        <command name="test/hello">
+        <command>
             <action class="org.apache.karaf.shell.samples.HelloShellCommand"/>
         </command>
     </command-bundle>
@@ -278,7 +278,7 @@ Using Blueprint, you can "inject" the completer linked to your command. The same
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
     <command-bundle xmlns="http://karaf.apache.org/xmlns/shell/v1.1.0">
-        <command name="test/hello">
+        <command>
             <action class="org.apache.karaf.shell.samples.HelloShellCommand"/>
             <completers>
                 <ref component-id="simpleNameCompleter"/>
@@ -331,7 +331,7 @@ blueprint configuration that will associate a completer with the -g option or it
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
     <command-bundle xmlns="http://karaf.apache.org/xmlns/shell/v1.1.0">
-        <command name="test/hello">
+        <command>
             <action class="org.apache.karaf.shell.samples.HelloShellCommand"/>
             <completers>
                 <ref component-id="simpleNameCompleter"/>


### PR DESCRIPTION
As mentioned in [this post](http://karaf.922171.n3.nabble.com/Karaf-3-0-0-Console-Extender-tp4027276p4027369.html) the documentation for Karaf 3.0.0  does not reflect the change made by KARAF-1001. This small patch corrects the chapter "Extending the console" in developers guide. 

https://issues.apache.org/jira/browse/KARAF-2124