### PR TITLE
bunde:scanner (new command) or bundle:watch (old command)

### DIFF
--- a/bundle/command/src/main/java/org/apache/karaf/bundle/command/Scanner.java
+++ b/bundle/command/src/main/java/org/apache/karaf/bundle/command/Scanner.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.bundle.command;
+
+import java.util.Map;
+
+import org.apache.karaf.bundle.core.BundleScanner;
+import org.apache.karaf.shell.commands.Command;
+import org.apache.karaf.shell.commands.Option;
+import org.apache.karaf.shell.console.AbstractAction;
+
+@Command( //
+scope = "bundle", //
+name = "scanner", //
+description = "Scans and updates snapshot bundles.", //
+detailedDescription = "Scans installed snapshot bundles, updates them from remote maven repository, and re-deploys changed jars in karaf.")
+public class Scanner extends AbstractAction {
+
+	@Option(name = "-i", aliases = { "--interval", "--time", "--delay" }, //
+	description = "Scan interval.", required = false, multiValued = false)
+	protected long interval;
+
+	@Option(name = "-b", aliases = { "--on", "--up", "--start", "--begin" }, //
+	description = "Starts scanner.", required = false, multiValued = false)
+	protected boolean start;
+
+	@Option(name = "-e", aliases = { "--off", "--down", "--stop", "--end" }, //
+	description = "Stops scanner.", required = false, multiValued = false)
+	protected boolean stop;
+
+	@Option(name = "-a", aliases = { "--add", "--new" }, //
+	description = "Adds new matching pattern.", required = false, multiValued = false)
+	protected String add;
+
+	@Option(name = "-r", aliases = { "--del", "--rem", "--kill", "--remove",
+			"--delete" }, //
+	description = "Removes existing matching pattern.", required = false, multiValued = false)
+	protected String remove;
+
+	@Option(name = "-l", aliases = { "--list", "--show", "--pattern" }, //
+	description = "Displays matching patterns.", required = false, multiValued = false)
+	protected boolean list;
+
+	@Option(name = "-x", aliases = { "--clear-list", "--list-clear",
+			"--kill-list" }, //
+	description = "Clear matching patterns.", required = false, multiValued = false)
+	protected boolean listClear;
+
+	@Option(name = "-s", aliases = { "--stat", "--statistics", "--updates" }, //
+	description = "Displays update statistics.", required = false, multiValued = false)
+	protected boolean stats;
+
+	@Option(name = "-z", aliases = { "--clear-stat", "--stat-clear",
+			"--kill-stat" }, //
+	description = "Clear update statistics.", required = false, multiValued = false)
+	protected boolean statsClear;
+
+	private BundleScanner bundleScanner;
+
+	public void setBundleScanner(BundleScanner bundleScanner) {
+		this.bundleScanner = bundleScanner;
+	}
+
+	@Override
+	protected Object doExecute() throws Exception {
+
+		/** Keep in order. */
+
+		if (start && stop) {
+			System.err
+					.println("Please use only one of 'start' and 'stop' options.");
+			return null;
+		}
+
+		if (interval > 0) {
+			bundleScanner.setInterval(interval);
+			System.out.println("Setting scanner interval to " + interval
+					+ " ms.");
+		} else if (interval < 0) {
+			System.err.println("Interval must be positive.");
+		}
+
+		if (start) {
+			if (!bundleScanner.isRunning()) {
+				System.out.println("Starting scanner.");
+				bundleScanner.start();
+			} else {
+				System.err.println("Scanner is already running.");
+			}
+		}
+
+		if (stop) {
+			if (bundleScanner.isRunning()) {
+				System.out.println("Stopping scanner.");
+				bundleScanner.stop();
+			} else {
+				System.err.println("Scanner was not running.");
+			}
+		}
+
+		if (add != null) {
+			if (bundleScanner.add(add)) {
+				System.out.println("Scanner pattern added.");
+			} else {
+				System.err.println("Scanner pattern ignored.");
+			}
+		}
+
+		if (remove != null) {
+			if (bundleScanner.remove(remove)) {
+				System.out.println("Scanner pattern removed.");
+			} else {
+				System.err.println("Scanner pattern ignored.");
+			}
+		}
+
+		if (list) {
+			System.out.println("Matching patterns:");
+			for (String regex : bundleScanner.getPatterns()) {
+				System.out.println("\t" + regex);
+			}
+		}
+
+		if (stats) {
+			System.out.println("Update statistics:");
+			for (Map.Entry<String, Integer> entry : bundleScanner
+					.getStatistics().entrySet()) {
+				final String bundle = entry.getKey();
+				final Integer counter = entry.getValue();
+				System.out.println(String.format("\t%6d %s", counter, bundle));
+			}
+		}
+
+		if (listClear) {
+			bundleScanner.clearPatterns();
+			System.out.println("Matching patterns cleared.");
+		}
+
+		if (statsClear) {
+			bundleScanner.clearStatistics();
+			System.out.println("Update statistics cleared.");
+		}
+
+		return null;
+
+	}
+
+}

--- a/bundle/command/src/main/resources/OSGI-INF/blueprint/shell-bundles.xml
+++ b/bundle/command/src/main/resources/OSGI-INF/blueprint/shell-bundles.xml
@@ -21,6 +21,7 @@
 
     <reference id="bundleService" interface="org.apache.karaf.bundle.core.BundleService" />
     <reference id="bundleWatcher" interface="org.apache.karaf.bundle.core.BundleWatcher"/>
+    <reference id="bundleScanner" interface="org.apache.karaf.bundle.core.BundleScanner"/>
 
     <command-bundle xmlns="http://karaf.apache.org/xmlns/shell/v1.1.0">
         <command>
@@ -125,6 +126,11 @@
         <command>
             <action class="org.apache.karaf.bundle.command.Watch" >
                 <property name="bundleWatcher" ref="bundleWatcher"/>
+            </action>
+        </command>
+        <command>
+            <action class="org.apache.karaf.bundle.command.Scanner" >
+                <property name="bundleScanner" ref="bundleScanner"/>
             </action>
         </command>
     </command-bundle>

--- a/bundle/command/src/main/resources/OSGI-INF/bundle.info
+++ b/bundle/command/src/main/resources/OSGI-INF/bundle.info
@@ -21,8 +21,9 @@ The following commands are available:
 * bundle:refresh - Refresh bundles.
 * bundle:resolve - Resolve bundles.
 * bundle:restart - Stop and restart bundles.
+* bundle:scanner - Scans and updates snapshot bundles.
 * bundle:start - Starts bundles.
-* bundlestart-level - Get or set the start level of a bundle.
+* bundle:start-level - Get or set the start level of a bundle.
 * bundle:stop - Stop bundles.
 * bundle:uninstall - Uninstall bundles.
 * bundle:update - Update a bundle.

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/core/BundleScanner.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/core/BundleScanner.java
@@ -13,9 +13,15 @@
  */
 package org.apache.karaf.bundle.core;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Periodically scan and update snapshot bundles matching a given bundle
  * symbolic name pattern.
+ * <p>
+ * Requires maven repository update policy set to "always" either globally or
+ * for individual remote maven repositories. See pax-url-aether.
  */
 public interface BundleScanner {
 
@@ -31,25 +37,52 @@ public interface BundleScanner {
 	 * 
 	 * @return true, if regex was removed.
 	 */
-	boolean remove(String pattern);
+	boolean remove(String regex);
+
+	/**
+	 * List of matching patterns.
+	 * 
+	 * @return list of regex expressoins.
+	 */
+	List<String> getPatterns();
+
+	/**
+	 * Remove all bundle symbolic name match patterns.
+	 */
+	void clearPatterns();
 
 	/**
 	 * Start scanner service.
-	 * 
-	 * @return true, if service was started.
 	 */
-	boolean start();
+	void start();
 
 	/**
 	 * Stop scanner service.
-	 * 
-	 * @return true, if service was stopped.
 	 */
-	boolean stop();
+	void stop();
 
 	/**
 	 * Set scanner invocation interval.
 	 */
 	void setInterval(long interval);
+
+	/**
+	 * Bundle update statistics:
+	 * <p>
+	 * [bundle-symbolic-name : number-of-updates]
+	 */
+	Map<String, Integer> getStatistics();
+
+	/**
+	 * Reset bundle update statistics:
+	 */
+	void clearStatistics();
+	
+	/**
+	 * Verify scanner run status.
+	 * 
+	 * @return true, if scanner is running.
+	 */
+	boolean isRunning();
 
 }

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/core/BundleScanner.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/core/BundleScanner.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.bundle.core;
+
+/**
+ * Periodically scan and update snapshot bundles matching a given bundle
+ * symbolic name pattern.
+ */
+public interface BundleScanner {
+
+	/**
+	 * Add bundle symbolic name match pattern.
+	 * 
+	 * @return true if regex is valid and was added.
+	 */
+	boolean add(String regex);
+
+	/**
+	 * Remove bundle symbolic name match pattern.
+	 * 
+	 * @return true, if regex was removed.
+	 */
+	boolean remove(String pattern);
+
+	/**
+	 * Start scanner service.
+	 * 
+	 * @return true, if service was started.
+	 */
+	boolean start();
+
+	/**
+	 * Stop scanner service.
+	 * 
+	 * @return true, if service was stopped.
+	 */
+	boolean stop();
+
+	/**
+	 * Set scanner invocation interval.
+	 */
+	void setInterval(long interval);
+
+}

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/BundleScannerImpl.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/BundleScannerImpl.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.bundle.core.internal;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLStreamHandler;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+import org.apache.karaf.bundle.core.BundleScanner;
+import org.apache.karaf.bundle.core.BundleService;
+import org.apache.karaf.bundle.core.BundleWatcher;
+import org.ops4j.pax.url.mvn.Parser;
+import org.ops4j.pax.url.mvn.ServiceConstants;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.BundleListener;
+import org.osgi.service.packageadmin.PackageAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * See {@link BundleScanner}
+ */
+public class BundleScannerImpl implements Runnable, BundleScanner {
+
+	/**
+	 * Matching bundles only with this qualifier
+	 */
+	private static final String QUALIFIER = "SNAPSHOT";
+	private static final String THREAD_NAME = BundleScannerImpl.class.getName();
+
+	private final Logger logger = LoggerFactory
+			.getLogger(BundleScannerImpl.class);
+
+	private volatile BundleContext bundleContext;
+	private final PackageAdmin packageAdmin;
+	private final MavenConfigService mavenConfigService;
+
+	private final AtomicBoolean running = new AtomicBoolean(false);
+	private volatile long interval = 1000L;
+	private final Map<String, Pattern> matchingPatterns = new ConcurrentHashMap<String, Pattern>();
+
+	/**
+	 * Constructor
+	 */
+	@SuppressWarnings("deprecation")
+	public BundleScannerImpl( //
+			BundleContext bundleContext, //
+			PackageAdmin packageAdmin, //
+			MavenConfigService mavenConfigService //
+	) {
+		this.bundleContext = bundleContext;
+		this.packageAdmin = packageAdmin;
+		this.mavenConfigService = mavenConfigService;
+	}
+
+	/**
+	 * Runs in dedicated thread.
+	 */
+	@Override
+	public void run() {
+
+		logger.debug("Bundle scanner thread started.");
+
+		while (running.get()) {
+
+			runCore();
+
+			try {
+				Thread.sleep(interval);
+			} catch (InterruptedException ex) {
+				running.set(false);
+			}
+
+		}
+
+		logger.debug("Bundle scanner thread stopped.");
+
+	}
+
+	@SuppressWarnings("deprecation")
+	private void runCore() {
+
+		if (matchingPatterns.isEmpty()) {
+			return;
+		}
+
+		Map<String, Bundle> matchingBundles = new HashMap<String, Bundle>();
+
+		for (Bundle bundle : bundleContext.getBundles()) {
+
+			String name = bundle.getSymbolicName();
+			String qualifier = bundle.getVersion().getQualifier();
+
+			if (!QUALIFIER.equalsIgnoreCase(qualifier)) {
+				continue;
+			}
+
+			for (Pattern pattern : matchingPatterns.values()) {
+				if (pattern.matcher(name).matches()) {
+					matchingBundles.put(name, bundle);
+				}
+			}
+		}
+
+		if (matchingBundles.isEmpty()) {
+			return;
+		}
+
+		File localRepository = mavenConfigService.getLocalRepository();
+
+		List<Bundle> updatedBundles = getUpdatedBundles(localRepository,
+				matchingBundles.values());
+
+		packageAdmin.refreshPackages(updatedBundles
+				.toArray(new Bundle[updatedBundles.size()]));
+
+	}
+
+	/**
+	 * {@link ServiceConstants#PROTOCOL}
+	 */
+	private boolean isMavenURL(String url) {
+		if (url == null) {
+			return false;
+		}
+		return url.startsWith(ServiceConstants.PROTOCOL);
+	}
+
+	/**
+	 * 
+	 */
+	private List<Bundle> getUpdatedBundles(File localRepository,
+			Collection<Bundle> bundleList) {
+
+		final List<Bundle> updatedList = new ArrayList<Bundle>();
+
+		for (Bundle bundle : bundleList) {
+
+			String bundleLocation = bundle.getLocation();
+
+			if (!isMavenURL(bundleLocation)) {
+				continue;
+			}
+
+			try {
+
+				final File externalLocation = getBundleExternalLocation(
+						localRepository, bundle);
+
+				if (externalLocation == null || !externalLocation.exists()) {
+					continue;
+				}
+
+				long bundleStamp = bundle.getLastModified();
+
+				long currentStamp = externalLocation.lastModified();
+
+				/**
+				 * Force maven resolution, can be constrained by maven update
+				 * policy.
+				 */
+				new URL(bundleLocation).openStream().close();
+
+				long updatedStamp = externalLocation.lastModified();
+
+				if (updatedStamp <= currentStamp) {
+
+				}
+
+				if (externalLocation.lastModified() > bundle.getLastModified()) {
+
+					InputStream is = new FileInputStream(externalLocation);
+
+					try {
+						logger.info("[Scanner] Updating matching bundle: "
+								+ bundle.getSymbolicName() + " ("
+								+ bundle.getVersion() + ")");
+						bundle.update(is);
+						updatedList.add(bundle);
+					} finally {
+						is.close();
+					}
+
+				}
+
+			} catch (Exception e) {
+				logger.info(
+						"[Scanner] Bundle update failure. "
+								+ bundle.getSymbolicName() + " ("
+								+ bundle.getVersion() + ")", e);
+			}
+
+		}
+
+		return updatedList;
+
+	}
+
+	@Override
+	public boolean add(String regex) {
+		try {
+			Pattern pattern = Pattern.compile(regex);
+			matchingPatterns.put(regex, pattern);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean remove(String regex) {
+		Pattern pattern = matchingPatterns.remove(regex);
+		return pattern != null;
+	}
+
+	/**
+	 * Extract bundleURI from "mvn:bundleURI"
+	 */
+	private String getBundleURI(Bundle bundle) {
+
+		final String location = bundle.getLocation();
+
+		if (!isMavenURL(location)) {
+			throw new IllegalStateException("Non maven bundle location : "
+					+ bundle);
+		}
+
+		String bundleURI = location.substring(ServiceConstants.PROTOCOL
+				.length() + 1);
+
+		return bundleURI;
+
+	}
+
+	/**
+	 * Returns the location of the Bundle inside the local maven repository.
+	 * 
+	 * @param bundle
+	 * @return
+	 */
+	private File getBundleExternalLocation(File localRepository, Bundle bundle) {
+		try {
+
+			Parser parser = new Parser(getBundleURI(bundle));
+
+			String filePath = localRepository.getPath() + File.separator
+					+ parser.getArtifactPath();
+
+			return new File(filePath);
+
+		} catch (Exception e) {
+			logger.error(
+					"Could not parse artifact path for bundle"
+							+ bundle.getSymbolicName(), e);
+		}
+		return null;
+	}
+
+	@Override
+	public boolean start() {
+		if (running.compareAndSet(false, true)) {
+			Thread thread = new Thread(this, THREAD_NAME);
+			thread.start();
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean stop() {
+		if (running.compareAndSet(true, false)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	public long getInterval() {
+		return interval;
+	}
+
+	@Override
+	public void setInterval(long interval) {
+		this.interval = interval;
+	}
+
+	public boolean isRunning() {
+		return running.get();
+	}
+
+}

--- a/bundle/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/bundle/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -25,7 +25,7 @@
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
     <reference id="packageAdmin" interface="org.osgi.service.packageadmin.PackageAdmin"/>
     <reference-list id="bundleStateServices" interface="org.apache.karaf.bundle.core.BundleStateService" availability="optional" />
-
+    
     <bean id="bundleService" class="org.apache.karaf.bundle.core.internal.BundleServiceImpl">
         <argument ref="blueprintBundleContext"/>
         <argument ref="bundleStateServices"/>
@@ -33,17 +33,24 @@
 
     <bean id="blueprintListener" class="org.apache.karaf.bundle.core.internal.BlueprintListener" />
 
-
     <bean id="bundlesMBean" class="org.apache.karaf.bundle.core.internal.Bundles">
         <argument ref="blueprintBundleContext" />
         <argument ref="bundleService" />
     </bean>
 
-    <bean id="watcher" class="org.apache.karaf.bundle.core.internal.BundleWatcherImpl" init-method="start" destroy-method="stop">
+    <bean id="watcher" class="org.apache.karaf.bundle.core.internal.BundleWatcherImpl" 
+    	init-method="start" destroy-method="stop">
         <argument ref="blueprintBundleContext"/>
         <argument ref="packageAdmin"/>
         <argument ref="mavenConfigService"/>
         <argument ref="bundleService"/>
+    </bean>
+
+    <bean id="scanner" class="org.apache.karaf.bundle.core.internal.BundleScannerImpl" 
+    	init-method="start" destroy-method="stop">
+        <argument ref="blueprintBundleContext"/>
+        <argument ref="packageAdmin"/>
+        <argument ref="mavenConfigService"/>
     </bean>
 
     <bean id="mavenConfigService" class="org.apache.karaf.bundle.core.internal.MavenConfigService">
@@ -57,12 +64,17 @@
             <value>org.apache.karaf.bundle.core.BundleStateService</value>
         </interfaces>
     </service>
+    
     <service interface="org.apache.karaf.bundle.core.BundleService" ref="bundleService"/>
+    
     <service ref="bundlesMBean" auto-export="interfaces">
          <service-properties>
               <entry key="jmx.objectname" value="org.apache.karaf:type=bundle,name=$[karaf.name]"/>
           </service-properties>
     </service>
+    
     <service ref="watcher" interface="org.apache.karaf.bundle.core.BundleWatcher"/>
+
+    <service ref="scanner" interface="org.apache.karaf.bundle.core.BundleScanner"/>
 
 </blueprint>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <pax.logging.version>1.7.0</pax.logging.version>
         <pax.runner.version>1.7.6</pax.runner.version>
         <pax.base.version>1.4.0</pax.base.version>
-        <pax.url.version>1.5.1</pax.url.version>
+        <pax.url.version>1.5.2-SNAPSHOT</pax.url.version>
         <pax.web.version>3.0.0.M2</pax.web.version>
         <pax.swissbox.version>1.5.1</pax.swissbox.version>
         <pax.tinybundle.version>1.0.0</pax.tinybundle.version>


### PR DESCRIPTION
This pull request add support for new command.

See https://issues.apache.org/jira/browse/KARAF-2186

bunde:scanner (new command)

```
@Command( //
scope = "bundle", //
name = "scanner", //
description = "Scans and updates snapshot bundles.", //
detailedDescription = "Scans installed snapshot bundles, updates them from remote maven repository, and re-deploys changed jars in karaf.")
```
Depends on
https://issues.apache.org/jira/browse/KARAF-2183
https://github.com/ops4j/org.ops4j.pax.url/pull/7

Was tested on karaf 3.0.0-SNAPSHOT