### PR TITLE
Sanity check arguments in their specified order

### DIFF
--- a/shell/console/src/main/java/org/apache/karaf/shell/commands/basic/DefaultActionPreparator.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/commands/basic/DefaultActionPreparator.java
@@ -168,7 +168,7 @@ public class DefaultActionPreparator implements ActionPreparator {
                     );
             }
         }
-        for (Argument argument : arguments.keySet()) {
+        for (Argument argument : orderedArguments) {
             if (argument.required() && argumentValues.get(argument) == null) {
                     throw new CommandException(commandErrorSt +
                             Ansi.ansi().a("argument ").bold().a(argument.name()).boldOff().a(" is required").toString(),

--- a/shell/console/src/test/java/org/apache/karaf/shell/commands/TestCommands.java
+++ b/shell/console/src/test/java/org/apache/karaf/shell/commands/TestCommands.java
@@ -81,6 +81,34 @@ public class TestCommands extends TestCase {
         assertEquals(Arrays.asList(4), c.execute("my-action --increment 3"));
     }
 
+    public void testCommandTwoArguments() throws Exception {
+        Context c= new Context();
+        c.addCommand("my-action-two-arguments", new SimpleCommand(MyActionTwoArguments.class));
+
+        // Test required argument
+        try
+        {
+            c.execute("my-action-two-arguments");
+            fail("Action should have thrown an exception because of a missing argument");
+        }
+        catch (CommandException e)
+        {
+            assertEquals("Argument one is required", e.getMessage());
+        }
+
+        try
+        {
+            c.execute("my-action-two-arguments 1");
+            fail("Action should have thrown an exception because of a missing argument");
+        }
+        catch (CommandException e)
+        {
+            assertEquals("Argument two is required", e.getMessage());
+        }
+
+        c.execute("my-action-two-arguments 1 2");
+    }
+
     public String capture() throws IOException
     {
         StringWriter sw = new StringWriter();
@@ -134,6 +162,20 @@ public class TestCommands extends TestCase {
                 }
             }
             return ids;
+        }
+    }
+
+    @Command(scope = "test", name = "my-action-two-arguments", description = "My Action with two arguments")
+    public static class MyActionTwoArguments implements Action
+    {
+        @Argument(index = 0, name = "one", description = "one description", required = true)
+        private String one;
+
+        @Argument(index = 1, name = "two", description = "two description", required = true)
+        private String two;
+
+        public Object execute(CommandSession session) throws Exception {
+            return null;
         }
     }
 }


### PR DESCRIPTION
This yields the correct error message when a user lacks a parameter to
a command with more than one argument.  Fixed KARAF-2368.
