### PR TITLE
[KARAF-2395] Make karaf-maven-plugin usable with Maven 3.1 and 3.0

### DIFF
--- a/tooling/karaf-maven-plugin/pom.xml
+++ b/tooling/karaf-maven-plugin/pom.xml
@@ -54,6 +54,16 @@
            <version>1.11</version>
          </dependency>
         <dependency>
+           <groupId>org.eclipse.aether</groupId>
+           <artifactId>aether-api</artifactId>
+           <version>0.9.0.M2</version>
+         </dependency>
+         <dependency>
+           <groupId>org.eclipse.aether</groupId>
+           <artifactId>aether-util</artifactId>
+           <version>0.9.0.M2</version>
+         </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <version>3.0.3</version>

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/Dependency30Helper.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/Dependency30Helper.java
@@ -1,0 +1,381 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.tooling.features;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.maven.RepositoryUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.sonatype.aether.RepositorySystem;
+import org.sonatype.aether.RepositorySystemSession;
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.collection.CollectRequest;
+import org.sonatype.aether.collection.CollectResult;
+import org.sonatype.aether.collection.DependencyCollectionContext;
+import org.sonatype.aether.collection.DependencyCollectionException;
+import org.sonatype.aether.collection.DependencyGraphTransformer;
+import org.sonatype.aether.collection.DependencySelector;
+import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.repository.RemoteRepository;
+import org.sonatype.aether.resolution.ArtifactRequest;
+import org.sonatype.aether.resolution.ArtifactResolutionException;
+import org.sonatype.aether.resolution.ArtifactResult;
+import org.sonatype.aether.util.DefaultRepositorySystemSession;
+import org.sonatype.aether.util.artifact.DefaultArtifact;
+import org.sonatype.aether.util.graph.selector.AndDependencySelector;
+import org.sonatype.aether.util.graph.selector.ExclusionDependencySelector;
+import org.sonatype.aether.util.graph.selector.OptionalDependencySelector;
+import org.sonatype.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
+import org.sonatype.aether.util.graph.transformer.ConflictMarker;
+import org.sonatype.aether.util.graph.transformer.JavaDependencyContextRefiner;
+import org.sonatype.aether.util.graph.transformer.JavaEffectiveScopeCalculator;
+
+import static java.lang.String.*;
+import static org.apache.karaf.deployer.kar.KarArtifactInstaller.FEATURE_CLASSIFIER;
+
+public class Dependency30Helper implements DependencyHelper {
+
+    /**
+      * The entry point to Aether, i.e. the component doing all the work.
+      */
+     private final RepositorySystem repoSystem;
+
+     /**
+      * The current repository/network configuration of Maven.
+      */
+     private final RepositorySystemSession repoSession;
+
+     /**
+      * The project's remote repositories to use for the resolution of project dependencies.
+      *
+      * @parameter default-value="${project.remoteProjectRepositories}"
+      * @readonly
+      */
+     private final List<RemoteRepository> projectRepos;
+
+    //dependencies we are interested in
+    protected Map<Artifact, String> localDependencies;
+    //log of what happened during search
+    protected String treeListing;
+
+    public Dependency30Helper(List<RemoteRepository> projectRepos, RepositorySystemSession repoSession, RepositorySystem repoSystem) {
+        this.projectRepos = projectRepos;
+        this.repoSession = repoSession;
+        this.repoSystem = repoSystem;
+    }
+
+    @Override
+    public Map<Artifact, String> getLocalDependencies() {
+        return localDependencies;
+    }
+
+    @Override
+    public String getTreeListing() {
+        return treeListing;
+    }
+
+    //artifact search code adapted from geronimo car plugin
+
+    @Override
+    public void getDependencies(MavenProject project, boolean useTransitiveDependencies) throws MojoExecutionException {
+
+        DependencyNode rootNode = getDependencyTree(RepositoryUtils.toArtifact(project.getArtifact()));
+
+        Scanner scanner = new Scanner();
+        scanner.scan(rootNode, useTransitiveDependencies);
+        localDependencies = scanner.localDependencies;
+        treeListing = scanner.getLog();
+    }
+
+    private DependencyNode getDependencyTree(Artifact artifact) throws MojoExecutionException {
+        try {
+            CollectRequest collectRequest = new CollectRequest(new Dependency(artifact, "compile"), null, projectRepos);
+            DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(repoSession);
+            session.setDependencySelector(new AndDependencySelector(new OptionalDependencySelector(),
+                    new ScopeDependencySelector1(),
+                    new ExclusionDependencySelector()));
+            DependencyGraphTransformer transformer = new ChainedDependencyGraphTransformer(new ConflictMarker(),
+                    new JavaEffectiveScopeCalculator(),
+                    new JavaDependencyContextRefiner());
+            session.setDependencyGraphTransformer(transformer);
+            CollectResult result = repoSystem.collectDependencies(session, collectRequest);
+            return result.getRoot();
+        } catch (DependencyCollectionException e) {
+            throw new MojoExecutionException("Cannot build project dependency tree", e);
+        }
+    }
+
+    //aether's ScopeDependencySelector appears to always exclude the configured scopes (test and provided) and there is no way to configure it to
+    //accept the top level provided scope dependencies.  We need this 3 layer cake since aether never actually uses the top level selector you give it,
+    //it always starts by getting the child to apply to the project's dependencies.
+    private static class ScopeDependencySelector1 implements DependencySelector {
+
+        private DependencySelector child = new ScopeDependencySelector2();
+
+        public boolean selectDependency(Dependency dependency) {
+            throw new IllegalStateException("this does not appear to be called");
+        }
+
+        public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
+            return child;
+        }
+    }
+
+    private static class ScopeDependencySelector2 implements DependencySelector {
+
+        private DependencySelector child = new ScopeDependencySelector3();
+
+        public boolean selectDependency(Dependency dependency) {
+            String scope = dependency.getScope();
+            return !"test".equals(scope) && !"runtime".equals(scope);
+        }
+
+        public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
+            return child;
+        }
+    }
+
+    private static class ScopeDependencySelector3 implements DependencySelector {
+
+        public boolean selectDependency(Dependency dependency) {
+            String scope = dependency.getScope();
+            return !"test".equals(scope) && !"provided".equals(scope) && !"runtime".equals(scope);
+        }
+
+        public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
+            return this;
+        }
+    }
+
+    private static class Scanner {
+
+        private static enum Accept {
+            ACCEPT(true, true),
+            PROVIDED(true, false),
+            STOP(false, false);
+
+            private final boolean more;
+            private final boolean local;
+
+            private Accept(boolean more, boolean local) {
+                this.more = more;
+                this.local = local;
+            }
+
+            public boolean isContinue() {
+                return more;
+            }
+
+            public boolean isLocal() {
+                return local;
+            }
+        }
+
+        //all the dependencies needed for this car, with provided dependencies removed. artifact to scope map
+        private final Map<Artifact, String> localDependencies = new LinkedHashMap<Artifact, String>();
+        //dependencies from ancestor cars, to be removed from localDependencies.
+        private final Set<Artifact> carDependencies = new LinkedHashSet<Artifact>();
+
+        private final StringBuilder log = new StringBuilder();
+
+        public void scan(DependencyNode rootNode, boolean useTransitiveDependencies) throws MojoExecutionException {
+            for (DependencyNode child : rootNode.getChildren()) {
+                scan(child, Accept.ACCEPT, useTransitiveDependencies, false, "");
+            }
+            if (useTransitiveDependencies) {
+                localDependencies.keySet().removeAll(carDependencies);
+            }
+        }
+
+        private void scan(DependencyNode dependencyNode, Accept parentAccept, boolean useTransitiveDependencies, boolean isFromFeature, String indent) throws MojoExecutionException {
+//            Artifact artifact = getArtifact(rootNode);
+
+            Accept accept = accept(dependencyNode, parentAccept);
+            if (accept.isLocal()) {
+                if (isFromFeature) {
+                    if (!isFeature(dependencyNode)) {
+                        log.append(indent).append("from feature:").append(dependencyNode).append("\n");
+                        carDependencies.add(dependencyNode.getDependency().getArtifact());
+                    } else {
+                        log.append(indent).append("is feature:").append(dependencyNode).append("\n");
+                    }
+                } else {
+                    log.append(indent).append("local:").append(dependencyNode).append("\n");
+                    if (localDependencies.containsKey(dependencyNode.getDependency().getArtifact())) {
+                        log.append(indent).append("already in feature, returning:").append(dependencyNode).append("\n");
+                        return;
+                    }
+                    //TODO resolve scope conflicts
+                    localDependencies.put(dependencyNode.getDependency().getArtifact(), dependencyNode.getDependency().getScope());
+                    if (isFeature(dependencyNode) || !useTransitiveDependencies) {
+                        isFromFeature = true;
+                    }
+                }
+                if (useTransitiveDependencies && accept.isContinue()) {
+                    List<DependencyNode> children = dependencyNode.getChildren();
+                    for (DependencyNode child : children) {
+                        scan(child, accept, useTransitiveDependencies, isFromFeature, indent + "  ");
+                    }
+                }
+            }
+        }
+
+
+        public String getLog() {
+            return log.toString();
+        }
+
+        private Accept accept(DependencyNode dependency, Accept previous) {
+            String scope = dependency.getDependency().getScope();
+            if (scope == null || "runtime".equalsIgnoreCase(scope) || "compile".equalsIgnoreCase(scope)) {
+                return previous;
+            }
+            if ("provided".equalsIgnoreCase(scope)) {
+                return Accept.PROVIDED;
+            }
+            return Accept.STOP;
+        }
+
+    }
+
+    public static boolean isFeature(DependencyNode dependencyNode) {
+        return isFeature(dependencyNode.getDependency().getArtifact());
+    }
+
+    public static boolean isFeature(Artifact artifact) {
+        return artifact.getExtension().equals("kar") || FEATURE_CLASSIFIER.equals(artifact.getClassifier());
+    }
+
+    @Override
+    public boolean isArtifactAFeature(Object artifact) {
+        return Dependency30Helper.isFeature((Artifact)artifact);
+    }
+
+    @Override
+    public String getArtifactId(Object artifact) {
+        return ((Artifact)artifact).getArtifactId();
+    }
+
+    @Override
+    public String getClassifier(Object artifact) {
+        return ((Artifact)artifact).getClassifier();
+    }
+
+    @Override
+    public File resolve(Object artifact, Log log) {
+        ArtifactRequest request = new ArtifactRequest();
+        request.setArtifact((Artifact)artifact);
+        request.setRepositories(projectRepos);
+
+        log.debug("Resolving artifact " + artifact +
+                " from " + projectRepos);
+
+        ArtifactResult result;
+        try {
+            result = repoSystem.resolveArtifact(repoSession, request);
+        } catch (org.sonatype.aether.resolution.ArtifactResolutionException e) {
+            log.warn("could not resolve " + artifact, e);
+            return null;
+        }
+
+        log.debug("Resolved artifact " + artifact + " to " +
+                result.getArtifact().getFile() + " from "
+                + result.getRepository());
+        return result.getArtifact().getFile();
+    }
+
+    @Override
+    public File resolveById(String id, Log log) throws MojoFailureException {
+        id = MavenUtil.mvnToAether(id);
+        ArtifactRequest request = new ArtifactRequest();
+        request.setArtifact(new DefaultArtifact(id));
+        request.setRepositories((List<RemoteRepository>)projectRepos);
+
+        log.debug("Resolving artifact " + id +
+                " from " + projectRepos);
+
+        ArtifactResult result;
+        try {
+            result = repoSystem.resolveArtifact(repoSession, request);
+        } catch (ArtifactResolutionException e) {
+            log.warn("could not resolve " + id, e);
+            throw new MojoFailureException(format("Couldn't resolve artifact %s", id), e);
+        }
+
+        log.debug("Resolved artifact " + id + " to " +
+                result.getArtifact().getFile() + " from "
+                + result.getRepository());
+        return result.getArtifact().getFile();
+    }
+
+    @Override
+    public String artifactToMvn(org.apache.maven.artifact.Artifact artifact) {
+        return this.artifactToMvn(RepositoryUtils.toArtifact(artifact));
+    }
+
+    @Override
+    public String artifactToMvn(Object _artifact) {
+        Artifact artifact = (Artifact)_artifact;
+        String bundleName;
+        if (artifact.getExtension().equals("jar") && MavenUtil.isEmpty(artifact.getClassifier())) {
+            bundleName = String.format("mvn:%s/%s/%s", artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion());
+        } else {
+            if (MavenUtil.isEmpty(artifact.getClassifier())) {
+                bundleName = String.format("mvn:%s/%s/%s/%s", artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion(), artifact.getExtension());
+            } else {
+                bundleName = String.format("mvn:%s/%s/%s/%s/%s", artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion(), artifact.getExtension(), artifact.getClassifier());
+            }
+        }
+        return bundleName;
+    }
+
+    @Override
+    public org.apache.maven.artifact.Artifact mvnToArtifact(String name) {
+        name = MavenUtil.mvnToAether(name);
+        DefaultArtifact artifact = new DefaultArtifact(name);
+        org.apache.maven.artifact.Artifact mavenArtifact = RepositoryUtils.toArtifact(artifact);
+        return mavenArtifact;
+    }
+
+    @Override
+    public String pathFromMaven(String name) {
+        if (name.indexOf(':') == -1) {
+            return name;
+        }
+        name = MavenUtil.mvnToAether(name);
+        return pathFromAether(name);
+    }
+
+    @Override
+    public String pathFromAether(String name) {
+        DefaultArtifact artifact = new DefaultArtifact(name);
+        org.apache.maven.artifact.Artifact mavenArtifact = RepositoryUtils.toArtifact(artifact);
+        return MavenUtil.layout.pathOf(mavenArtifact);
+    }
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/Dependency31Helper.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/Dependency31Helper.java
@@ -1,0 +1,416 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.tooling.features;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.maven.RepositoryUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.collection.DependencyCollectionContext;
+import org.eclipse.aether.collection.DependencyCollectionException;
+import org.eclipse.aether.collection.DependencyGraphTransformer;
+import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.util.graph.selector.AndDependencySelector;
+import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
+import org.eclipse.aether.util.graph.selector.OptionalDependencySelector;
+import org.eclipse.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
+import org.eclipse.aether.util.graph.transformer.ConflictMarker;
+import org.eclipse.aether.util.graph.transformer.ConflictResolver;
+import org.eclipse.aether.util.graph.transformer.JavaDependencyContextRefiner;
+import org.eclipse.aether.util.graph.transformer.JavaScopeDeriver;
+import org.eclipse.aether.util.graph.transformer.JavaScopeSelector;
+import org.eclipse.aether.util.graph.transformer.NearestVersionSelector;
+import org.eclipse.aether.util.graph.transformer.SimpleOptionalitySelector;
+
+import static java.lang.String.*;
+import static org.apache.karaf.deployer.kar.KarArtifactInstaller.FEATURE_CLASSIFIER;
+
+/**
+ * <p>{@link DependencyHelper} for accessing Aether system when used with Maven 3.1.0+. It uses reflection to access
+ * these methods of {@code maven-core} APIs which directly references Aether classes.</p>
+ * 
+ * <p>When {@code karaf-maven-plugin} switches to {@code maven-core:3.1.0+}, reflection should be use for Sonatype
+ * variant of Aether in {@link Dependency30Helper} and this class will use Maven API directly..</p>
+ *
+ * @author Grzegorz Grzybek
+ */
+public class Dependency31Helper implements DependencyHelper {
+
+    /**
+      * The entry point to Aether, i.e. the component doing all the work.
+      */
+     private final RepositorySystem repoSystem;
+
+     /**
+      * The current repository/network configuration of Maven.
+      */
+     private final RepositorySystemSession repoSession;
+
+     /**
+      * The project's remote repositories to use for the resolution of project dependencies.
+      *
+      * @parameter default-value="${project.remoteProjectRepositories}"
+      * @readonly
+      */
+     private final List<RemoteRepository> projectRepos;
+
+    //dependencies we are interested in
+    protected Map<Artifact, String> localDependencies;
+    //log of what happened during search
+    protected String treeListing;
+
+    @SuppressWarnings("unchecked")
+    public Dependency31Helper(List<?> repositories, Object session, RepositorySystem repoSystem) {
+        this.projectRepos = (List<RemoteRepository>)repositories;
+        this.repoSession = (RepositorySystemSession)session;
+        this.repoSystem = repoSystem;
+    }
+
+    @Override
+    public Map<?, String> getLocalDependencies() {
+        return localDependencies;
+    }
+
+    @Override
+    public String getTreeListing() {
+        return treeListing;
+    }
+
+    //artifact search code adapted from geronimo car plugin
+
+    @Override
+    public void getDependencies(MavenProject project, boolean useTransitiveDependencies) throws MojoExecutionException {
+
+        DependencyNode rootNode = getDependencyTree(toArtifact(project.getArtifact()));;
+
+        Scanner scanner = new Scanner();
+        scanner.scan(rootNode, useTransitiveDependencies);
+        localDependencies = scanner.localDependencies;
+        treeListing = scanner.getLog();
+    }
+
+    private DependencyNode getDependencyTree(Artifact artifact) throws MojoExecutionException {
+        try {
+            CollectRequest collectRequest = new CollectRequest(new Dependency(artifact, "compile"), null, projectRepos);
+            DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(repoSession);
+            session.setDependencySelector(new AndDependencySelector(new OptionalDependencySelector(),
+                    new ScopeDependencySelector1(),
+                    new ExclusionDependencySelector()));
+            // between aether-util-0.9.0.M1 and M2 JavaEffectiveScopeCalculator was removed
+            // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=397241
+            DependencyGraphTransformer transformer = new ChainedDependencyGraphTransformer(new ConflictMarker(),
+                    new ConflictResolver(new NearestVersionSelector(), new JavaScopeSelector(), new SimpleOptionalitySelector(), new JavaScopeDeriver()),
+                    new JavaDependencyContextRefiner());
+            session.setDependencyGraphTransformer(transformer);
+            CollectResult result = repoSystem.collectDependencies(session, collectRequest);
+            return result.getRoot();
+        } catch (DependencyCollectionException e) {
+            throw new MojoExecutionException("Cannot build project dependency tree", e);
+        }
+    }
+
+    //aether's ScopeDependencySelector appears to always exclude the configured scopes (test and provided) and there is no way to configure it to
+    //accept the top level provided scope dependencies.  We need this 3 layer cake since aether never actually uses the top level selector you give it,
+    //it always starts by getting the child to apply to the project's dependencies.
+    private static class ScopeDependencySelector1 implements DependencySelector {
+
+        private DependencySelector child = new ScopeDependencySelector2();
+
+        public boolean selectDependency(Dependency dependency) {
+            throw new IllegalStateException("this does not appear to be called");
+        }
+
+        public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
+            return child;
+        }
+    }
+
+    private static class ScopeDependencySelector2 implements DependencySelector {
+
+        private DependencySelector child = new ScopeDependencySelector3();
+
+        public boolean selectDependency(Dependency dependency) {
+            String scope = dependency.getScope();
+            return !"test".equals(scope) && !"runtime".equals(scope);
+        }
+
+        public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
+            return child;
+        }
+    }
+
+    private static class ScopeDependencySelector3 implements DependencySelector {
+
+        public boolean selectDependency(Dependency dependency) {
+            String scope = dependency.getScope();
+            return !"test".equals(scope) && !"provided".equals(scope) && !"runtime".equals(scope);
+        }
+
+        public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
+            return this;
+        }
+    }
+
+    private static class Scanner {
+
+        private static enum Accept {
+            ACCEPT(true, true),
+            PROVIDED(true, false),
+            STOP(false, false);
+
+            private final boolean more;
+            private final boolean local;
+
+            private Accept(boolean more, boolean local) {
+                this.more = more;
+                this.local = local;
+            }
+
+            public boolean isContinue() {
+                return more;
+            }
+
+            public boolean isLocal() {
+                return local;
+            }
+        }
+
+        //all the dependencies needed for this car, with provided dependencies removed. artifact to scope map
+        private final Map<Artifact, String> localDependencies = new LinkedHashMap<Artifact, String>();
+        //dependencies from ancestor cars, to be removed from localDependencies.
+        private final Set<Artifact> carDependencies = new LinkedHashSet<Artifact>();
+
+        private final StringBuilder log = new StringBuilder();
+
+        public void scan(DependencyNode rootNode, boolean useTransitiveDependencies) throws MojoExecutionException {
+            for (DependencyNode child : rootNode.getChildren()) {
+                scan(child, Accept.ACCEPT, useTransitiveDependencies, false, "");
+            }
+            if (useTransitiveDependencies) {
+                localDependencies.keySet().removeAll(carDependencies);
+            }
+        }
+
+        private void scan(DependencyNode dependencyNode, Accept parentAccept, boolean useTransitiveDependencies, boolean isFromFeature, String indent) throws MojoExecutionException {
+//            Artifact artifact = getArtifact(rootNode);
+
+            Accept accept = accept(dependencyNode, parentAccept);
+            if (accept.isLocal()) {
+                if (isFromFeature) {
+                    if (!isFeature(dependencyNode)) {
+                        log.append(indent).append("from feature:").append(dependencyNode).append("\n");
+                        carDependencies.add(dependencyNode.getDependency().getArtifact());
+                    } else {
+                        log.append(indent).append("is feature:").append(dependencyNode).append("\n");
+                    }
+                } else {
+                    log.append(indent).append("local:").append(dependencyNode).append("\n");
+                    if (localDependencies.containsKey(dependencyNode.getDependency().getArtifact())) {
+                        log.append(indent).append("already in feature, returning:").append(dependencyNode).append("\n");
+                        return;
+                    }
+                    //TODO resolve scope conflicts
+                    localDependencies.put(dependencyNode.getDependency().getArtifact(), dependencyNode.getDependency().getScope());
+                    if (isFeature(dependencyNode) || !useTransitiveDependencies) {
+                        isFromFeature = true;
+                    }
+                }
+                if (useTransitiveDependencies && accept.isContinue()) {
+                    List<DependencyNode> children = dependencyNode.getChildren();
+                    for (DependencyNode child : children) {
+                        scan(child, accept, useTransitiveDependencies, isFromFeature, indent + "  ");
+                    }
+                }
+            }
+        }
+
+
+        public String getLog() {
+            return log.toString();
+        }
+
+        private Accept accept(DependencyNode dependency, Accept previous) {
+            String scope = dependency.getDependency().getScope();
+            if (scope == null || "runtime".equalsIgnoreCase(scope) || "compile".equalsIgnoreCase(scope)) {
+                return previous;
+            }
+            if ("provided".equalsIgnoreCase(scope)) {
+                return Accept.PROVIDED;
+            }
+            return Accept.STOP;
+        }
+
+    }
+
+    public static boolean isFeature(DependencyNode dependencyNode) {
+        return isFeature(dependencyNode.getDependency().getArtifact());
+    }
+
+    public static boolean isFeature(Artifact artifact) {
+        return artifact.getExtension().equals("kar") || FEATURE_CLASSIFIER.equals(artifact.getClassifier());
+    }
+
+    @Override
+    public boolean isArtifactAFeature(Object artifact) {
+        return Dependency31Helper.isFeature((Artifact)artifact);
+    }
+
+    @Override
+    public String getArtifactId(Object artifact) {
+        return ((Artifact)artifact).getArtifactId();
+    }
+
+    @Override
+    public String getClassifier(Object artifact) {
+        return ((Artifact)artifact).getClassifier();
+    }
+
+    @Override
+    public File resolve(Object artifact, Log log) {
+        ArtifactRequest request = new ArtifactRequest();
+        request.setArtifact((Artifact)artifact);
+        request.setRepositories(projectRepos);
+
+        log.debug("Resolving artifact " + artifact +
+                " from " + projectRepos);
+
+        ArtifactResult result;
+        try {
+            result = repoSystem.resolveArtifact(repoSession, request);
+        } catch (org.eclipse.aether.resolution.ArtifactResolutionException e) {
+            log.warn("could not resolve " + artifact, e);
+            return null;
+        }
+
+        log.debug("Resolved artifact " + artifact + " to " +
+                result.getArtifact().getFile() + " from "
+                + result.getRepository());
+        return result.getArtifact().getFile();
+    }
+
+    @Override
+    public File resolveById(String id, Log log) throws MojoFailureException {
+        id = MavenUtil.mvnToAether(id);
+        ArtifactRequest request = new ArtifactRequest();
+        request.setArtifact(new DefaultArtifact(id));
+        request.setRepositories((List<RemoteRepository>)projectRepos);
+
+        log.debug("Resolving artifact " + id +
+                " from " + projectRepos);
+
+        ArtifactResult result;
+        try {
+            result = repoSystem.resolveArtifact(repoSession, request);
+        } catch (ArtifactResolutionException e) {
+            log.warn("could not resolve " + id, e);
+            throw new MojoFailureException(format("Couldn't resolve artifact %s", id), e);
+        }
+
+        log.debug("Resolved artifact " + id + " to " +
+                result.getArtifact().getFile() + " from "
+                + result.getRepository());
+        return result.getArtifact().getFile();
+    }
+
+    @Override
+    public String artifactToMvn(org.apache.maven.artifact.Artifact artifact) throws MojoExecutionException {
+        return this.artifactToMvn(toArtifact(artifact));
+    }
+
+    @Override
+    public String artifactToMvn(Object _artifact) {
+        Artifact artifact = (Artifact)_artifact;
+        String bundleName;
+        if (artifact.getExtension().equals("jar") && MavenUtil.isEmpty(artifact.getClassifier())) {
+            bundleName = String.format("mvn:%s/%s/%s", artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion());
+        } else {
+            if (MavenUtil.isEmpty(artifact.getClassifier())) {
+                bundleName = String.format("mvn:%s/%s/%s/%s", artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion(), artifact.getExtension());
+            } else {
+                bundleName = String.format("mvn:%s/%s/%s/%s/%s", artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion(), artifact.getExtension(), artifact.getClassifier());
+            }
+        }
+        return bundleName;
+    }
+
+    private static Artifact toArtifact(org.apache.maven.artifact.Artifact artifact) throws MojoExecutionException {
+        try {
+            Method toArtifact = RepositoryUtils.class.getMethod("toArtifact", org.apache.maven.artifact.Artifact.class);
+            return (Artifact)toArtifact.invoke(null, artifact);
+        } catch (Exception e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+    }
+    
+    private static org.apache.maven.artifact.Artifact toArtifact(Artifact artifact) throws MojoExecutionException {
+        try {
+            Method toArtifact = RepositoryUtils.class.getMethod("toArtifact", Artifact.class);
+            return (org.apache.maven.artifact.Artifact)toArtifact.invoke(null, artifact);
+        } catch (Exception e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public org.apache.maven.artifact.Artifact mvnToArtifact(String name) throws MojoExecutionException {
+        name = MavenUtil.mvnToAether(name);
+        DefaultArtifact artifact = new DefaultArtifact(name);
+        org.apache.maven.artifact.Artifact mavenArtifact = toArtifact(artifact);
+        return mavenArtifact;
+    }
+
+    @Override
+    public String pathFromMaven(String name) throws MojoExecutionException {
+        if (name.indexOf(':') == -1) {
+            return name;
+        }
+        name = MavenUtil.mvnToAether(name);
+        return pathFromAether(name);
+    }
+
+    @Override
+    public String pathFromAether(String name) throws MojoExecutionException {
+        DefaultArtifact artifact = new DefaultArtifact(name);
+        org.apache.maven.artifact.Artifact mavenArtifact = toArtifact(artifact);
+        return MavenUtil.layout.pathOf(mavenArtifact);
+    }
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/DependencyHelper.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/DependencyHelper.java
@@ -18,255 +18,72 @@
  */
 package org.apache.karaf.tooling.features;
 
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.io.File;
 import java.util.Map;
-import java.util.Set;
 
-import org.apache.maven.RepositoryUtils;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
-import org.sonatype.aether.RepositorySystem;
-import org.sonatype.aether.RepositorySystemSession;
-import org.sonatype.aether.artifact.Artifact;
-import org.sonatype.aether.collection.CollectRequest;
-import org.sonatype.aether.collection.CollectResult;
-import org.sonatype.aether.collection.DependencyCollectionContext;
-import org.sonatype.aether.collection.DependencyCollectionException;
-import org.sonatype.aether.collection.DependencyGraphTransformer;
-import org.sonatype.aether.collection.DependencySelector;
-import org.sonatype.aether.graph.Dependency;
-import org.sonatype.aether.graph.DependencyNode;
-import org.sonatype.aether.repository.RemoteRepository;
-import org.sonatype.aether.util.DefaultRepositorySystemSession;
-import org.sonatype.aether.util.graph.selector.AndDependencySelector;
-import org.sonatype.aether.util.graph.selector.ExclusionDependencySelector;
-import org.sonatype.aether.util.graph.selector.OptionalDependencySelector;
-import org.sonatype.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
-import org.sonatype.aether.util.graph.transformer.ConflictMarker;
-import org.sonatype.aether.util.graph.transformer.JavaDependencyContextRefiner;
-import org.sonatype.aether.util.graph.transformer.JavaEffectiveScopeCalculator;
 
-import static org.apache.karaf.deployer.kar.KarArtifactInstaller.FEATURE_CLASSIFIER;
+/**
+ * <p>An interface for accessing available Aether subsystem (Sonatype for Maven 3.0.x or Eclipse for Maven 3.1.x)</p>
+ * 
+ * <p>Some methods have {@link Object} parameters because they should be able to receive Aether classes from
+ * both Aether variants.</p>
+ *
+ * @author Grzegorz Grzybek
+ */
+public interface DependencyHelper {
 
-public class DependencyHelper {
+    public abstract Map<?, String> getLocalDependencies();
+
+    public abstract String getTreeListing();
+
+    public abstract void getDependencies(MavenProject project, boolean useTransitiveDependencies) throws MojoExecutionException;
+
+    public boolean isArtifactAFeature(Object artifact);
+
+    public abstract String getArtifactId(Object artifact);
+
+    public abstract String getClassifier(Object artifact);
+
+    public abstract File resolve(Object artifact, Log log);
+
+    public abstract File resolveById(String id, Log log) throws MojoFailureException;
 
     /**
-      * The entry point to Aether, i.e. the component doing all the work.
-      *
-      * @component
-      * @required
-      * @readonly
-      */
-     private final RepositorySystem repoSystem;
+     * Convert a Maven <code>Artifact</code> into a PAX URL mvn format.
+     *
+     * @param artifact the Maven <code>Artifact</code>.
+     * @return the corresponding PAX URL mvn format (mvn:<groupId>/<artifactId>/<version>/<type>/<classifier>)
+     */
+    public String artifactToMvn(Artifact artifact) throws MojoExecutionException;
 
-     /**
-      * The current repository/network configuration of Maven.
-      *
-      * @parameter default-value="${repositorySystemSession}"
-      * @required
-      * @readonly
-      */
-     private final RepositorySystemSession repoSession;
+    /**
+     * Convert an Aether (Sonatype or Eclipse) into a PAX URL mvn format.
+     *
+     * @param artifact the Aether <code>org.sonatype|eclipse.aether.artifact.Artifact</code>.
+     * @return the corresponding PAX URL mvn format (mvn:<groupId>/<artifactId>/<version>/<type>/<classifier>)
+     */
+    public String artifactToMvn(Object artifact);
 
-     /**
-      * The project's remote repositories to use for the resolution of project dependencies.
-      *
-      * @parameter default-value="${project.remoteProjectRepositories}"
-      * @readonly
-      */
-     private final List<RemoteRepository> projectRepos;
+    public Artifact mvnToArtifact(String name) throws MojoExecutionException;
 
-    //dependencies we are interested in
-    protected Map<Artifact, String> localDependencies;
-    //log of what happened during search
-    protected String treeListing;
+    /**
+     * Convert a PAX URL mvn format into a filesystem path.
+     *
+     * @param name PAX URL mvn format (mvn:<groupId>/<artifactId>/<version>/<type>/<classifier>)
+     * @return a filesystem path
+     */
+    public String pathFromMaven(String name) throws MojoExecutionException;
 
-    public DependencyHelper(List<RemoteRepository> projectRepos, RepositorySystemSession repoSession, RepositorySystem repoSystem) {
-        this.projectRepos = projectRepos;
-        this.repoSession = repoSession;
-        this.repoSystem = repoSystem;
-    }
-
-    public Map<Artifact, String> getLocalDependencies() {
-        return localDependencies;
-    }
-
-    public String getTreeListing() {
-        return treeListing;
-    }
-
-    //artifact search code adapted from geronimo car plugin
-
-    public void getDependencies(MavenProject project, boolean useTransitiveDependencies) throws MojoExecutionException {
-
-        DependencyNode rootNode = getDependencyTree(RepositoryUtils.toArtifact(project.getArtifact()));
-
-        Scanner scanner = new Scanner();
-        scanner.scan(rootNode, useTransitiveDependencies);
-        localDependencies = scanner.localDependencies;
-        treeListing = scanner.getLog();
-    }
-
-    private DependencyNode getDependencyTree(Artifact artifact) throws MojoExecutionException {
-        try {
-            CollectRequest collectRequest = new CollectRequest(new Dependency(artifact, "compile"), null, projectRepos);
-            DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(repoSession);
-            session.setDependencySelector(new AndDependencySelector(new OptionalDependencySelector(),
-                    new ScopeDependencySelector1(),
-                    new ExclusionDependencySelector()));
-            DependencyGraphTransformer transformer = new ChainedDependencyGraphTransformer(new ConflictMarker(),
-                    new JavaEffectiveScopeCalculator(),
-                    new JavaDependencyContextRefiner());
-            session.setDependencyGraphTransformer(transformer);
-            CollectResult result = repoSystem.collectDependencies(session, collectRequest);
-            return result.getRoot();
-        } catch (DependencyCollectionException e) {
-            throw new MojoExecutionException("Cannot build project dependency tree", e);
-        }
-    }
-
-    //aether's ScopeDependencySelector appears to always exclude the configured scopes (test and provided) and there is no way to configure it to
-    //accept the top level provided scope dependencies.  We need this 3 layer cake since aether never actually uses the top level selector you give it,
-    //it always starts by getting the child to apply to the project's dependencies.
-    private static class ScopeDependencySelector1 implements DependencySelector {
-
-        private DependencySelector child = new ScopeDependencySelector2();
-
-        public boolean selectDependency(Dependency dependency) {
-            throw new IllegalStateException("this does not appear to be called");
-        }
-
-        public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
-            return child;
-        }
-    }
-
-    private static class ScopeDependencySelector2 implements DependencySelector {
-
-        private DependencySelector child = new ScopeDependencySelector3();
-
-        public boolean selectDependency(Dependency dependency) {
-            String scope = dependency.getScope();
-            return !"test".equals(scope) && !"runtime".equals(scope);
-        }
-
-        public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
-            return child;
-        }
-    }
-
-    private static class ScopeDependencySelector3 implements DependencySelector {
-
-        public boolean selectDependency(Dependency dependency) {
-            String scope = dependency.getScope();
-            return !"test".equals(scope) && !"provided".equals(scope) && !"runtime".equals(scope);
-        }
-
-        public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
-            return this;
-        }
-    }
-
-    private static class Scanner {
-
-        private static enum Accept {
-            ACCEPT(true, true),
-            PROVIDED(true, false),
-            STOP(false, false);
-
-            private final boolean more;
-            private final boolean local;
-
-            private Accept(boolean more, boolean local) {
-                this.more = more;
-                this.local = local;
-            }
-
-            public boolean isContinue() {
-                return more;
-            }
-
-            public boolean isLocal() {
-                return local;
-            }
-        }
-
-        //all the dependencies needed for this car, with provided dependencies removed. artifact to scope map
-        private final Map<Artifact, String> localDependencies = new LinkedHashMap<Artifact, String>();
-        //dependencies from ancestor cars, to be removed from localDependencies.
-        private final Set<Artifact> carDependencies = new LinkedHashSet<Artifact>();
-
-        private final StringBuilder log = new StringBuilder();
-
-        public void scan(DependencyNode rootNode, boolean useTransitiveDependencies) throws MojoExecutionException {
-            for (DependencyNode child : rootNode.getChildren()) {
-                scan(child, Accept.ACCEPT, useTransitiveDependencies, false, "");
-            }
-            if (useTransitiveDependencies) {
-                localDependencies.keySet().removeAll(carDependencies);
-            }
-        }
-
-        private void scan(DependencyNode dependencyNode, Accept parentAccept, boolean useTransitiveDependencies, boolean isFromFeature, String indent) throws MojoExecutionException {
-//            Artifact artifact = getArtifact(rootNode);
-
-            Accept accept = accept(dependencyNode, parentAccept);
-            if (accept.isLocal()) {
-                if (isFromFeature) {
-                    if (!isFeature(dependencyNode)) {
-                        log.append(indent).append("from feature:").append(dependencyNode).append("\n");
-                        carDependencies.add(dependencyNode.getDependency().getArtifact());
-                    } else {
-                        log.append(indent).append("is feature:").append(dependencyNode).append("\n");
-                    }
-                } else {
-                    log.append(indent).append("local:").append(dependencyNode).append("\n");
-                    if (localDependencies.containsKey(dependencyNode.getDependency().getArtifact())) {
-                        log.append(indent).append("already in feature, returning:").append(dependencyNode).append("\n");
-                        return;
-                    }
-                    //TODO resolve scope conflicts
-                    localDependencies.put(dependencyNode.getDependency().getArtifact(), dependencyNode.getDependency().getScope());
-                    if (isFeature(dependencyNode) || !useTransitiveDependencies) {
-                        isFromFeature = true;
-                    }
-                }
-                if (useTransitiveDependencies && accept.isContinue()) {
-                    List<DependencyNode> children = dependencyNode.getChildren();
-                    for (DependencyNode child : children) {
-                        scan(child, accept, useTransitiveDependencies, isFromFeature, indent + "  ");
-                    }
-                }
-            }
-        }
-
-
-        public String getLog() {
-            return log.toString();
-        }
-
-        private Accept accept(DependencyNode dependency, Accept previous) {
-            String scope = dependency.getDependency().getScope();
-            if (scope == null || "runtime".equalsIgnoreCase(scope) || "compile".equalsIgnoreCase(scope)) {
-                return previous;
-            }
-            if ("provided".equalsIgnoreCase(scope)) {
-                return Accept.PROVIDED;
-            }
-            return Accept.STOP;
-        }
-
-    }
-
-    public static boolean isFeature(DependencyNode dependencyNode) {
-        return isFeature(dependencyNode.getDependency().getArtifact());
-    }
-
-    public static boolean isFeature(Artifact artifact) {
-        return artifact.getExtension().equals("kar") || FEATURE_CLASSIFIER.equals(artifact.getClassifier());
-    }
-
-
+    /**
+     * Convert a Aether coordinate format into a filesystem path.
+     *
+     * @param name the Aether coordinate format (<groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>)
+     * @return the filesystem path
+     */
+    public String pathFromAether(String name) throws MojoExecutionException;
 }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/DependencyHelperFactory.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/DependencyHelperFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.tooling.features;
+
+import java.util.List;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.sonatype.aether.repository.RemoteRepository;
+
+/**
+ * <p>Service-locator based factory for available aether system (Sonatype for Maven 3.0.x or Eclipse for Maven 3.1.x).</p>
+ *
+ * @author Grzegorz Grzybek
+ */
+public class DependencyHelperFactory {
+
+    /**
+     * <p>Creates new {@link DependencyHelper} based on what's been found in {@link PlexusContainer}.</p>
+     * 
+     * <p>{@code karaf-maven-plugin} depends on {@code maven-core:3.0.3}, so for Maven 3.0.x it may use it's API directly.
+     * When used with Maven 3.1.x it should use reflection to invoke e.g., org.apache.maven.RepositoryUtils.toArtifact(Artifact)
+     * because this signature directly references particular Aether release.</p>
+     * 
+     * <p>When {@code karaf-maven-plugin} switches to {@code maven-core:3.1.0+}, reflection should be use for Sonatype
+     * variant of Aether.</p>
+     * 
+     * @param container
+     * @param project 
+     * @param mavenSession 
+     * @param log 
+     * @return
+     */
+    public static DependencyHelper createDependencyHelper(PlexusContainer container, MavenProject mavenProject, MavenSession mavenSession, Log log) throws MojoFailureException, MojoExecutionException {
+        try {
+            if (container.hasComponent(org.sonatype.aether.RepositorySystem.class)) {
+                org.sonatype.aether.RepositorySystem system = container.lookup(org.sonatype.aether.RepositorySystem.class);
+                org.sonatype.aether.RepositorySystemSession session = mavenSession.getRepositorySession();
+                List<RemoteRepository> repositories = mavenProject.getRemoteProjectRepositories();
+                return new Dependency30Helper(repositories, session, system);
+            } else if (container.hasComponent(org.eclipse.aether.RepositorySystem.class)) {
+                org.eclipse.aether.RepositorySystem system = container.lookup(org.eclipse.aether.RepositorySystem.class);
+                Object session;
+                try {
+                    session = MavenSession.class.getMethod("getRepositorySession").invoke(mavenSession);
+                } catch (Exception e) {
+                    throw new MojoExecutionException(e.getMessage(), e);
+                }
+                List<?> repositories = mavenProject.getRemoteProjectRepositories();
+                return new Dependency31Helper(repositories, session, system);
+            }
+        } catch (ComponentLookupException e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+        throw new MojoExecutionException("Cannot locate either org.sonatype.aether.RepositorySystem or org.eclipse.aether.RepositorySystem");
+    }
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/InstallKarsMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/InstallKarsMojo.java
@@ -18,8 +18,6 @@
  */
 package org.apache.karaf.tooling.features;
 
-import static java.lang.String.format;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -57,13 +55,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.sonatype.aether.RepositorySystem;
-import org.sonatype.aether.RepositorySystemSession;
-import org.sonatype.aether.repository.RemoteRepository;
-import org.sonatype.aether.resolution.ArtifactRequest;
-import org.sonatype.aether.resolution.ArtifactResolutionException;
-import org.sonatype.aether.resolution.ArtifactResult;
-import org.sonatype.aether.util.artifact.DefaultArtifact;
 
 /**
  * Installs kar dependencies into a server-under-construction in target/assembly
@@ -142,30 +133,6 @@ public class InstallKarsMojo extends MojoSupport {
      */
     private List<String> installedFeatures;
 
-    // Aether support
-    /**
-     * The entry point to Aether, i.e. the component doing all the work.
-     *
-     * @component
-     */
-    private RepositorySystem repoSystem;
-
-    /**
-     * The current repository/network configuration of Maven.
-     *
-     * @parameter default-value="${repositorySystemSession}"
-     * @readonly
-     */
-    private RepositorySystemSession repoSession;
-
-    /**
-     * The project's remote repositories to use for the resolution of plugins and their dependencies.
-     *
-     * @parameter default-value="${project.remoteProjectRepositories}"
-     * @readonly
-     */
-    private List<RemoteRepository> remoteRepos;
-
     /**
      * When a feature depends on another feature, try to find it in another referenced feature-file and install that one
      * too.
@@ -179,6 +146,9 @@ public class InstallKarsMojo extends MojoSupport {
     private Set<Feature> featureSet = new HashSet<Feature>();
     private List<Dependency> missingDependencies = new ArrayList<Dependency>();
 
+    //an access layer for available aether implementation
+    protected DependencyHelper dependencyHelper;
+
     /**
      * list of features to  install into local repo.
      */
@@ -187,6 +157,7 @@ public class InstallKarsMojo extends MojoSupport {
     @SuppressWarnings("deprecation")
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        this.dependencyHelper = DependencyHelperFactory.createDependencyHelper(this.container, this.project, this.mavenSession, getLog());
         systemDirectory.mkdirs();
         system = systemDirectory.toURI();
         if (startupPropertiesFile.exists()) {
@@ -229,7 +200,7 @@ public class InstallKarsMojo extends MojoSupport {
                 }
             }
             if ("features".equals(artifact.getClassifier()) && acceptScope(artifact)) {
-                String uri = MavenUtil.artifactToMvn(artifact);
+                String uri = this.dependencyHelper.artifactToMvn(artifact);
 
                 File source = artifact.getFile();
                 DefaultRepositoryLayout layout = new DefaultRepositoryLayout();
@@ -272,7 +243,7 @@ public class InstallKarsMojo extends MojoSupport {
         Set<?> keySet = startupProperties.keySet();
         for (Object keyObject : keySet) {
             String key = (String) keyObject;
-            String path = MavenUtil.pathFromMaven(key);
+            String path = this.dependencyHelper.pathFromMaven(key);
             File target = new File(system.resolve(path));
             if (!target.exists()) {
                 install(key, target);
@@ -284,16 +255,16 @@ public class InstallKarsMojo extends MojoSupport {
             for (Bundle bundle : feature.getBundle()) {
                 if (!bundle.isDependency()) {
                     String key = bundle.getLocation();
-                    String path = MavenUtil.pathFromMaven(key);
+                    String path = this.dependencyHelper.pathFromMaven(key);
                     File test = new File(system.resolve(path));
                     if (!test.exists()) {
                         File target = new File(system.resolve(path));
                         if (!target.exists()) {
                             install(key, target);
-                            Artifact artifact = MavenUtil.mvnToArtifact(key);
+                            Artifact artifact = this.dependencyHelper.mvnToArtifact(key);
                             if (artifact.isSnapshot()) {
                                 // generate maven-metadata-local.xml for the artifact
-                                File metadataSource = new File(resolve(key).getParentFile(), "maven-metadata-local.xml");
+                                File metadataSource = new File(this.dependencyHelper.resolveById(key, getLog()).getParentFile(), "maven-metadata-local.xml");
                                 File metadataTarget = new File(target.getParentFile(), "maven-metadata-local.xml");
                                 metadataTarget.getParentFile().mkdirs();
                                 try {
@@ -331,36 +302,13 @@ public class InstallKarsMojo extends MojoSupport {
     }
 
     private void install(String key, File target) throws MojoFailureException {
-        File source = resolve(key);
+        File source = this.dependencyHelper.resolveById(key, getLog());
         target.getParentFile().mkdirs();
         copy(source, target);
     }
     
     private boolean acceptScope(Artifact artifact) {
         return "compile".equals(artifact.getScope()) || "runtime".equals(artifact.getScope());
-    }
-
-    public File resolve(String id) throws MojoFailureException {
-        id = MavenUtil.mvnToAether(id);
-        ArtifactRequest request = new ArtifactRequest();
-        request.setArtifact(new DefaultArtifact(id));
-        request.setRepositories(remoteRepos);
-
-        getLog().debug("Resolving artifact " + id +
-                " from " + remoteRepos);
-
-        ArtifactResult result;
-        try {
-            result = repoSystem.resolveArtifact(repoSession, request);
-        } catch (ArtifactResolutionException e) {
-            getLog().warn("could not resolve " + id, e);
-            throw new MojoFailureException(format("Couldn't resolve artifact %s", id), e);
-        }
-
-        getLog().debug("Resolved artifact " + id + " to " +
-                result.getArtifact().getFile() + " from "
-                + result.getRepository());
-        return result.getArtifact().getFile();
     }
 
     private class OfflineFeaturesService implements FeaturesService {
@@ -454,10 +402,10 @@ public class InstallKarsMojo extends MojoSupport {
             return properties.containsKey(key) && properties.get(key) != null ?  properties.get(key) + "," : "";
         }
 
-        private Features readFeatures(URI uri) throws XMLStreamException, JAXBException, IOException {
+        private Features readFeatures(URI uri) throws MojoExecutionException, XMLStreamException, JAXBException, IOException {
             File repoFile;
             if (uri.toString().startsWith("mvn:")) {
-                URI featuresPath = system.resolve(MavenUtil.pathFromMaven(uri.toString()));
+                URI featuresPath = system.resolve(dependencyHelper.pathFromMaven(uri.toString()));
                 repoFile = new File(featuresPath);
             } else {
                 repoFile = new File(uri);

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/MavenUtil.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/MavenUtil.java
@@ -26,7 +26,6 @@ import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.artifact.repository.metadata.Metadata;
@@ -34,14 +33,13 @@ import org.apache.maven.artifact.repository.metadata.Snapshot;
 import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
-import org.sonatype.aether.util.artifact.DefaultArtifact;
 
 /**
  * Util method for Maven manipulation (URL convert, metadata generation, etc).
  */
 public class MavenUtil {
 
-    private static final DefaultRepositoryLayout layout = new DefaultRepositoryLayout();
+    static final DefaultRepositoryLayout layout = new DefaultRepositoryLayout();
     private static final Pattern aetherPattern = Pattern.compile("([^: ]+):([^: ]+)(:([^: ]*)(:([^: ]+))?)?:([^: ]+)");
     private static final Pattern mvnPattern = Pattern.compile("mvn:([^/ ]+)/([^/ ]+)/([^/ ]*)(/([^/ ]+)(/([^/ ]+))?)?");
 
@@ -116,71 +114,8 @@ public class MavenUtil {
         return b.toString();
     }
 
-    /**
-     * Convert a PAX URL mvn format into a filesystem path.
-     *
-     * @param name PAX URL mvn format (mvn:<groupId>/<artifactId>/<version>/<type>/<classifier>)
-     * @return a filesystem path
-     */
-    static String pathFromMaven(String name) {
-        if (name.indexOf(':') == -1) {
-            return name;
-        }
-        name = mvnToAether(name);
-        return pathFromAether(name);
-    }
-
-    /**
-     * Convert a Aether coordinate format into a filesystem path.
-     *
-     * @param name the Aether coordinate format (<groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>)
-     * @return the filesystem path
-     */
-    static String pathFromAether(String name) {
-        DefaultArtifact artifact = new DefaultArtifact(name);
-        Artifact mavenArtifact = RepositoryUtils.toArtifact(artifact);
-        return layout.pathOf(mavenArtifact);
-    }
-
-    /**
-     * Convert a Maven <code>Artifact</code> into a PAX URL mvn format.
-     *
-     * @param artifact the Maven <code>Artifact</code>.
-     * @return the corresponding PAX URL mvn format (mvn:<groupId>/<artifactId>/<version>/<type>/<classifier>)
-     */
-    static String artifactToMvn(Artifact artifact) {
-        return artifactToMvn(RepositoryUtils.toArtifact(artifact));
-    }
-
-    /**
-     * Convert an Aether <code>org.sonatype.aether.artifact.Artifact</code> into a PAX URL mvn format.
-     *
-     * @param artifact the Aether <code>org.sonatype.aether.artifact.Artifact</code>.
-     * @return the corresponding PAX URL mvn format (mvn:<groupId>/<artifactId>/<version>/<type>/<classifier>)
-     */
-    static String artifactToMvn(org.sonatype.aether.artifact.Artifact artifact) {
-        String bundleName;
-        if (artifact.getExtension().equals("jar") && isEmpty(artifact.getClassifier())) {
-            bundleName = String.format("mvn:%s/%s/%s", artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion());
-        } else {
-            if (isEmpty(artifact.getClassifier())) {
-                bundleName = String.format("mvn:%s/%s/%s/%s", artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion(), artifact.getExtension());
-            } else {
-                bundleName = String.format("mvn:%s/%s/%s/%s/%s", artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion(), artifact.getExtension(), artifact.getClassifier());
-            }
-        }
-        return bundleName;
-    }
-
-    private static boolean isEmpty(String classifier) {
+    static boolean isEmpty(String classifier) {
         return classifier == null || classifier.length() == 0;
-    }
-    
-    static Artifact mvnToArtifact(String name) {
-        name = mvnToAether(name);
-        DefaultArtifact artifact = new DefaultArtifact(name);
-        Artifact mavenArtifact = RepositoryUtils.toArtifact(artifact);
-        return mavenArtifact;
     }
 
     /**

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MojoSupport.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MojoSupport.java
@@ -50,6 +50,7 @@ import org.apache.maven.project.MavenProjectBuilder;
 import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.settings.Proxy;
+import org.codehaus.plexus.PlexusContainer;
 
 @SuppressWarnings({"deprecation", "rawtypes", "unchecked"})
 public abstract class MojoSupport extends AbstractMojo {
@@ -123,6 +124,18 @@ public abstract class MojoSupport extends AbstractMojo {
      * @required
      */
     protected MavenSession mavenSession;
+
+    /**
+     * <p>We can't autowire strongly typed RepositorySystem from Aether because it may be Sonatype (Maven 3.0.x)
+     * or Eclipse (Maven 3.1.x) version, so we switch to service locator by autowiring entire {@link PlexusContainer}.</p>
+     * 
+     * <p>It's a bit of a hack but we have no choice when we want to be usable both in Maven 3.0.x and 3.1.x.</p>
+     *
+     * @component
+     * @required
+     * @readonly
+     */
+    protected PlexusContainer container;
 
     protected MavenProject getProject() {
         return project;

--- a/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/features/MavenUtilTest.java
+++ b/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/features/MavenUtilTest.java
@@ -20,14 +20,11 @@
 
 package org.apache.karaf.tooling.features;
 
+import org.junit.Ignore;
 import org.junit.Test;
-import org.sonatype.aether.util.artifact.DefaultArtifact;
 
 import static org.apache.karaf.tooling.features.MavenUtil.aetherToMvn;
-import static org.apache.karaf.tooling.features.MavenUtil.artifactToMvn;
 import static org.apache.karaf.tooling.features.MavenUtil.mvnToAether;
-import static org.apache.karaf.tooling.features.MavenUtil.pathFromAether;
-import static org.apache.karaf.tooling.features.MavenUtil.pathFromMaven;
 import static org.junit.Assert.assertEquals;
 
 public class MavenUtilTest {
@@ -47,24 +44,53 @@ public class MavenUtilTest {
     }
 
     @Test
-    public void testPathFromMvn() throws Exception {
-        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT.jar", pathFromMaven("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT"));
-        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT.kar", pathFromMaven("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT/kar"));
-        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT-features.xml", pathFromMaven("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT/xml/features"));
+    public void testPathFromMvnSonatype() throws Exception {
+        Dependency30Helper helper = new Dependency30Helper(null, null, null);
+        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT.jar", helper.pathFromMaven("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT"));
+        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT.kar", helper.pathFromMaven("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT/kar"));
+        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT-features.xml", helper.pathFromMaven("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT/xml/features"));
     }
 
     @Test
-    public void testPathFromAether() throws Exception {
-        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT.jar", pathFromAether("org.foo:org.foo.bar:1.0-SNAPSHOT"));
-        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT.kar", pathFromAether("org.foo:org.foo.bar:kar:1.0-SNAPSHOT"));
-        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT-features.xml", pathFromAether("org.foo:org.foo.bar:xml:features:1.0-SNAPSHOT"));
+    @Ignore("Will work with org.apache.maven:maven-core:3.1.0+")
+    public void testPathFromMvnEclipse() throws Exception {
+        Dependency31Helper helper = new Dependency31Helper(null, null, null);
+        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT.jar", helper.pathFromMaven("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT"));
+        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT.kar", helper.pathFromMaven("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT/kar"));
+        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT-features.xml", helper.pathFromMaven("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT/xml/features"));
     }
 
     @Test
-    public void testArtifactToMvn() throws Exception {
-        assertEquals("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT", artifactToMvn(new DefaultArtifact("org.foo:org.foo.bar:1.0-SNAPSHOT")));
-        assertEquals("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT/kar", artifactToMvn(new DefaultArtifact("org.foo:org.foo.bar:kar:1.0-SNAPSHOT")));
-        assertEquals("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT/xml/features", artifactToMvn(new DefaultArtifact("org.foo:org.foo.bar:xml:features:1.0-SNAPSHOT")));
+    public void testPathFromAetherSonatype() throws Exception {
+        Dependency30Helper helper = new Dependency30Helper(null, null, null);
+        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT.jar", helper.pathFromAether("org.foo:org.foo.bar:1.0-SNAPSHOT"));
+        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT.kar", helper.pathFromAether("org.foo:org.foo.bar:kar:1.0-SNAPSHOT"));
+        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT-features.xml", helper.pathFromAether("org.foo:org.foo.bar:xml:features:1.0-SNAPSHOT"));
+    }
+
+    @Test
+    @Ignore("Will work with org.apache.maven:maven-core:3.1.0+")
+    public void testPathFromAetherEclipse() throws Exception {
+        Dependency31Helper helper = new Dependency31Helper(null, null, null);
+        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT.jar", helper.pathFromAether("org.foo:org.foo.bar:1.0-SNAPSHOT"));
+        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT.kar", helper.pathFromAether("org.foo:org.foo.bar:kar:1.0-SNAPSHOT"));
+        assertEquals("org/foo/org.foo.bar/1.0-SNAPSHOT/org.foo.bar-1.0-SNAPSHOT-features.xml", helper.pathFromAether("org.foo:org.foo.bar:xml:features:1.0-SNAPSHOT"));
+    }
+
+    @Test
+    public void testSonatypeArtifactToMvn() throws Exception {
+        Dependency30Helper helper = new Dependency30Helper(null, null, null);
+        assertEquals("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT", helper.artifactToMvn(new org.sonatype.aether.util.artifact.DefaultArtifact("org.foo:org.foo.bar:1.0-SNAPSHOT")));
+        assertEquals("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT/kar", helper.artifactToMvn(new org.sonatype.aether.util.artifact.DefaultArtifact("org.foo:org.foo.bar:kar:1.0-SNAPSHOT")));
+        assertEquals("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT/xml/features", helper.artifactToMvn(new org.sonatype.aether.util.artifact.DefaultArtifact("org.foo:org.foo.bar:xml:features:1.0-SNAPSHOT")));
+    }
+
+    @Test
+    public void testEclipseArtifactToMvn() throws Exception {
+        Dependency31Helper helper = new Dependency31Helper(null, null, null);
+        assertEquals("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT", helper.artifactToMvn(new org.eclipse.aether.artifact.DefaultArtifact("org.foo:org.foo.bar:1.0-SNAPSHOT")));
+        assertEquals("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT/kar", helper.artifactToMvn(new org.eclipse.aether.artifact.DefaultArtifact("org.foo:org.foo.bar:kar:1.0-SNAPSHOT")));
+        assertEquals("mvn:org.foo/org.foo.bar/1.0-SNAPSHOT/xml/features", helper.artifactToMvn(new org.eclipse.aether.artifact.DefaultArtifact("org.foo:org.foo.bar:xml:features:1.0-SNAPSHOT")));
     }
 
 }


### PR DESCRIPTION
Mojos use available Aether subsystem (Sonatype or Eclipse) by looking at what's
available in PlexusContainer.

It's easy to add Maven deps for both Sonatype and Eclipse versions of Aether, but it's not that easy to depend on both `maven-core:3.0.3` and `maven-core:3.1.0+`.

Mojos don't get particular Aether component autowired directly by type - they can however get autowired entire `PlexusContainer`. We then look at the available Aether subsystems and the use a `DependencyHelper` layer to access correct Aether (both Sonatype and Eclipse).

`karaf-maven-plugin` may use `maven-core` API directly for Sonatype version of Aether (for dependency on `maven-core:3.0.3`), but it also can use Eclipse Aether and the methods from Maven API which reference Eclipse Aether when used with Maven 3.1.0+ - it however requires a bit of `java.lang.reflect`.
