### PR TITLE
Added feature generation goal based on semantic version ranges

### DIFF
--- a/tooling/karaf-maven-plugin/pom.xml
+++ b/tooling/karaf-maven-plugin/pom.xml
@@ -46,12 +46,12 @@
         <dependency>
            <groupId>org.sonatype.aether</groupId>
            <artifactId>aether-api</artifactId>
-           <version>1.11</version>
+           <version>1.13</version>
          </dependency>
          <dependency>
            <groupId>org.sonatype.aether</groupId>
            <artifactId>aether-util</artifactId>
-           <version>1.11</version>
+           <version>1.13</version>
          </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/tooling/karaf-maven-plugin/src/it/test-feature-range/_build_/maven-install-debug.ant
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-range/_build_/maven-install-debug.ant
@@ -1,0 +1,26 @@
+<project default="maven" basedir="./..">
+
+	<target name="maven">
+
+		<echo message="basedir : ${basedir}" />
+
+		<!-- note: mvn executable must be present on o/s path -->
+		<condition property="executable" value="mvn.bat">
+			<os family="windows" />
+		</condition>
+		<condition property="executable" value="mvn">
+			<os family="unix" />
+		</condition>
+
+		<exec executable="${executable}">
+
+			<arg value="clean" />
+			<arg value="install" />
+
+			<arg value="--debug" />
+
+		</exec>
+
+	</target>
+
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-feature-range/_build_/maven-install.ant
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-range/_build_/maven-install.ant
@@ -1,0 +1,24 @@
+<project default="maven" basedir="./..">
+
+	<target name="maven">
+
+		<echo message="basedir : ${basedir}" />
+
+		<!-- note: mvn executable must be present on o/s path -->
+		<condition property="executable" value="mvn.bat">
+			<os family="windows" />
+		</condition>
+		<condition property="executable" value="mvn">
+			<os family="unix" />
+		</condition>
+
+		<exec executable="${executable}">
+
+			<arg value="clean" />
+			<arg value="install" />
+
+		</exec>
+
+	</target>
+
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-feature-range/control.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-range/control.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0" name="test-feature-range">
+    <feature name="test-feature-range" version="1.0-SNAPSHOT" description="test-feature-range">
+        <details>test-feature-range</details>
+        <bundle>mvn:com.barchart.version.tester/tester-one-api/3.1.2</bundle>
+        <bundle>mvn:com.barchart.version.tester/tester-one-api-consumer/4.0.4</bundle>
+        <bundle>mvn:com.barchart.version.tester/tester-one-api-provider/5.3.2</bundle>
+    </feature>
+</features>

--- a/tooling/karaf-maven-plugin/src/it/test-feature-range/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-range/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.barchart.base</groupId>
+		<artifactId>barchart-archon</artifactId>
+		<version>2.5.6</version>
+		<relativePath />
+	</parent>
+
+	<groupId>test</groupId>
+	<artifactId>test-feature-range</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+
+		<!-- API Consumer bundle dependency. -->
+		<dependency>
+			<groupId>com.barchart.version.tester</groupId>
+			<artifactId>tester-one-api-consumer</artifactId>
+			<version>[4,5)</version>
+		</dependency>
+
+		<!-- API Provider bundle dependency. -->
+		<dependency>
+			<groupId>com.barchart.version.tester</groupId>
+			<artifactId>tester-one-api-provider</artifactId>
+			<version>[5,6)</version>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+
+			<plugin>
+				<groupId>org.apache.karaf.tooling</groupId>
+				<artifactId>karaf-maven-plugin</artifactId>
+				<!-- <version>@project.version@</version> -->
+				<version>3.0.0-build004-SNAPSHOT</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>features-generate-semantic</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+		</plugins>
+	</build>
+
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-feature-range/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-range/verify.bsh
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.custommonkey.xmlunit.*;
+import java.io.*;
+import java.lang.*;
+
+Reader source = new FileReader(new File(basedir, "control.xml"));
+Reader target = new FileReader(new File(basedir, "target/feature/feature.xml"));
+
+try {
+	XMLAssert.assertXMLEqual(source,target);
+	return true;
+} catch (Throwable e) { 
+	return false;
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -97,7 +97,7 @@ public class GenerateDescriptorMojo extends AbstractLogEnabled implements Mojo {
      *
      * @parameter default-value="${project.build.directory}/feature/feature.xml"
      */
-    private File outputFile;
+    protected File outputFile;
 
     /**
      * (wrapper) Exclude some artifacts from the generated feature.
@@ -118,14 +118,14 @@ public class GenerateDescriptorMojo extends AbstractLogEnabled implements Mojo {
      *
      * @parameter default-value="xml"
      */
-    private String attachmentArtifactType = "xml";
+    protected String attachmentArtifactType = "xml";
 
     /**
      * (wrapper) The artifact classifier for attaching the generated file to the project
      *
      * @parameter default-value="features"
      */
-    private String attachmentArtifactClassifier = "features";
+    protected String attachmentArtifactClassifier = "features";
 
     /**
      * Specifies whether features dependencies of this project will be included inline of the the
@@ -170,7 +170,7 @@ public class GenerateDescriptorMojo extends AbstractLogEnabled implements Mojo {
      *
      * @parameter default-value="true"
      */
-    private boolean includeTransitiveDependency;
+    protected boolean includeTransitiveDependency;
 
     /**
      * The standard behavior is to add dependencies as <code>&lt;bundle&gt;</code> elements to a <code>&lt;feature&gt;</code>
@@ -209,7 +209,7 @@ public class GenerateDescriptorMojo extends AbstractLogEnabled implements Mojo {
      * @required
      * @readonly
      */
-    private RepositorySystem repoSystem;
+    protected RepositorySystem repoSystem;
 
     /**
      * The current repository/network configuration of Maven.
@@ -218,7 +218,7 @@ public class GenerateDescriptorMojo extends AbstractLogEnabled implements Mojo {
      * @required
      * @readonly
      */
-    private RepositorySystemSession repoSession;
+    protected RepositorySystemSession repoSession;
 
     /**
      * The project's remote repositories to use for the resolution of project dependencies.
@@ -226,7 +226,7 @@ public class GenerateDescriptorMojo extends AbstractLogEnabled implements Mojo {
      * @parameter default-value="${project.remoteProjectRepositories}"
      * @readonly
      */
-    private List<RemoteRepository> projectRepos;
+    protected List<RemoteRepository> projectRepos;
 
     /**
      * @component role="org.apache.maven.shared.filtering.MavenResourcesFiltering" role-hint="default"
@@ -258,12 +258,16 @@ public class GenerateDescriptorMojo extends AbstractLogEnabled implements Mojo {
     //maven log
     private Log log;
 
+    protected void prepare() throws Exception {
+		DependencyHelper dependencyHelper = new DependencyHelper(projectRepos, repoSession, repoSystem);
+		dependencyHelper.getDependencies(project, includeTransitiveDependency);
+		this.localDependencies = dependencyHelper.getLocalDependencies();
+		this.treeListing = dependencyHelper.getTreeListing();
+    }
+    
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
-            DependencyHelper dependencyHelper = new DependencyHelper(projectRepos, repoSession, repoSystem);
-            dependencyHelper.getDependencies(project, includeTransitiveDependency);
-            this.localDependencies = dependencyHelper.getLocalDependencies();
-            this.treeListing = dependencyHelper.getTreeListing();
+        	prepare();
             File dir = outputFile.getParentFile();
             if (dir.isDirectory() || dir.mkdirs()) {
                 PrintStream out = new PrintStream(new FileOutputStream(outputFile));
@@ -287,7 +291,7 @@ public class GenerateDescriptorMojo extends AbstractLogEnabled implements Mojo {
     /*
      * Write all project dependencies as feature
      */
-    private void writeFeatures(PrintStream out) throws ArtifactResolutionException, ArtifactNotFoundException,
+    protected void writeFeatures(PrintStream out) throws ArtifactResolutionException, ArtifactNotFoundException,
             IOException, JAXBException, SAXException, ParserConfigurationException, XMLStreamException, MojoExecutionException {
         getLogger().info("Generating feature descriptor file " + outputFile.getAbsolutePath());
         //read in an existing feature.xml

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/MavenUtil.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/MavenUtil.java
@@ -34,6 +34,7 @@ import org.apache.maven.artifact.repository.metadata.Snapshot;
 import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
+import org.apache.maven.project.MavenProject;
 import org.sonatype.aether.util.artifact.DefaultArtifact;
 
 /**

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/GenerateSemanticMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/GenerateSemanticMojo.java
@@ -1,0 +1,221 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.tooling.semantic;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.karaf.tooling.features.GenerateDescriptorMojo;
+import org.apache.karaf.tooling.semantic.eclipse.ConflictIdSorter;
+import org.apache.karaf.tooling.semantic.eclipse.ConflictMarker;
+import org.apache.karaf.tooling.semantic.eclipse.ConflictResolver;
+import org.apache.karaf.tooling.semantic.eclipse.JavaScopeDeriver;
+import org.apache.karaf.tooling.semantic.eclipse.JavaScopeSelector;
+import org.apache.karaf.tooling.semantic.eclipse.NearestVersionSelector;
+import org.apache.karaf.tooling.semantic.eclipse.SimpleOptionalitySelector;
+import org.apache.karaf.tooling.semantic.xform.SnapshotTransformer;
+import org.apache.maven.RepositoryUtils;
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.collection.CollectRequest;
+import org.sonatype.aether.collection.CollectResult;
+import org.sonatype.aether.collection.DependencySelector;
+import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.resolution.DependencyRequest;
+import org.sonatype.aether.resolution.DependencyResult;
+import org.sonatype.aether.util.DefaultRepositorySystemSession;
+import org.sonatype.aether.util.graph.PostorderNodeListGenerator;
+import org.sonatype.aether.util.graph.selector.AndDependencySelector;
+import org.sonatype.aether.util.graph.selector.ExclusionDependencySelector;
+import org.sonatype.aether.util.graph.selector.OptionalDependencySelector;
+import org.sonatype.aether.util.graph.selector.ScopeDependencySelector;
+import org.sonatype.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
+
+/**
+ * Generates the semantic features XML file for packaging=pom
+ * 
+ * @goal features-generate-semantic
+ * @phase package
+ * @requiresDependencyResolution runtime
+ * @inheritByDefault true
+ * @description TODO
+ * 
+ * @author Andrei Pozolotin
+ */
+public class GenerateSemanticMojo extends GenerateDescriptorMojo {
+
+	/**
+	 * FIXME normal equals does not work.
+	 */
+	public static boolean equals(Dependency one, Dependency two) {
+		return one.toString().equals(two.toString());
+	}
+
+	/**
+	 * Dependency scope to include. Default include: compile.
+	 * 
+	 * @parameter
+	 */
+	protected Set<String> scopeIncluded;
+	{
+		scopeIncluded = new HashSet<String>();
+		scopeIncluded.add("compile");
+	}
+
+	/**
+	 * Root artifact packaging to include. Default include: bundle.
+	 * 
+	 * @parameter
+	 */
+	protected Set<String> packagingIncluded;
+	{
+		packagingIncluded = new HashSet<String>();
+		packagingIncluded.add("bundle");
+	}
+
+	/**
+	 * Dependency scope to exclude. Default exclude: runtime, provided, system,
+	 * test.
+	 * 
+	 * @parameter
+	 */
+	protected Set<String> scopeExcluded;
+	{
+		scopeExcluded = new HashSet<String>();
+		scopeExcluded.add("runtime");
+		scopeExcluded.add("provided");
+		scopeExcluded.add("system");
+		scopeExcluded.add("test");
+	}
+
+	/**
+	 * 
+	 * @parameter
+	 */
+	protected Map<String, String> resolverSettings = new HashMap<String, String>();
+
+	/**
+	 */
+	public static Map<Artifact, String> prepare(MojoContext context)
+			throws Exception {
+
+		Artifact artifact = RepositoryUtils.toArtifact(context.project
+				.getArtifact());
+
+		Dependency root = new Dependency(artifact, "compile");
+
+		CollectRequest collectRequest = new CollectRequest(root,
+				context.projectRepos);
+
+		DependencySelector selector = new AndDependencySelector(
+				new DependencySelector[] {
+						new OptionalDependencySelector(),
+						new ScopeDependencySelector(context.scopeIncluded,
+								context.scopeExcluded),
+						new ExclusionDependencySelector() });
+
+		DefaultRepositorySystemSession localSession = new DefaultRepositorySystemSession(
+				context.session);
+
+		localSession.setDependencySelector(selector);
+
+		//
+
+		ConflictMarker marker = new ConflictMarker();
+		ConflictIdSorter sorter = new ConflictIdSorter();
+
+		SnapshotTransformer snapper = new SnapshotTransformer(
+				context.resolverSettings);
+
+		ConflictResolver.VersionSelector versionSelector = new NearestVersionSelector();
+		ConflictResolver.ScopeSelector scopeSelector = new JavaScopeSelector();
+		ConflictResolver.OptionalitySelector optionalitySelector = new SimpleOptionalitySelector();
+		ConflictResolver.ScopeDeriver scopeDeriver = new JavaScopeDeriver();
+
+		ConflictResolver resolver = new ConflictResolver(versionSelector,
+				scopeSelector, optionalitySelector, scopeDeriver);
+
+		ChainedDependencyGraphTransformer transformer = new ChainedDependencyGraphTransformer(
+				marker, sorter, snapper, resolver);
+
+		localSession.setDependencyGraphTransformer(transformer);
+
+		//
+
+		CollectResult collectResult = context.system.collectDependencies(
+				localSession, collectRequest);
+
+		DependencyNode collectNode = collectResult.getRoot();
+
+		DependencyRequest dependencyRequest = new DependencyRequest(
+				collectNode, null);
+
+		DependencyResult resolveResult = context.system.resolveDependencies(
+				localSession, dependencyRequest);
+
+		DependencyNode resolveNode = resolveResult.getRoot();
+
+		PostorderNodeListGenerator generator = new PostorderNodeListGenerator();
+
+		resolveNode.accept(generator);
+
+		List<Dependency> dependencyList = generator.getDependencies(false);
+
+		Map<Artifact, String> dependencyMap = new LinkedHashMap<Artifact, String>();
+
+		for (Dependency dependency : dependencyList) {
+
+			boolean isRootNode = equals(root, dependency);
+
+			boolean isPackagingIncluded = context.packagingIncluded
+					.contains(context.project.getPackaging());
+
+			if (isRootNode) {
+				if (!isPackagingIncluded) {
+					context.logger.info("Excluded: " + dependency);
+					continue;
+				}
+			}
+
+			context.logger.info("\t " + dependency);
+
+			dependencyMap.put(dependency.getArtifact(), dependency.getScope());
+
+		}
+
+		return dependencyMap;
+	}
+
+	@Override
+	protected void prepare() throws Exception {
+
+		MojoContext context = new MojoContext(getLogger(), project,
+				scopeIncluded, scopeExcluded, repoSystem, repoSession,
+				projectRepos, resolverSettings, packagingIncluded);
+
+		this.localDependencies = prepare(context);
+
+		this.treeListing = "not available";
+
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/MojoContext.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/MojoContext.java
@@ -1,0 +1,46 @@
+package org.apache.karaf.tooling.semantic;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.logging.Logger;
+import org.sonatype.aether.RepositorySystem;
+import org.sonatype.aether.RepositorySystemSession;
+import org.sonatype.aether.repository.RemoteRepository;
+
+public class MojoContext {
+
+	public final Logger logger;
+	public final MavenProject project;
+	public final Set<String> scopeIncluded;
+	public final Set<String> scopeExcluded;
+	public final RepositorySystem system;
+	public final RepositorySystemSession session;
+	public final List<RemoteRepository> projectRepos;
+	public final Map<String, String> resolverSettings;
+	public final Set<String> packagingIncluded;
+
+	public MojoContext( //
+			Logger logger, //
+			MavenProject project, //
+			Set<String> scopeIncluded, //
+			Set<String> scopeExcluded, //
+			RepositorySystem system, //
+			RepositorySystemSession session, //
+			List<RemoteRepository> projectRepos, //
+			Map<String, String> resolverSettings, //
+			Set<String> packagingIncluded //
+	) {
+		this.logger = logger;
+		this.project = project;
+		this.scopeIncluded = scopeIncluded;
+		this.scopeExcluded = scopeExcluded;
+		this.system = system;
+		this.session = session;
+		this.projectRepos = projectRepos;
+		this.resolverSettings = resolverSettings;
+		this.packagingIncluded = packagingIncluded;
+	}
+	
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/ReflectUtil.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/ReflectUtil.java
@@ -1,0 +1,18 @@
+package org.apache.karaf.tooling.semantic;
+
+import java.lang.reflect.Field;
+
+public class ReflectUtil {
+
+	@SuppressWarnings("unchecked")
+	public static <T> T readField(Object instance, String name) {
+		try {
+			Field field = instance.getClass().getDeclaredField(name);
+			field.setAccessible(true);
+			return (T) field.get(instance);
+		} catch (Throwable e) {
+			throw new IllegalStateException("Failed to read field.", e);
+		}
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/ConflictIdSorter.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/ConflictIdSorter.java
@@ -1,0 +1,363 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2012 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Sonatype, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.apache.karaf.tooling.semantic.eclipse;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.sonatype.aether.RepositoryException;
+import org.sonatype.aether.collection.DependencyGraphTransformationContext;
+import org.sonatype.aether.collection.DependencyGraphTransformer;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.util.graph.transformer.TransformationContextKeys;
+
+
+/**
+ * A dependency graph transformer that creates a topological sorting of the conflict ids which have been assigned to the
+ * dependency nodes. Conflict ids are sorted according to the dependency relation induced by the dependency graph. This
+ * transformer will query the key {@link TransformationContextKeys#CONFLICT_IDS} in the transformation context for an
+ * existing mapping of nodes to their conflicts ids. In absence of this map, the transformer will automatically invoke
+ * the {@link ConflictMarker} to calculate the conflict ids. When this transformer has executed, the transformation
+ * context holds a {@code List<Object>} that denotes the topologically sorted conflict ids. The list will be stored
+ * using the key {@link TransformationContextKeys#SORTED_CONFLICT_IDS}. In addition, the transformer will store a
+ * {@code Collection<Collection<Object>>} using the key {@link TransformationContextKeys#CYCLIC_CONFLICT_IDS} that
+ * describes cycles among conflict ids.
+ */
+public final class ConflictIdSorter
+    implements DependencyGraphTransformer
+{
+
+    public DependencyNode transformGraph( DependencyNode node, DependencyGraphTransformationContext context )
+        throws RepositoryException
+    {
+        Map<?, ?> conflictIds = (Map<?, ?>) context.get( TransformationContextKeys.CONFLICT_IDS );
+        if ( conflictIds == null )
+        {
+            ConflictMarker marker = new ConflictMarker();
+            marker.transformGraph( node, context );
+
+            conflictIds = (Map<?, ?>) context.get( TransformationContextKeys.CONFLICT_IDS );
+        }
+
+        @SuppressWarnings( "unchecked" )
+        Map<String, Object> stats = (Map<String, Object>) context.get( ContextKeys.STATS );
+        long time1 = System.currentTimeMillis();
+
+        Map<Object, ConflictId> ids = new LinkedHashMap<Object, ConflictId>( 256 );
+
+        {
+            ConflictId id = null;
+            Object key = conflictIds.get( node );
+            if ( key != null )
+            {
+                id = new ConflictId( key, 0 );
+                ids.put( key, id );
+            }
+
+            Map<DependencyNode, Object> visited = new IdentityHashMap<DependencyNode, Object>( conflictIds.size() );
+
+            buildConflitIdDAG( ids, node, id, 0, visited, conflictIds );
+        }
+
+        long time2 = System.currentTimeMillis();
+
+        int cycles = topsortConflictIds( ids.values(), context );
+
+        if ( stats != null )
+        {
+            long time3 = System.currentTimeMillis();
+            stats.put( "ConflictIdSorter.graphTime", time2 - time1 );
+            stats.put( "ConflictIdSorter.topsortTime", time3 - time2 );
+            stats.put( "ConflictIdSorter.conflictIdCount", ids.size() );
+            stats.put( "ConflictIdSorter.conflictIdCycleCount", cycles );
+        }
+
+        return node;
+    }
+
+    private void buildConflitIdDAG( Map<Object, ConflictId> ids, DependencyNode node, ConflictId id, int depth,
+                                    Map<DependencyNode, Object> visited, Map<?, ?> conflictIds )
+    {
+        if ( visited.put( node, Boolean.TRUE ) != null )
+        {
+            return;
+        }
+
+        depth++;
+
+        for ( DependencyNode child : node.getChildren() )
+        {
+            Object key = conflictIds.get( child );
+            ConflictId childId = ids.get( key );
+            if ( childId == null )
+            {
+                childId = new ConflictId( key, depth );
+                ids.put( key, childId );
+            }
+            else
+            {
+                childId.pullup( depth );
+            }
+
+            if ( id != null )
+            {
+                id.add( childId );
+            }
+
+            buildConflitIdDAG( ids, child, childId, depth, visited, conflictIds );
+        }
+    }
+
+    private int topsortConflictIds( Collection<ConflictId> conflictIds, DependencyGraphTransformationContext context )
+    {
+        List<Object> sorted = new ArrayList<Object>( conflictIds.size() );
+
+        RootQueue roots = new RootQueue( conflictIds.size() / 2 );
+        for ( ConflictId id : conflictIds )
+        {
+            if ( id.inDegree <= 0 )
+            {
+                roots.add( id );
+            }
+        }
+
+        processRoots( sorted, roots );
+
+        boolean cycle = sorted.size() < conflictIds.size();
+
+        while ( sorted.size() < conflictIds.size() )
+        {
+            // cycle -> deal gracefully with nodes still having positive in-degree
+
+            ConflictId nearest = null;
+            for ( ConflictId id : conflictIds )
+            {
+                if ( id.inDegree <= 0 )
+                {
+                    continue;
+                }
+                if ( nearest == null || id.minDepth < nearest.minDepth
+                    || ( id.minDepth == nearest.minDepth && id.inDegree < nearest.inDegree ) )
+                {
+                    nearest = id;
+                }
+            }
+
+            nearest.inDegree = 0;
+            roots.add( nearest );
+
+            processRoots( sorted, roots );
+        }
+
+        Collection<Collection<Object>> cycles = Collections.emptySet();
+        if ( cycle )
+        {
+            cycles = findCycles( conflictIds );
+        }
+
+        context.put( TransformationContextKeys.SORTED_CONFLICT_IDS, sorted );
+        context.put( TransformationContextKeys.CYCLIC_CONFLICT_IDS, cycles );
+
+        return cycles.size();
+    }
+
+    private void processRoots( List<Object> sorted, RootQueue roots )
+    {
+        while ( !roots.isEmpty() )
+        {
+            ConflictId root = roots.remove();
+
+            sorted.add( root.key );
+
+            for ( ConflictId child : root.children )
+            {
+                child.inDegree--;
+                if ( child.inDegree == 0 )
+                {
+                    roots.add( child );
+                }
+            }
+        }
+    }
+
+    private Collection<Collection<Object>> findCycles( Collection<ConflictId> conflictIds )
+    {
+        Collection<Collection<Object>> cycles = new HashSet<Collection<Object>>();
+
+        Map<Object, Integer> stack = new HashMap<Object, Integer>( 128 );
+        Map<ConflictId, Object> visited = new IdentityHashMap<ConflictId, Object>( conflictIds.size() );
+        for ( ConflictId id : conflictIds )
+        {
+            findCycles( id, visited, stack, cycles );
+        }
+
+        return cycles;
+    }
+
+    private void findCycles( ConflictId id, Map<ConflictId, Object> visited, Map<Object, Integer> stack,
+                             Collection<Collection<Object>> cycles )
+    {
+        Integer depth = stack.put( id.key, stack.size() );
+        if ( depth != null )
+        {
+            stack.put( id.key, depth );
+            Collection<Object> cycle = new HashSet<Object>();
+            for ( Map.Entry<Object, Integer> entry : stack.entrySet() )
+            {
+                if ( entry.getValue() >= depth )
+                {
+                    cycle.add( entry.getKey() );
+                }
+            }
+            cycles.add( cycle );
+        }
+        else
+        {
+            if ( visited.put( id, Boolean.TRUE ) == null )
+            {
+                for ( ConflictId childId : id.children )
+                {
+                    findCycles( childId, visited, stack, cycles );
+                }
+            }
+            stack.remove( id.key );
+        }
+    }
+
+    static final class ConflictId
+    {
+
+        final Object key;
+
+        Collection<ConflictId> children = Collections.emptySet();
+
+        int inDegree;
+
+        int minDepth;
+
+        public ConflictId( Object key, int depth )
+        {
+            this.key = key;
+            this.minDepth = depth;
+        }
+
+        public void add( ConflictId child )
+        {
+            if ( children.isEmpty() )
+            {
+                children = new HashSet<ConflictId>();
+            }
+            if ( children.add( child ) )
+            {
+                child.inDegree++;
+            }
+        }
+
+        public void pullup( int depth )
+        {
+            if ( depth < minDepth )
+            {
+                minDepth = depth;
+                depth++;
+                for ( ConflictId child : children )
+                {
+                    child.pullup( depth );
+                }
+            }
+        }
+
+        @Override
+        public boolean equals( Object obj )
+        {
+            if ( this == obj )
+            {
+                return true;
+            }
+            else if ( !( obj instanceof ConflictId ) )
+            {
+                return false;
+            }
+            ConflictId that = (ConflictId) obj;
+            return this.key.equals( that.key );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return key.hashCode();
+        }
+
+        @Override
+        public String toString()
+        {
+            return key + " @ " + minDepth + " <" + inDegree;
+        }
+
+    }
+
+    static final class RootQueue
+    {
+
+        private int nextOut;
+
+        private int nextIn;
+
+        private ConflictId[] ids;
+
+        RootQueue( int capacity )
+        {
+            ids = new ConflictId[capacity + 16];
+        }
+
+        boolean isEmpty()
+        {
+            return nextOut >= nextIn;
+        }
+
+        void add( ConflictId id )
+        {
+            if ( nextOut >= nextIn && nextOut > 0 )
+            {
+                nextIn -= nextOut;
+                nextOut = 0;
+            }
+            if ( nextIn >= ids.length )
+            {
+                ConflictId[] tmp = new ConflictId[ids.length + ids.length / 2 + 16];
+                System.arraycopy( ids, nextOut, tmp, 0, nextIn - nextOut );
+                ids = tmp;
+                nextIn -= nextOut;
+                nextOut = 0;
+            }
+            int i;
+            for ( i = nextIn - 1; i >= nextOut && id.minDepth < ids[i].minDepth; i-- )
+            {
+                ids[i + 1] = ids[i];
+            }
+            ids[i + 1] = id;
+            nextIn++;
+        }
+
+        ConflictId remove()
+        {
+            return ids[nextOut++];
+        }
+
+    }
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/ConflictMarker.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/ConflictMarker.java
@@ -1,0 +1,308 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2012 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Sonatype, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.apache.karaf.tooling.semantic.eclipse;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.sonatype.aether.RepositoryException;
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.collection.DependencyGraphTransformationContext;
+import org.sonatype.aether.collection.DependencyGraphTransformer;
+import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.util.graph.transformer.TransformationContextKeys;
+
+
+/**
+ * A dependency graph transformer that identifies conflicting dependencies. When this transformer has executed, the
+ * transformation context holds a {@code Map<DependencyNode, Object>} where dependency nodes that belong to the same
+ * conflict group will have an equal conflict identifier. This map is stored using the key
+ * {@link TransformationContextKeys#CONFLICT_IDS}.
+ */
+public final class ConflictMarker
+    implements DependencyGraphTransformer
+{
+
+    /**
+     * After the execution of this method, every DependencyNode with an attached dependency is member of one conflict
+     * group.
+     * 
+     * @see DependencyGraphTransformer#transformGraph(DependencyNode, DependencyGraphTransformationContext)
+     */
+    public DependencyNode transformGraph( DependencyNode node, DependencyGraphTransformationContext context )
+        throws RepositoryException
+    {
+        @SuppressWarnings( "unchecked" )
+        Map<String, Object> stats = (Map<String, Object>) context.get( ContextKeys.STATS );
+        long time1 = System.currentTimeMillis();
+
+        Map<DependencyNode, Object> nodes = new IdentityHashMap<DependencyNode, Object>( 1024 );
+        Map<Object, ConflictGroup> groups = new HashMap<Object, ConflictGroup>( 1024 );
+
+        analyze( node, nodes, groups, new int[] { 0 } );
+
+        long time2 = System.currentTimeMillis();
+
+        Map<DependencyNode, Object> conflictIds = mark( nodes.keySet(), groups );
+
+        context.put( TransformationContextKeys.CONFLICT_IDS, conflictIds );
+
+        if ( stats != null )
+        {
+            long time3 = System.currentTimeMillis();
+            stats.put( "ConflictMarker.analyzeTime", time2 - time1 );
+            stats.put( "ConflictMarker.markTime", time3 - time2 );
+            stats.put( "ConflictMarker.nodeCount", nodes.size() );
+        }
+
+        return node;
+    }
+
+    private void analyze( DependencyNode node, Map<DependencyNode, Object> nodes, Map<Object, ConflictGroup> groups,
+                          int[] counter )
+    {
+        if ( nodes.put( node, Boolean.TRUE ) != null )
+        {
+            return;
+        }
+
+        Set<Object> keys = getKeys( node );
+        if ( !keys.isEmpty() )
+        {
+            ConflictGroup group = null;
+            boolean fixMappings = false;
+
+            for ( Object key : keys )
+            {
+                ConflictGroup g = groups.get( key );
+
+                if ( group != g )
+                {
+                    if ( group == null )
+                    {
+                        Set<Object> newKeys = merge( g.keys, keys );
+                        if ( newKeys == g.keys )
+                        {
+                            group = g;
+                            break;
+                        }
+                        else
+                        {
+                            group = new ConflictGroup( newKeys, counter[0]++ );
+                            fixMappings = true;
+                        }
+                    }
+                    else if ( g == null )
+                    {
+                        fixMappings = true;
+                    }
+                    else
+                    {
+                        Set<Object> newKeys = merge( g.keys, group.keys );
+                        if ( newKeys == g.keys )
+                        {
+                            group = g;
+                            fixMappings = false;
+                            break;
+                        }
+                        else if ( newKeys != group.keys )
+                        {
+                            group = new ConflictGroup( newKeys, counter[0]++ );
+                            fixMappings = true;
+                        }
+                    }
+                }
+            }
+
+            if ( group == null )
+            {
+                group = new ConflictGroup( keys, counter[0]++ );
+                fixMappings = true;
+            }
+            if ( fixMappings )
+            {
+                for ( Object key : group.keys )
+                {
+                    groups.put( key, group );
+                }
+            }
+        }
+
+        for ( DependencyNode child : node.getChildren() )
+        {
+            analyze( child, nodes, groups, counter );
+        }
+    }
+
+    private Set<Object> merge( Set<Object> keys1, Set<Object> keys2 )
+    {
+        int size1 = keys1.size();
+        int size2 = keys2.size();
+
+        if ( size1 < size2 )
+        {
+            if ( keys2.containsAll( keys1 ) )
+            {
+                return keys2;
+            }
+        }
+        else
+        {
+            if ( keys1.containsAll( keys2 ) )
+            {
+                return keys1;
+            }
+        }
+
+        Set<Object> keys = new HashSet<Object>();
+        keys.addAll( keys1 );
+        keys.addAll( keys2 );
+        return keys;
+    }
+
+    private Set<Object> getKeys( DependencyNode node )
+    {
+        Set<Object> keys;
+
+        Dependency dependency = node.getDependency();
+
+        if ( dependency == null )
+        {
+            keys = Collections.emptySet();
+        }
+        else
+        {
+            Object key = toKey( dependency.getArtifact() );
+
+            if ( node.getRelocations().isEmpty() && node.getAliases().isEmpty() )
+            {
+                keys = Collections.singleton( key );
+            }
+            else
+            {
+                keys = new HashSet<Object>();
+                keys.add( key );
+
+                for ( Artifact relocation : node.getRelocations() )
+                {
+                    key = toKey( relocation );
+                    keys.add( key );
+                }
+
+                for ( Artifact alias : node.getAliases() )
+                {
+                    key = toKey( alias );
+                    keys.add( key );
+                }
+            }
+        }
+
+        return keys;
+    }
+
+    private Map<DependencyNode, Object> mark( Collection<DependencyNode> nodes, Map<Object, ConflictGroup> groups )
+    {
+        Map<DependencyNode, Object> conflictIds = new IdentityHashMap<DependencyNode, Object>( nodes.size() + 1 );
+
+        for ( DependencyNode node : nodes )
+        {
+            Dependency dependency = node.getDependency();
+            if ( dependency != null )
+            {
+                Object key = toKey( dependency.getArtifact() );
+                conflictIds.put( node, groups.get( key ).index );
+            }
+        }
+
+        return conflictIds;
+    }
+
+    private static Object toKey( Artifact artifact )
+    {
+        return new Key( artifact );
+    }
+
+    static class ConflictGroup
+    {
+
+        final Set<Object> keys;
+
+        final int index;
+
+        public ConflictGroup( Set<Object> keys, int index )
+        {
+            this.keys = keys;
+            this.index = index;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.valueOf( keys );
+        }
+
+    }
+
+    static class Key
+    {
+
+        private final Artifact artifact;
+
+        public Key( Artifact artifact )
+        {
+            this.artifact = artifact;
+        }
+
+        @Override
+        public boolean equals( Object obj )
+        {
+            if ( obj == this )
+            {
+                return true;
+            }
+            else if ( !( obj instanceof Key ) )
+            {
+                return false;
+            }
+            Key that = (Key) obj;
+            return artifact.getArtifactId().equals( that.artifact.getArtifactId() )
+                && artifact.getGroupId().equals( that.artifact.getGroupId() )
+                && artifact.getExtension().equals( that.artifact.getExtension() )
+                && artifact.getClassifier().equals( that.artifact.getClassifier() );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int hash = 17;
+            hash = hash * 31 + artifact.getArtifactId().hashCode();
+            hash = hash * 31 + artifact.getGroupId().hashCode();
+            hash = hash * 31 + artifact.getClassifier().hashCode();
+            hash = hash * 31 + artifact.getExtension().hashCode();
+            return hash;
+        }
+
+        @Override
+        public String toString()
+        {
+            return artifact.getGroupId() + ':' + artifact.getArtifactId() + ':' + artifact.getClassifier() + ':'
+                + artifact.getExtension();
+        }
+
+    }
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/ConflictResolver.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/ConflictResolver.java
@@ -1,0 +1,1313 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2013 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Sonatype, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.apache.karaf.tooling.semantic.eclipse;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+
+import org.sonatype.aether.RepositoryException;
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.collection.DependencyGraphTransformationContext;
+import org.sonatype.aether.collection.DependencyGraphTransformer;
+import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.util.ConfigUtils;
+import org.sonatype.aether.util.graph.DefaultDependencyNode;
+import org.sonatype.aether.util.graph.transformer.TransformationContextKeys;
+
+
+/**
+ * A dependency graph transformer that resolves version and scope conflicts among dependencies. For a given set of
+ * conflicting nodes, one node will be chosen as the winner and the other nodes are removed from the dependency graph.
+ * The exact rules by which a winning node and its effective scope are determined are controlled by user-supplied
+ * implementations of {@link VersionSelector}, {@link ScopeSelector}, {@link OptionalitySelector} and
+ * {@link ScopeDeriver}.
+ * <p>
+ * By default, this graph transformer will turn the dependency graph into a tree without duplicate artifacts. Using the
+ * configuration property {@link #CONFIG_PROP_VERBOSE}, a verbose mode can be enabled where the graph is still turned
+ * into a tree but all nodes participating in a conflict are retained. The nodes that were rejected during conflict
+ * resolution have no children and link back to the winner node via the {@link #NODE_DATA_WINNER} key in their custom
+ * data. Additionally, the keys {@link #NODE_DATA_ORIGINAL_SCOPE} and {@link #NODE_DATA_ORIGINAL_OPTIONALITY} are used
+ * to store the original scope and optionality of each node. Obviously, the resulting dependency tree is not suitable
+ * for artifact resolution unless a filter is employed to exclude the duplicate dependencies.
+ * <p>
+ * This transformer will query the keys {@link TransformationContextKeys#CONFLICT_IDS},
+ * {@link TransformationContextKeys#SORTED_CONFLICT_IDS}, {@link TransformationContextKeys#CYCLIC_CONFLICT_IDS} for
+ * existing information about conflict ids. In absence of this information, it will automatically invoke the
+ * {@link ConflictIdSorter} to calculate it.
+ */
+public final class ConflictResolver
+    implements DependencyGraphTransformer
+{
+
+    /**
+     * The key in the repository session's {@link RepositorySystemSession#getConfigProperties() configuration
+     * properties} used to store a {@link Boolean} flag controlling the transformer's verbose mode.
+     */
+    public static final String CONFIG_PROP_VERBOSE = "aether.conflictResolver.verbose";
+
+    /**
+     * The key in the dependency node's {@link DependencyNode#getData() custom data} under which a reference to the
+     * {@link DependencyNode} which has won the conflict is stored.
+     */
+    public static final String NODE_DATA_WINNER = "conflict.winner";
+
+    /**
+     * The key in the dependency node's {@link DependencyNode#getData() custom data} under which the scope of the
+     * dependency before scope derivation and conflict resolution is stored.
+     */
+    public static final String NODE_DATA_ORIGINAL_SCOPE = "conflict.originalScope";
+
+    /**
+     * The key in the dependency node's {@link DependencyNode#getData() custom data} under which the optional flag of
+     * the dependency before derivation and conflict resolution is stored.
+     */
+    public static final String NODE_DATA_ORIGINAL_OPTIONALITY = "conflict.originalOptionality";
+
+    private final VersionSelector versionSelector;
+
+    private final ScopeSelector scopeSelector;
+
+    private final ScopeDeriver scopeDeriver;
+
+    private final OptionalitySelector optionalitySelector;
+
+    /**
+     * Creates a new conflict resolver instance with the specified hooks.
+     * 
+     * @param versionSelector The version selector to use, must not be {@code null}.
+     * @param scopeSelector The scope selector to use, must not be {@code null}.
+     * @param optionalitySelector The optionality selector ot use, must not be {@code null}.
+     * @param scopeDeriver The scope deriver to use, must not be {@code null}.
+     */
+    public ConflictResolver( VersionSelector versionSelector, ScopeSelector scopeSelector,
+                             OptionalitySelector optionalitySelector, ScopeDeriver scopeDeriver )
+    {
+        if ( versionSelector == null )
+        {
+            throw new IllegalArgumentException( "version selector not specified" );
+        }
+        this.versionSelector = versionSelector;
+        if ( scopeSelector == null )
+        {
+            throw new IllegalArgumentException( "scope selector not specified" );
+        }
+        this.scopeSelector = scopeSelector;
+        if ( scopeDeriver == null )
+        {
+            throw new IllegalArgumentException( "scope deriver not specified" );
+        }
+        this.scopeDeriver = scopeDeriver;
+        if ( optionalitySelector == null )
+        {
+            throw new IllegalArgumentException( "optionality selector not specified" );
+        }
+        this.optionalitySelector = optionalitySelector;
+    }
+
+    public DependencyNode transformGraph( DependencyNode node, DependencyGraphTransformationContext context )
+        throws RepositoryException
+    {
+        List<?> sortedConflictIds = (List<?>) context.get( TransformationContextKeys.SORTED_CONFLICT_IDS );
+        if ( sortedConflictIds == null )
+        {
+            ConflictIdSorter sorter = new ConflictIdSorter();
+            sorter.transformGraph( node, context );
+
+            sortedConflictIds = (List<?>) context.get( TransformationContextKeys.SORTED_CONFLICT_IDS );
+        }
+
+        @SuppressWarnings( "unchecked" )
+        Map<String, Object> stats = (Map<String, Object>) context.get( ContextKeys.STATS ); // XXX
+        long time1 = System.currentTimeMillis();
+
+        @SuppressWarnings( "unchecked" )
+        Collection<Collection<?>> conflictIdCycles =
+            (Collection<Collection<?>>) context.get( TransformationContextKeys.CYCLIC_CONFLICT_IDS );
+        if ( conflictIdCycles == null )
+        {
+            throw new RepositoryException( "conflict id cycles have not been identified" );
+        }
+
+        Map<?, ?> conflictIds = (Map<?, ?>) context.get( TransformationContextKeys.CONFLICT_IDS );
+        if ( conflictIds == null )
+        {
+            throw new RepositoryException( "conflict groups have not been identified" );
+        }
+
+        Map<Object, Collection<Object>> cyclicPredecessors = new HashMap<Object, Collection<Object>>();
+        for ( Collection<?> cycle : conflictIdCycles )
+        {
+            for ( Object conflictId : cycle )
+            {
+                Collection<Object> predecessors = cyclicPredecessors.get( conflictId );
+                if ( predecessors == null )
+                {
+                    predecessors = new HashSet<Object>();
+                    cyclicPredecessors.put( conflictId, predecessors );
+                }
+                predecessors.addAll( cycle );
+            }
+        }
+
+        State state = new State( node, conflictIds, sortedConflictIds.size(), context );
+        for ( Iterator<?> it = sortedConflictIds.iterator(); it.hasNext(); )
+        {
+            Object conflictId = it.next();
+
+            // reset data structures for next graph walk
+            state.prepare( conflictId, cyclicPredecessors.get( conflictId ) );
+
+            // find nodes with the current conflict id and while walking the graph (more deeply), nuke leftover losers
+            gatherConflictItems( node, state );
+
+            // now that we know the min depth of the parents, update depth of conflict items
+            state.finish();
+
+            // earlier runs might have nuked all parents of the current conflict id, so it might not exist anymore
+            if ( !state.items.isEmpty() )
+            {
+                ConflictContext ctx = state.conflictCtx;
+                state.versionSelector.selectVersion( ctx );
+                if ( ctx.winner == null )
+                {
+                    throw new RepositoryException( "conflict resolver did not select winner among " + state.items );
+                }
+                DependencyNode winner = ctx.winner.node;
+
+                state.scopeSelector.selectScope( ctx );
+                if ( state.verbose )
+                {
+                    winner.setData( NODE_DATA_ORIGINAL_SCOPE, winner.getDependency().getScope() );
+                }
+                winner.setScope( ctx.scope );
+
+                state.optionalitySelector.selectOptionality( ctx );
+                if ( state.verbose )
+                {
+                    winner.setData( NODE_DATA_ORIGINAL_OPTIONALITY, winner.getDependency().isOptional() );
+                }
+                // winner.setOptional( ctx.optional ); // XXX
+
+                removeLosers( state );
+            }
+
+            // record the winner so we can detect leftover losers during future graph walks
+            state.winner();
+
+            // in case of cycles, trigger final graph walk to ensure all leftover losers are gone
+            if ( !it.hasNext() && !conflictIdCycles.isEmpty() && state.conflictCtx.winner != null )
+            {
+                DependencyNode winner = state.conflictCtx.winner.node;
+                state.prepare( state, null );
+                gatherConflictItems( winner, state );
+            }
+        }
+
+        if ( stats != null )
+        {
+            long time2 = System.currentTimeMillis();
+            stats.put( "ConflictResolver.totalTime", time2 - time1 );
+            stats.put( "ConflictResolver.conflictItemCount", state.totalConflictItems );
+        }
+
+        return node;
+    }
+
+    private boolean gatherConflictItems( DependencyNode node, State state )
+        throws RepositoryException
+    {
+        Object conflictId = state.conflictIds.get( node );
+        if ( state.currentId.equals( conflictId ) )
+        {
+            // found it, add conflict item (if not already done earlier by another path)
+            state.add( node );
+            // we don't recurse here so we might miss losers beneath us, those will be nuked during future walks below
+        }
+        else if ( state.loser( node, conflictId ) )
+        {
+            // found a leftover loser (likely in a cycle) of an already processed conflict id, tell caller to nuke it
+            return false;
+        }
+        else if ( state.push( node, conflictId ) )
+        {
+            // found potential parent, no cycle and not visisted before with the same derived scope, so recurse
+            for ( Iterator<DependencyNode> it = node.getChildren().iterator(); it.hasNext(); )
+            {
+                DependencyNode child = it.next();
+                if ( !gatherConflictItems( child, state ) )
+                {
+                    it.remove();
+                }
+            }
+            state.pop();
+        }
+        return true;
+    }
+
+    private void removeLosers( State state )
+    {
+        ConflictItem winner = state.conflictCtx.winner;
+        List<DependencyNode> previousParent = null;
+        ListIterator<DependencyNode> childIt = null;
+        boolean conflictVisualized = false;
+        for ( ConflictItem item : state.items )
+        {
+            if ( item == winner )
+            {
+                continue;
+            }
+            if ( item.parent != previousParent )
+            {
+                childIt = item.parent.listIterator();
+                previousParent = item.parent;
+                conflictVisualized = false;
+            }
+            while ( childIt.hasNext() )
+            {
+                DependencyNode child = childIt.next();
+                if ( child == item.node )
+                {
+                    if ( state.verbose && !conflictVisualized && item.parent != winner.parent )
+                    {
+                        conflictVisualized = true;
+                        DependencyNode loser = new DefaultDependencyNode( child );
+                        loser.setData( NODE_DATA_WINNER, winner.node );
+                        loser.setData( NODE_DATA_ORIGINAL_SCOPE, loser.getDependency().getScope() );
+                        loser.setData( NODE_DATA_ORIGINAL_OPTIONALITY, loser.getDependency().isOptional() );
+                        loser.setScope( item.getScopes().iterator().next() );
+                        // loser.setChildren( Collections.<DependencyNode> emptyList() ); // XXX
+                        childIt.set( loser );
+                    }
+                    else
+                    {
+                        childIt.remove();
+                    }
+                    break;
+                }
+            }
+        }
+        // there might still be losers beneath the winner (e.g. in case of cycles)
+        // those will be nuked during future graph walks when we include the winner in the recursion
+    }
+
+    final class NodeInfo
+    {
+
+        /**
+         * The smallest depth at which the node was seen, used for "the" depth of its conflict items.
+         */
+        int minDepth;
+
+        /**
+         * The set of derived scopes the node was visited with, used to check whether an already seen node needs to be
+         * revisited again in context of another scope. To conserve memory, we start with {@code String} and update to
+         * {@code Set<String>} if needed.
+         */
+        Object derivedScopes;
+
+        /**
+         * The set of derived optionalities the node was visited with, used to check whether an already seen node needs
+         * to be revisited again in context of another optionality. To conserve memory, encoded as bit field (bit 0 ->
+         * optional=false, bit 1 -> optional=true).
+         */
+        int derivedOptionalities;
+
+        /**
+         * The conflict items which are immediate children of the node, used to easily update those conflict items after
+         * a new parent scope/optionality was encountered.
+         */
+        List<ConflictItem> children;
+
+        static final int CHANGE_SCOPE = 0x01;
+
+        static final int CHANGE_OPTIONAL = 0x02;
+
+        private static final int OPT_FALSE = 0x01;
+
+        private static final int OPT_TRUE = 0x02;
+
+        NodeInfo( int depth, String derivedScope, boolean optional )
+        {
+            minDepth = depth;
+            derivedScopes = derivedScope;
+            derivedOptionalities = optional ? OPT_TRUE : OPT_FALSE;
+        }
+
+        @SuppressWarnings( "unchecked" )
+        int update( int depth, String derivedScope, boolean optional )
+        {
+            if ( depth < minDepth )
+            {
+                minDepth = depth;
+            }
+            int changes;
+            if ( derivedScopes.equals( derivedScope ) )
+            {
+                changes = 0;
+            }
+            else if ( derivedScopes instanceof Collection )
+            {
+                changes = ( (Collection<String>) derivedScopes ).add( derivedScope ) ? CHANGE_SCOPE : 0;
+            }
+            else
+            {
+                Collection<String> scopes = new HashSet<String>();
+                scopes.add( (String) derivedScopes );
+                scopes.add( derivedScope );
+                derivedScopes = scopes;
+                changes = CHANGE_SCOPE;
+            }
+            int bit = optional ? OPT_TRUE : OPT_FALSE;
+            if ( ( derivedOptionalities & bit ) == 0 )
+            {
+                derivedOptionalities |= bit;
+                changes |= CHANGE_OPTIONAL;
+            }
+            return changes;
+        }
+
+        void add( ConflictItem item )
+        {
+            if ( children == null )
+            {
+                children = new ArrayList<ConflictItem>( 1 );
+            }
+            children.add( item );
+        }
+
+    }
+
+    final class State
+    {
+
+        /**
+         * The conflict id currently processed.
+         */
+        Object currentId;
+
+        /**
+         * Stats counter.
+         */
+        int totalConflictItems;
+
+        /**
+         * Flag whether we should keep losers in the graph to enable visualization/troubleshooting of conflicts.
+         */
+        final boolean verbose;
+
+        /**
+         * A mapping from conflict id to winner node, helps to recognize nodes that have their effective
+         * scope&optionality set or are leftovers from previous removals.
+         */
+        final Map<Object, DependencyNode> resolvedIds;
+
+        /**
+         * The set of conflict ids which could apply to ancestors of nodes with the current conflict id, used to avoid
+         * recursion early on. This is basically a superset of the key set of resolvedIds, the additional ids account
+         * for cyclic dependencies.
+         */
+        final Collection<Object> potentialAncestorIds;
+
+        /**
+         * The output from the conflict marker
+         */
+        final Map<?, ?> conflictIds;
+
+        /**
+         * The conflict items we have gathered so far for the current conflict id.
+         */
+        final List<ConflictItem> items;
+
+        /**
+         * The (conceptual) mapping from nodes to extra infos, technically keyed by the node's child list which better
+         * captures the identity of a node since we're basically concerned with effects towards children.
+         */
+        final Map<List<DependencyNode>, NodeInfo> infos;
+
+        /**
+         * The set of nodes on the DFS stack to detect cycles, technically keyed by the node's child list to match the
+         * dirty graph structure produced by the dependency collector for cycles.
+         */
+        final Map<List<DependencyNode>, Object> stack;
+
+        /**
+         * The stack of parent nodes.
+         */
+        final List<DependencyNode> parentNodes;
+
+        /**
+         * The stack of derived scopes for parent nodes.
+         */
+        final List<String> parentScopes;
+
+        /**
+         * The stack of derived optional flags for parent nodes.
+         */
+        final List<Boolean> parentOptionals;
+
+        /**
+         * The stack of node infos for parent nodes, may contain {@code null} which is used to disable creating new
+         * conflict items when visiting their parent again (conflict items are meant to be unique by parent-node combo).
+         */
+        final List<NodeInfo> parentInfos;
+
+        /**
+         * The conflict context passed to the version/scope/optionality selectors, updated as we move along rather than
+         * recreated to avoid tmp objects.
+         */
+        final ConflictContext conflictCtx;
+
+        /**
+         * The scope context passed to the scope deriver, updated as we move along rather than recreated to avoid tmp
+         * objects.
+         */
+        final ScopeContext scopeCtx;
+
+        /**
+         * The effective version selector, i.e. after initialization.
+         */
+        final VersionSelector versionSelector;
+
+        /**
+         * The effective scope selector, i.e. after initialization.
+         */
+        final ScopeSelector scopeSelector;
+
+        /**
+         * The effective scope deriver, i.e. after initialization.
+         */
+        final ScopeDeriver scopeDeriver;
+
+        /**
+         * The effective optionality selector, i.e. after initialization.
+         */
+        final OptionalitySelector optionalitySelector;
+
+        State( DependencyNode root, Map<?, ?> conflictIds, int conflictIdCount,
+               DependencyGraphTransformationContext context )
+            throws RepositoryException
+        {
+            this.conflictIds = conflictIds;
+            verbose = ConfigUtils.getBoolean( context.getSession(), false, CONFIG_PROP_VERBOSE );
+            potentialAncestorIds = new HashSet<Object>( conflictIdCount * 2 );
+            resolvedIds = new HashMap<Object, DependencyNode>( conflictIdCount * 2 );
+            items = new ArrayList<ConflictItem>( 256 );
+            infos = new IdentityHashMap<List<DependencyNode>, NodeInfo>( 64 );
+            stack = new IdentityHashMap<List<DependencyNode>, Object>( 64 );
+            parentNodes = new ArrayList<DependencyNode>( 64 );
+            parentScopes = new ArrayList<String>( 64 );
+            parentOptionals = new ArrayList<Boolean>( 64 );
+            parentInfos = new ArrayList<NodeInfo>( 64 );
+            conflictCtx = new ConflictContext( root, conflictIds, items );
+            scopeCtx = new ScopeContext( null, null );
+            versionSelector = ConflictResolver.this.versionSelector.getInstance( root, context );
+            scopeSelector = ConflictResolver.this.scopeSelector.getInstance( root, context );
+            scopeDeriver = ConflictResolver.this.scopeDeriver.getInstance( root, context );
+            optionalitySelector = ConflictResolver.this.optionalitySelector.getInstance( root, context );
+        }
+
+        void prepare( Object conflictId, Collection<Object> cyclicPredecessors )
+        {
+            currentId = conflictCtx.conflictId = conflictId;
+            conflictCtx.winner = null;
+            conflictCtx.scope = null;
+            conflictCtx.optional = null;
+            items.clear();
+            infos.clear();
+            if ( cyclicPredecessors != null )
+            {
+                potentialAncestorIds.addAll( cyclicPredecessors );
+            }
+        }
+
+        void finish()
+        {
+            List<DependencyNode> previousParent = null;
+            int previousDepth = 0;
+            totalConflictItems += items.size();
+            for ( int i = items.size() - 1; i >= 0; i-- )
+            {
+                ConflictItem item = items.get( i );
+                if ( item.parent == previousParent )
+                {
+                    item.depth = previousDepth;
+                }
+                else if ( item.parent != null )
+                {
+                    previousParent = item.parent;
+                    NodeInfo info = infos.get( previousParent );
+                    previousDepth = info.minDepth + 1;
+                    item.depth = previousDepth;
+                }
+            }
+            potentialAncestorIds.add( currentId );
+        }
+
+        void winner()
+        {
+            resolvedIds.put( currentId, ( conflictCtx.winner != null ) ? conflictCtx.winner.node : null );
+        }
+
+        boolean loser( DependencyNode node, Object conflictId )
+        {
+            DependencyNode winner = resolvedIds.get( conflictId );
+            return winner != null && winner != node;
+        }
+
+        boolean push( DependencyNode node, Object conflictId )
+            throws RepositoryException
+        {
+            if ( conflictId == null )
+            {
+                if ( node.getDependency() != null )
+                {
+                    if ( node.getData().get( NODE_DATA_WINNER ) != null )
+                    {
+                        return false;
+                    }
+                    throw new RepositoryException( "missing conflict id for node " + node );
+                }
+            }
+            else if ( !potentialAncestorIds.contains( conflictId ) )
+            {
+                return false;
+            }
+
+            List<DependencyNode> graphNode = node.getChildren();
+            if ( stack.put( graphNode, Boolean.TRUE ) != null )
+            {
+                return false;
+            }
+
+            int depth = depth();
+            String scope = deriveScope( node, conflictId );
+            boolean optional = deriveOptional( node, conflictId );
+            NodeInfo info = infos.get( graphNode );
+            if ( info == null )
+            {
+                info = new NodeInfo( depth, scope, optional );
+                infos.put( graphNode, info );
+                parentInfos.add( info );
+                parentNodes.add( node );
+                parentScopes.add( scope );
+                parentOptionals.add( optional );
+            }
+            else
+            {
+                int changes = info.update( depth, scope, optional );
+                if ( changes == 0 )
+                {
+                    stack.remove( graphNode );
+                    return false;
+                }
+                parentInfos.add( null ); // disable creating new conflict items, we update the existing ones below
+                parentNodes.add( node );
+                parentScopes.add( scope );
+                parentOptionals.add( optional );
+                if ( info.children != null )
+                {
+                    if ( ( changes & NodeInfo.CHANGE_SCOPE ) != 0 )
+                    {
+                        for ( int i = info.children.size() - 1; i >= 0; i-- )
+                        {
+                            ConflictItem item = info.children.get( i );
+                            String childScope = deriveScope( item.node, null );
+                            item.addScope( childScope );
+                        }
+                    }
+                    if ( ( changes & NodeInfo.CHANGE_OPTIONAL ) != 0 )
+                    {
+                        for ( int i = info.children.size() - 1; i >= 0; i-- )
+                        {
+                            ConflictItem item = info.children.get( i );
+                            boolean childOptional = deriveOptional( item.node, null );
+                            item.addOptional( childOptional );
+                        }
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        void pop()
+        {
+            int last = parentInfos.size() - 1;
+            parentInfos.remove( last );
+            parentScopes.remove( last );
+            parentOptionals.remove( last );
+            DependencyNode node = parentNodes.remove( last );
+            stack.remove( node.getChildren() );
+        }
+
+        void add( DependencyNode node )
+            throws RepositoryException
+        {
+            DependencyNode parent = parent();
+            if ( parent == null )
+            {
+                ConflictItem item = newConflictItem( parent, node );
+                items.add( item );
+            }
+            else
+            {
+                NodeInfo info = parentInfos.get( parentInfos.size() - 1 );
+                if ( info != null )
+                {
+                    ConflictItem item = newConflictItem( parent, node );
+                    info.add( item );
+                    items.add( item );
+                }
+            }
+        }
+
+        private ConflictItem newConflictItem( DependencyNode parent, DependencyNode node )
+            throws RepositoryException
+        {
+            return new ConflictItem( parent, node, deriveScope( node, null ), deriveOptional( node, null ) );
+        }
+
+        private int depth()
+        {
+            return parentNodes.size();
+        }
+
+        private DependencyNode parent()
+        {
+            int size = parentNodes.size();
+            return ( size <= 0 ) ? null : parentNodes.get( size - 1 );
+        }
+
+        private String deriveScope( DependencyNode node, Object conflictId )
+            throws RepositoryException
+        {
+        	// XXX
+//            if ( ( node.getManagedBits() & DependencyNode.MANAGED_SCOPE ) != 0
+//                || ( conflictId != null && resolvedIds.containsKey( conflictId ) ) )
+//            {
+//                return scope( node.getDependency() );
+//            }
+
+            int depth = parentNodes.size();
+            scopes( depth, node.getDependency() );
+            if ( depth > 0 )
+            {
+                scopeDeriver.deriveScope( scopeCtx );
+            }
+            return scopeCtx.derivedScope;
+        }
+
+        private void scopes( int parent, Dependency child )
+        {
+            scopeCtx.parentScope = ( parent > 0 ) ? parentScopes.get( parent - 1 ) : null;
+            scopeCtx.derivedScope = scopeCtx.childScope = scope( child );
+        }
+
+        private String scope( Dependency dependency )
+        {
+            return ( dependency != null ) ? dependency.getScope() : null;
+        }
+
+        private boolean deriveOptional( DependencyNode node, Object conflictId )
+        {
+            Dependency dep = node.getDependency();
+            boolean optional = ( dep != null ) ? dep.isOptional() : false;
+            // XXX
+//            if ( optional || ( node.getManagedBits() & DependencyNode.MANAGED_OPTIONAL ) != 0
+//                || ( conflictId != null && resolvedIds.containsKey( conflictId ) ) )
+//            {
+//                return optional;
+//            }
+            int depth = parentNodes.size();
+            return ( depth > 0 ) ? parentOptionals.get( depth - 1 ) : false;
+        }
+
+    }
+
+    /**
+     * A context used to hold information that is relevant for deriving the scope of a child dependency.
+     * 
+     * @see ScopeDeriver
+     * @noinstantiate This class is not intended to be instantiated by clients in production code, the constructor may
+     *                change without notice and only exists to enable unit testing.
+     */
+    public static final class ScopeContext
+    {
+
+        String parentScope;
+
+        String childScope;
+
+        String derivedScope;
+
+        /**
+         * Creates a new scope context with the specified properties.
+         * 
+         * @param parentScope The scope of the parent dependency, may be {@code null}.
+         * @param childScope The scope of the child dependency, may be {@code null}.
+         * @noreference This class is not intended to be instantiated by clients in production code, the constructor may
+         *              change without notice and only exists to enable unit testing.
+         */
+        public ScopeContext( String parentScope, String childScope )
+        {
+            this.parentScope = ( parentScope != null ) ? parentScope : "";
+            derivedScope = this.childScope = ( childScope != null ) ? childScope : "";
+        }
+
+        /**
+         * Gets the scope of the parent dependency. This is usually the scope that was derived by earlier invocations of
+         * the scope deriver.
+         * 
+         * @return The scope of the parent dependency, never {@code null}.
+         */
+        public String getParentScope()
+        {
+            return parentScope;
+        }
+
+        /**
+         * Gets the original scope of the child dependency. This is the scope that was declared in the artifact
+         * descriptor of the parent dependency.
+         * 
+         * @return The original scope of the child dependency, never {@code null}.
+         */
+        public String getChildScope()
+        {
+            return childScope;
+        }
+
+        /**
+         * Gets the derived scope of the child dependency. This is initially equal to {@link #getChildScope()} until the
+         * scope deriver makes changes.
+         * 
+         * @return The derived scope of the child dependency, never {@code null}.
+         */
+        public String getDerivedScope()
+        {
+            return derivedScope;
+        }
+
+        /**
+         * Sets the derived scope of the child dependency.
+         * 
+         * @param derivedScope The derived scope of the dependency, may be {@code null}.
+         */
+        public void setDerivedScope( String derivedScope )
+        {
+            this.derivedScope = ( derivedScope != null ) ? derivedScope : "";
+        }
+
+    }
+
+    /**
+     * A conflicting dependency.
+     * 
+     * @noinstantiate This class is not intended to be instantiated by clients in production code, the constructor may
+     *                change without notice and only exists to enable unit testing.
+     */
+    public static final class ConflictItem
+    {
+
+        // nodes can share child lists, we care about the unique owner of a child node which is the child list
+        final List<DependencyNode> parent;
+
+        // only for debugging/toString() to help identify the parent node(s)
+        final Artifact artifact;
+
+        final DependencyNode node;
+
+        int depth;
+
+        // we start with String and update to Set<String> if needed
+        Object scopes;
+
+        // bit field of OPTIONAL_FALSE and OPTIONAL_TRUE
+        int optionalities;
+
+        /**
+         * Bit flag indicating whether one or more paths consider the dependency non-optional.
+         */
+        public static final int OPTIONAL_FALSE = 0x01;
+
+        /**
+         * Bit flag indicating whether one or more paths consider the dependency optional.
+         */
+        public static final int OPTIONAL_TRUE = 0x02;
+
+        ConflictItem( DependencyNode parent, DependencyNode node, String scope, boolean optional )
+        {
+            if ( parent != null )
+            {
+                this.parent = parent.getChildren();
+                this.artifact = parent.getDependency().getArtifact(); // XXX
+            }
+            else
+            {
+                this.parent = null;
+                this.artifact = null;
+            }
+            this.node = node;
+            this.scopes = scope;
+            this.optionalities = optional ? OPTIONAL_TRUE : OPTIONAL_FALSE;
+        }
+
+        /**
+         * Creates a new conflict item with the specified properties.
+         * 
+         * @param parent The parent node of the conflicting dependency, may be {@code null}.
+         * @param node The conflicting dependency, must not be {@code null}.
+         * @param depth The zero-based depth of the conflicting dependency.
+         * @param optionalities The optionalities the dependency was encountered with, encoded as a bit field consisting
+         *            of {@link ConflictResolver.ConflictItem#OPTIONAL_TRUE} and
+         *            {@link ConflictResolver.ConflictItem#OPTIONAL_FALSE}.
+         * @param scopes The derived scopes of the conflicting dependency, must not be {@code null}.
+         * @noreference This class is not intended to be instantiated by clients in production code, the constructor may
+         *              change without notice and only exists to enable unit testing.
+         */
+        public ConflictItem( DependencyNode parent, DependencyNode node, int depth, int optionalities, String... scopes )
+        {
+            this.parent = ( parent != null ) ? parent.getChildren() : null;
+            this.artifact = ( parent != null ) ? parent.getDependency().getArtifact() : null; // XXX
+            this.node = node;
+            this.depth = depth;
+            this.optionalities = optionalities;
+            this.scopes = Arrays.asList( scopes );
+        }
+
+        /**
+         * Determines whether the specified conflict item is a sibling of this item.
+         * 
+         * @param item The other conflict item, must not be {@code null}.
+         * @return {@code true} if the given item has the same parent as this item, {@code false} otherwise.
+         */
+        public boolean isSibling( ConflictItem item )
+        {
+            return parent == item.parent;
+        }
+
+        /**
+         * Gets the dependency node involved in the conflict.
+         * 
+         * @return The involved dependency node, never {@code null}.
+         */
+        public DependencyNode getNode()
+        {
+            return node;
+        }
+
+        /**
+         * Gets the dependency involved in the conflict, short for {@code getNode.getDependency()}.
+         * 
+         * @return The involved dependency, never {@code null}.
+         */
+        public Dependency getDependency()
+        {
+            return node.getDependency();
+        }
+
+        /**
+         * Gets the zero-based depth at which the conflicting node occurs in the graph. As such, the depth denotes the
+         * number of parent nodes. If actually multiple paths lead to the node, the return value denotes the smallest
+         * possible depth.
+         * 
+         * @return The zero-based depth of the node in the graph.
+         */
+        public int getDepth()
+        {
+            return depth;
+        }
+
+        /**
+         * Gets the derived scopes of the dependency. In general, the same dependency node could be reached via
+         * different paths and each path might result in a different derived scope.
+         * 
+         * @see ScopeDeriver
+         * @return The (read-only) set of derived scopes of the dependency, never {@code null}.
+         */
+        @SuppressWarnings( "unchecked" )
+        public Collection<String> getScopes()
+        {
+            if ( scopes instanceof String )
+            {
+                return Collections.singleton( (String) scopes );
+            }
+            return (Collection<String>) scopes;
+        }
+
+        @SuppressWarnings( "unchecked" )
+        void addScope( String scope )
+        {
+            if ( scopes instanceof Collection )
+            {
+                ( (Collection<String>) scopes ).add( scope );
+            }
+            else if ( !scopes.equals( scope ) )
+            {
+                Collection<Object> set = new HashSet<Object>();
+                set.add( scopes );
+                set.add( scope );
+                scopes = set;
+            }
+        }
+
+        /**
+         * Gets the derived optionalities of the dependency. In general, the same dependency node could be reached via
+         * different paths and each path might result in a different derived optionality.
+         * 
+         * @return A bit field consisting of {@link ConflictResolver.ConflictItem#OPTIONAL_FALSE} and/or
+         *         {@link ConflictResolver.ConflictItem#OPTIONAL_TRUE} indicating the derived optionalities the
+         *         dependency was encountered with.
+         */
+        public int getOptionalities()
+        {
+            return optionalities;
+        }
+
+        void addOptional( boolean optional )
+        {
+            optionalities |= optional ? OPTIONAL_TRUE : OPTIONAL_FALSE;
+        }
+
+        @Override
+        public String toString()
+        {
+            return node + " @ " + depth + " < " + artifact;
+        }
+
+    }
+
+    /**
+     * A context used to hold information that is relevant for resolving version and scope conflicts.
+     * 
+     * @see VersionSelector
+     * @see ScopeSelector
+     * @noinstantiate This class is not intended to be instantiated by clients in production code, the constructor may
+     *                change without notice and only exists to enable unit testing.
+     */
+    public static final class ConflictContext
+    {
+
+        final DependencyNode root;
+
+        final Map<?, ?> conflictIds;
+
+        final Collection<ConflictItem> items;
+
+        Object conflictId;
+
+        ConflictItem winner;
+
+        String scope;
+
+        Boolean optional;
+
+        ConflictContext( DependencyNode root, Map<?, ?> conflictIds, Collection<ConflictItem> items )
+        {
+            this.root = root;
+            this.conflictIds = conflictIds;
+            this.items = Collections.unmodifiableCollection( items );
+        }
+
+        /**
+         * Creates a new conflict context.
+         * 
+         * @param root The root node of the dependency graph, must not be {@code null}.
+         * @param conflictId The conflict id for the set of conflicting dependencies in this context, must not be
+         *            {@code null}.
+         * @param conflictIds The mapping from dependency node to conflict id, must not be {@code null}.
+         * @param items The conflict items in this context, must not be {@code null}.
+         * @noreference This class is not intended to be instantiated by clients in production code, the constructor may
+         *              change without notice and only exists to enable unit testing.
+         */
+        public ConflictContext( DependencyNode root, Object conflictId, Map<DependencyNode, Object> conflictIds,
+                                Collection<ConflictItem> items )
+        {
+            this( root, conflictIds, items );
+            this.conflictId = conflictId;
+        }
+
+        /**
+         * Gets the root node of the dependency graph being transformed.
+         * 
+         * @return The root node of the dependeny graph, never {@code null}.
+         */
+        public DependencyNode getRoot()
+        {
+            return root;
+        }
+
+        /**
+         * Determines whether the specified dependency node belongs to this conflict context.
+         * 
+         * @param node The dependency node to check, must not be {@code null}.
+         * @return {@code true} if the given node belongs to this conflict context, {@code false} otherwise.
+         */
+        public boolean isIncluded( DependencyNode node )
+        {
+            return conflictId.equals( conflictIds.get( node ) );
+        }
+
+        /**
+         * Gets the collection of conflict items in this context.
+         * 
+         * @return The (read-only) collection of conflict items in this context, never {@code null}.
+         */
+        public Collection<ConflictItem> getItems()
+        {
+            return items;
+        }
+
+        /**
+         * Gets the conflict item which has been selected as the winner among the conflicting dependencies.
+         * 
+         * @return The winning conflict item or {@code null} if not set yet.
+         */
+        public ConflictItem getWinner()
+        {
+            return winner;
+        }
+
+        /**
+         * Sets the conflict item which has been selected as the winner among the conflicting dependencies.
+         * 
+         * @param winner The winning conflict item, may be {@code null}.
+         */
+        public void setWinner( ConflictItem winner )
+        {
+            this.winner = winner;
+        }
+
+        /**
+         * Gets the effective scope of the winning dependency.
+         * 
+         * @return The effective scope of the winning dependency or {@code null} if none.
+         */
+        public String getScope()
+        {
+            return scope;
+        }
+
+        /**
+         * Sets the effective scope of the winning dependency.
+         * 
+         * @param scope The effective scope, may be {@code null}.
+         */
+        public void setScope( String scope )
+        {
+            this.scope = scope;
+        }
+
+        /**
+         * Gets the effective optional flag of the winning dependency.
+         * 
+         * @return The effective optional flag or {@code null} if none.
+         */
+        public Boolean getOptional()
+        {
+            return optional;
+        }
+
+        /**
+         * Sets the effective optional flag of the winning dependency.
+         * 
+         * @param optional The effective optional flag, may be {@code null}.
+         */
+        public void setOptional( Boolean optional )
+        {
+            this.optional = optional;
+        }
+
+        @Override
+        public String toString()
+        {
+            return winner + " @ " + scope + " < " + items;
+        }
+
+    }
+
+    /**
+     * An extension point of {@link ConflictResolver} that determines the winner among conflicting dependencies. The
+     * winning node (and its children) will be retained in the dependency graph, the other nodes will get removed. The
+     * version selector does not need to deal with potential scope conflicts, these will be addressed afterwards by the
+     * {@link ScopeSelector}. Implementations must be stateless.
+     */
+    public static abstract class VersionSelector
+    {
+
+        /**
+         * Retrieves the version selector for use during the specified graph transformation. The conflict resolver calls
+         * this method once per
+         * {@link ConflictResolver#transformGraph(DependencyNode, DependencyGraphTransformationContext)} invocation to
+         * allow implementations to prepare any auxiliary data that is needed for their operation. Given that
+         * implementations need to be stateless, a new instance needs to be returned to hold such auxiliary data. The
+         * default implementation simply returns the current instance which is appropriate for implementations which do
+         * not require auxiliary data.
+         * 
+         * @param root The root node of the (possibly cyclic!) graph to transform, must not be {@code null}.
+         * @param context The graph transformation context, must not be {@code null}.
+         * @return The scope deriver to use for the given graph transformation, never {@code null}.
+         * @throws RepositoryException If the instance could not be retrieved.
+         */
+        public VersionSelector getInstance( DependencyNode root, DependencyGraphTransformationContext context )
+            throws RepositoryException
+        {
+            return this;
+        }
+
+        /**
+         * Determines the winning node among conflicting dependencies. Implementations will usually iterate
+         * {@link ConflictContext#getItems()}, inspect {@link ConflictItem#getNode()} and eventually call
+         * {@link ConflictContext#setWinner(ConflictResolver.ConflictItem)} to deliver the winner. Failure to select a
+         * winner will automatically fail the entire conflict resolution.
+         * 
+         * @param context The conflict context, must not be {@code null}.
+         * @throws RepositoryException If the version selection failed.
+         */
+        public abstract void selectVersion( ConflictContext context )
+            throws RepositoryException;
+
+    }
+
+    /**
+     * An extension point of {@link ConflictResolver} that determines the effective scope of a dependency from a
+     * potentially conflicting set of {@link ScopeDeriver derived scopes}. The scope selector gets invoked after the
+     * {@link VersionSelector} has picked the winning node. Implementations must be stateless.
+     */
+    public static abstract class ScopeSelector
+    {
+
+        /**
+         * Retrieves the scope selector for use during the specified graph transformation. The conflict resolver calls
+         * this method once per
+         * {@link ConflictResolver#transformGraph(DependencyNode, DependencyGraphTransformationContext)} invocation to
+         * allow implementations to prepare any auxiliary data that is needed for their operation. Given that
+         * implementations need to be stateless, a new instance needs to be returned to hold such auxiliary data. The
+         * default implementation simply returns the current instance which is appropriate for implementations which do
+         * not require auxiliary data.
+         * 
+         * @param root The root node of the (possibly cyclic!) graph to transform, must not be {@code null}.
+         * @param context The graph transformation context, must not be {@code null}.
+         * @return The scope selector to use for the given graph transformation, never {@code null}.
+         * @throws RepositoryException If the instance could not be retrieved.
+         */
+        public ScopeSelector getInstance( DependencyNode root, DependencyGraphTransformationContext context )
+            throws RepositoryException
+        {
+            return this;
+        }
+
+        /**
+         * Determines the effective scope of the dependency given by {@link ConflictContext#getWinner()}.
+         * Implementations will usually iterate {@link ConflictContext#getItems()}, inspect
+         * {@link ConflictItem#getScopes()} and eventually call {@link ConflictContext#setScope(String)} to deliver the
+         * effective scope.
+         * 
+         * @param context The conflict context, must not be {@code null}.
+         * @throws RepositoryException If the scope selection failed.
+         */
+        public abstract void selectScope( ConflictContext context )
+            throws RepositoryException;
+
+    }
+
+    /**
+     * An extension point of {@link ConflictResolver} that determines the scope of a dependency in relation to the scope
+     * of its parent. Implementations must be stateless.
+     */
+    public static abstract class ScopeDeriver
+    {
+
+        /**
+         * Retrieves the scope deriver for use during the specified graph transformation. The conflict resolver calls
+         * this method once per
+         * {@link ConflictResolver#transformGraph(DependencyNode, DependencyGraphTransformationContext)} invocation to
+         * allow implementations to prepare any auxiliary data that is needed for their operation. Given that
+         * implementations need to be stateless, a new instance needs to be returned to hold such auxiliary data. The
+         * default implementation simply returns the current instance which is appropriate for implementations which do
+         * not require auxiliary data.
+         * 
+         * @param root The root node of the (possibly cyclic!) graph to transform, must not be {@code null}.
+         * @param context The graph transformation context, must not be {@code null}.
+         * @return The scope deriver to use for the given graph transformation, never {@code null}.
+         * @throws RepositoryException If the instance could not be retrieved.
+         */
+        public ScopeDeriver getInstance( DependencyNode root, DependencyGraphTransformationContext context )
+            throws RepositoryException
+        {
+            return this;
+        }
+
+        /**
+         * Determines the scope of a dependency in relation to the scope of its parent. Implementors need to call
+         * {@link ScopeContext#setDerivedScope(String)} to deliver the result of their calculation. If said method is
+         * not invoked, the conflict resolver will assume the scope of the child dependency remains unchanged.
+         * 
+         * @param context The scope context, must not be {@code null}.
+         * @throws RepositoryException If the scope deriviation failed.
+         */
+        public abstract void deriveScope( ScopeContext context )
+            throws RepositoryException;
+
+    }
+
+    /**
+     * An extension point of {@link ConflictResolver} that determines the effective optional flag of a dependency from a
+     * potentially conflicting set of derived optionalities. The optionality selector gets invoked after the
+     * {@link VersionSelector} has picked the winning node. Implementations must be stateless.
+     */
+    public static abstract class OptionalitySelector
+    {
+
+        /**
+         * Retrieves the optionality selector for use during the specified graph transformation. The conflict resolver
+         * calls this method once per
+         * {@link ConflictResolver#transformGraph(DependencyNode, DependencyGraphTransformationContext)} invocation to
+         * allow implementations to prepare any auxiliary data that is needed for their operation. Given that
+         * implementations need to be stateless, a new instance needs to be returned to hold such auxiliary data. The
+         * default implementation simply returns the current instance which is appropriate for implementations which do
+         * not require auxiliary data.
+         * 
+         * @param root The root node of the (possibly cyclic!) graph to transform, must not be {@code null}.
+         * @param context The graph transformation context, must not be {@code null}.
+         * @return The optionality selector to use for the given graph transformation, never {@code null}.
+         * @throws RepositoryException If the instance could not be retrieved.
+         */
+        public OptionalitySelector getInstance( DependencyNode root, DependencyGraphTransformationContext context )
+            throws RepositoryException
+        {
+            return this;
+        }
+
+        /**
+         * Determines the effective optional flag of the dependency given by {@link ConflictContext#getWinner()}.
+         * Implementations will usually iterate {@link ConflictContext#getItems()}, inspect
+         * {@link ConflictItem#getOptionalities()} and eventually call {@link ConflictContext#setOptional(Boolean)} to
+         * deliver the effective optional flag.
+         * 
+         * @param context The conflict context, must not be {@code null}.
+         * @throws RepositoryException If the optionality selection failed.
+         */
+        public abstract void selectOptionality( ConflictContext context )
+            throws RepositoryException;
+
+    }
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/ContextKeys.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/ContextKeys.java
@@ -1,0 +1,7 @@
+package org.apache.karaf.tooling.semantic.eclipse;
+
+public class ContextKeys {
+	
+	public static final String STATS = "STATS";
+	
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/JavaScopeDeriver.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/JavaScopeDeriver.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2013 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Sonatype, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.apache.karaf.tooling.semantic.eclipse;
+
+import org.apache.karaf.tooling.semantic.eclipse.ConflictResolver.ScopeContext;
+import org.apache.karaf.tooling.semantic.eclipse.ConflictResolver.ScopeDeriver;
+import org.sonatype.aether.RepositoryException;
+import org.sonatype.aether.util.artifact.JavaScopes;
+
+
+/**
+ * A scope deriver for use with {@link ConflictResolver} that supports the scopes from {@link JavaScopes}.
+ */
+public final class JavaScopeDeriver
+    extends ScopeDeriver
+{
+
+    /**
+     * Creates a new instance of this scope deriver.
+     */
+    public JavaScopeDeriver()
+    {
+    }
+
+    @Override
+    public void deriveScope( ScopeContext context )
+        throws RepositoryException
+    {
+        context.setDerivedScope( getDerivedScope( context.getParentScope(), context.getChildScope() ) );
+    }
+
+    private String getDerivedScope( String parentScope, String childScope )
+    {
+        String derivedScope;
+
+        if ( JavaScopes.SYSTEM.equals( childScope ) || JavaScopes.TEST.equals( childScope ) )
+        {
+            derivedScope = childScope;
+        }
+        else if ( parentScope == null || parentScope.length() <= 0 || JavaScopes.COMPILE.equals( parentScope ) )
+        {
+            derivedScope = childScope;
+        }
+        else if ( JavaScopes.TEST.equals( parentScope ) || JavaScopes.RUNTIME.equals( parentScope ) )
+        {
+            derivedScope = parentScope;
+        }
+        else if ( JavaScopes.SYSTEM.equals( parentScope ) || JavaScopes.PROVIDED.equals( parentScope ) )
+        {
+            derivedScope = JavaScopes.PROVIDED;
+        }
+        else
+        {
+            derivedScope = JavaScopes.RUNTIME;
+        }
+
+        return derivedScope;
+    }
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/JavaScopeSelector.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/JavaScopeSelector.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2013 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Sonatype, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.apache.karaf.tooling.semantic.eclipse;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.karaf.tooling.semantic.eclipse.ConflictResolver.ConflictContext;
+import org.apache.karaf.tooling.semantic.eclipse.ConflictResolver.ConflictItem;
+import org.apache.karaf.tooling.semantic.eclipse.ConflictResolver.ScopeSelector;
+import org.sonatype.aether.RepositoryException;
+import org.sonatype.aether.util.artifact.JavaScopes;
+
+
+/**
+ * A scope selector for use with {@link ConflictResolver} that supports the scopes from {@link JavaScopes}. In general,
+ * this selector picks the widest scope present among conflicting dependencies where e.g. "compile" is wider than
+ * "runtime" which is wider than "test". If however a direct dependency is involved, its scope is selected.
+ */
+public final class JavaScopeSelector
+    extends ScopeSelector
+{
+
+    /**
+     * Creates a new instance of this scope selector.
+     */
+    public JavaScopeSelector()
+    {
+    }
+
+    @Override
+    public void selectScope( ConflictContext context )
+        throws RepositoryException
+    {
+        String scope = context.getWinner().getDependency().getScope();
+        if ( !JavaScopes.SYSTEM.equals( scope ) )
+        {
+            scope = chooseEffectiveScope( context.getItems() );
+        }
+        context.setScope( scope );
+    }
+
+    private String chooseEffectiveScope( Collection<ConflictItem> items )
+    {
+        Set<String> scopes = new HashSet<String>();
+        for ( ConflictItem item : items )
+        {
+            if ( item.getDepth() <= 1 )
+            {
+                return item.getDependency().getScope();
+            }
+            scopes.addAll( item.getScopes() );
+        }
+        return chooseEffectiveScope( scopes );
+    }
+
+    private String chooseEffectiveScope( Set<String> scopes )
+    {
+        if ( scopes.size() > 1 )
+        {
+            scopes.remove( JavaScopes.SYSTEM );
+        }
+
+        String effectiveScope = "";
+
+        if ( scopes.size() == 1 )
+        {
+            effectiveScope = scopes.iterator().next();
+        }
+        else if ( scopes.contains( JavaScopes.COMPILE ) )
+        {
+            effectiveScope = JavaScopes.COMPILE;
+        }
+        else if ( scopes.contains( JavaScopes.RUNTIME ) )
+        {
+            effectiveScope = JavaScopes.RUNTIME;
+        }
+        else if ( scopes.contains( JavaScopes.PROVIDED ) )
+        {
+            effectiveScope = JavaScopes.PROVIDED;
+        }
+        else if ( scopes.contains( JavaScopes.TEST ) )
+        {
+            effectiveScope = JavaScopes.TEST;
+        }
+
+        return effectiveScope;
+    }
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/NearestVersionSelector.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/NearestVersionSelector.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2013 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Sonatype, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.apache.karaf.tooling.semantic.eclipse;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.karaf.tooling.semantic.eclipse.ConflictResolver.ConflictContext;
+import org.apache.karaf.tooling.semantic.eclipse.ConflictResolver.ConflictItem;
+import org.apache.karaf.tooling.semantic.eclipse.ConflictResolver.VersionSelector;
+import org.sonatype.aether.RepositoryException;
+import org.sonatype.aether.collection.UnsolvableVersionConflictException;
+import org.sonatype.aether.graph.DependencyFilter;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.util.graph.PathRecordingDependencyVisitor;
+import org.sonatype.aether.version.Version;
+import org.sonatype.aether.version.VersionConstraint;
+
+
+/**
+ * A version selector for use with {@link ConflictResolver} that resolves version conflicts using a nearest-wins
+ * strategy. If there is no single node that satisfies all encountered version ranges, the selector will fail.
+ */
+public final class NearestVersionSelector
+    extends VersionSelector
+{
+
+    /**
+     * Creates a new instance of this version selector.
+     */
+    public NearestVersionSelector()
+    {
+    }
+
+    @Override
+    public void selectVersion( ConflictContext context )
+        throws RepositoryException
+    {
+        ConflictGroup group = new ConflictGroup();
+        for ( ConflictItem item : context.getItems() )
+        {
+            DependencyNode node = item.getNode();
+            VersionConstraint constraint = node.getVersionConstraint();
+
+            boolean backtrack = false;
+            boolean hardConstraint = !constraint.getRanges().isEmpty(); // XXX
+
+            if ( hardConstraint )
+            {
+                if ( group.constraints.add( constraint ) )
+                {
+                    if ( group.winner != null && !constraint.containsVersion( group.winner.getNode().getVersion() ) )
+                    {
+                        backtrack = true;
+                    }
+                }
+            }
+
+            if ( isAcceptable( group, node.getVersion() ) )
+            {
+                group.candidates.add( item );
+
+                if ( backtrack )
+                {
+                    backtrack( group, context );
+                }
+                else if ( group.winner == null || isNearer( item, group.winner ) )
+                {
+                    group.winner = item;
+                }
+            }
+            else if ( backtrack )
+            {
+                backtrack( group, context );
+            }
+        }
+        context.setWinner( group.winner );
+    }
+
+    private void backtrack( ConflictGroup group, ConflictContext context )
+        throws UnsolvableVersionConflictException
+    {
+        group.winner = null;
+
+        for ( Iterator<ConflictItem> it = group.candidates.iterator(); it.hasNext(); )
+        {
+            ConflictItem candidate = it.next();
+
+            if ( !isAcceptable( group, candidate.getNode().getVersion() ) )
+            {
+                it.remove();
+            }
+            else if ( group.winner == null || isNearer( candidate, group.winner ) )
+            {
+                group.winner = candidate;
+            }
+        }
+
+        if ( group.winner == null )
+        {
+            throw newFailure( context );
+        }
+    }
+
+    private boolean isAcceptable( ConflictGroup group, Version version )
+    {
+        for ( VersionConstraint constraint : group.constraints )
+        {
+            if ( !constraint.containsVersion( version ) )
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isNearer( ConflictItem item1, ConflictItem item2 )
+    {
+        if ( item1.isSibling( item2 ) )
+        {
+            return item1.getNode().getVersion().compareTo( item2.getNode().getVersion() ) > 0;
+        }
+        else
+        {
+            return item1.getDepth() < item2.getDepth();
+        }
+    }
+
+    private UnsolvableVersionConflictException newFailure( final ConflictContext context )
+    {
+        DependencyFilter filter = new DependencyFilter()
+        {
+            public boolean accept( DependencyNode node, List<DependencyNode> parents )
+            {
+                return context.isIncluded( node );
+            }
+        };
+        PathRecordingDependencyVisitor visitor = new PathRecordingDependencyVisitor( filter );
+        context.getRoot().accept( visitor );
+        return new UnsolvableVersionConflictException( visitor.getPaths(), "bada-boom" ); // XXX
+    }
+
+    static final class ConflictGroup
+    {
+
+        final Collection<VersionConstraint> constraints;
+
+        final Collection<ConflictItem> candidates;
+
+        ConflictItem winner;
+
+        public ConflictGroup()
+        {
+            constraints = new HashSet<VersionConstraint>();
+            candidates = new ArrayList<ConflictItem>( 64 );
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.valueOf( winner );
+        }
+
+    }
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/SimpleOptionalitySelector.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/SimpleOptionalitySelector.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Sonatype, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.apache.karaf.tooling.semantic.eclipse;
+
+import java.util.Collection;
+
+import org.apache.karaf.tooling.semantic.eclipse.ConflictResolver.ConflictContext;
+import org.apache.karaf.tooling.semantic.eclipse.ConflictResolver.ConflictItem;
+import org.apache.karaf.tooling.semantic.eclipse.ConflictResolver.OptionalitySelector;
+import org.sonatype.aether.RepositoryException;
+
+
+/**
+ * An optionality selector for use with {@link ConflictResolver}. In general, this selector only marks a dependency as
+ * optional if all its occurrences are optional. If however a direct dependency is involved, its optional flag is
+ * selected.
+ */
+public final class SimpleOptionalitySelector
+    extends OptionalitySelector
+{
+
+    /**
+     * Creates a new instance of this scope selector.
+     */
+    public SimpleOptionalitySelector()
+    {
+    }
+
+    @Override
+    public void selectOptionality( ConflictContext context )
+        throws RepositoryException
+    {
+        boolean optional = chooseEffectiveOptionality( context.getItems() );
+        context.setOptional( optional );
+    }
+
+    private boolean chooseEffectiveOptionality( Collection<ConflictItem> items )
+    {
+        boolean optional = true;
+        for ( ConflictItem item : items )
+        {
+            if ( item.getDepth() <= 1 )
+            {
+                return item.getDependency().isOptional();
+            }
+            if ( ( item.getOptionalities() & ConflictItem.OPTIONAL_FALSE ) != 0 )
+            {
+                optional = false;
+            }
+        }
+        return optional;
+    }
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/package-info.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/eclipse/package-info.java
@@ -1,0 +1,5 @@
+package org.apache.karaf.tooling.semantic.eclipse;
+
+/**
+ * Back port from https://github.com/eclipse/aether-core
+ */

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/package-info.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/package-info.java
@@ -1,0 +1,2 @@
+package org.apache.karaf.tooling.semantic;
+

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/SemanticRange.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/SemanticRange.java
@@ -1,0 +1,111 @@
+package org.apache.karaf.tooling.semantic.range;
+
+import org.sonatype.aether.version.Version;
+
+/**
+ * A range of versions.
+ */
+public interface SemanticRange {
+
+	/**
+	 * Determines whether the specified version is contained within this range.
+	 * 
+	 * @param version
+	 *            The version to test, must not be {@code null}.
+	 * @return {@code true} if this range contains the specified version,
+	 *         {@code false} otherwise.
+	 */
+	boolean containsVersion(Version version);
+
+	/**
+	 * Gets a lower bound (if any) for this range. If existent, this range does
+	 * not contain any version smaller than its lower bound. Note that complex
+	 * version ranges might exclude some versions even within their bounds.
+	 * 
+	 * @return A lower bound for this range or {@code null} is there is none.
+	 */
+	Bound getLowerBound();
+
+	/**
+	 * Gets an upper bound (if any) for this range. If existent, this range does
+	 * not contain any version greater than its upper bound. Note that complex
+	 * version ranges might exclude some versions even within their bounds.
+	 * 
+	 * @return An upper bound for this range or {@code null} is there is none.
+	 */
+	Bound getUpperBound();
+
+	/**
+	 * A bound of a version range.
+	 */
+	static final class Bound {
+
+		private final Version version;
+
+		private final boolean inclusive;
+
+		/**
+		 * Creates a new bound with the specified properties.
+		 * 
+		 * @param version
+		 *            The bounding version, must not be {@code null}.
+		 * @param inclusive
+		 *            A flag whether the specified version is included in the
+		 *            range or not.
+		 */
+		public Bound(Version version, boolean inclusive) {
+			if (version == null) {
+				throw new IllegalArgumentException("version missing");
+			}
+			this.version = version;
+			this.inclusive = inclusive;
+		}
+
+		/**
+		 * Gets the bounding version.
+		 * 
+		 * @return The bounding version, never {@code null}.
+		 */
+		public Version getVersion() {
+			return version;
+		}
+
+		/**
+		 * Indicates whether the bounding version is included in the range or
+		 * not.
+		 * 
+		 * @return {@code true} if the bounding version is included in the
+		 *         range, {@code false} if not.
+		 */
+		public boolean isInclusive() {
+			return inclusive;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == this) {
+				return true;
+			} else if (obj == null || !getClass().equals(obj.getClass())) {
+				return false;
+			}
+
+			Bound that = (Bound) obj;
+			return inclusive == that.inclusive && version.equals(that.version);
+		}
+
+		@Override
+		public int hashCode() {
+			int hash = 17;
+			hash = hash * 31 + version.hashCode();
+			hash = hash * 31 + (inclusive ? 1 : 0);
+			return hash;
+		}
+
+		@Override
+		public String toString() {
+			return String.valueOf(version);
+		}
+
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/SemanticRangeBase.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/SemanticRangeBase.java
@@ -1,0 +1,14 @@
+package org.apache.karaf.tooling.semantic.range;
+
+public abstract class SemanticRangeBase implements SemanticRange {
+
+	public boolean equals(Object other) {
+		if (other instanceof SemanticRange) {
+			SemanticRange that = (SemanticRange) other;
+			return this.getLowerBound().equals(that.getLowerBound())
+					&& this.getUpperBound().equals(that.getUpperBound());
+		}
+		return false;
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/SemanticRangeFactory.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/SemanticRangeFactory.java
@@ -1,0 +1,43 @@
+package org.apache.karaf.tooling.semantic.range;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.version.Version;
+import org.sonatype.aether.version.VersionConstraint;
+import org.sonatype.aether.version.VersionRange;
+
+public class SemanticRangeFactory {
+
+	public static SemanticRange from(DependencyNode node) {
+
+		VersionConstraint constraint = node.getVersionConstraint();
+
+		VersionType versionType = VersionType.form(constraint);
+
+		switch (versionType) {
+
+		case VALUE:
+			Version version = constraint.getVersion();
+			return new SemanticRangePoint(version);
+
+		case RANGE:
+			Collection<VersionRange> rangeList = constraint.getRanges();
+			Iterator<VersionRange> iterator = rangeList.iterator();
+			VersionRange range = iterator.next();
+			if (iterator.hasNext()) {
+				throw new IllegalStateException("Unexpected multiple ranges = "
+						+ rangeList);
+			}
+			return new SemanticRangeSpan(range);
+
+		default:
+			throw new IllegalStateException("Wrong version type = "
+					+ versionType);
+
+		}
+
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/SemanticRangeList.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/SemanticRangeList.java
@@ -1,0 +1,8 @@
+package org.apache.karaf.tooling.semantic.range;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@SuppressWarnings("serial")
+public class SemanticRangeList extends CopyOnWriteArrayList<SemanticRange>{
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/SemanticRangePoint.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/SemanticRangePoint.java
@@ -1,0 +1,33 @@
+package org.apache.karaf.tooling.semantic.range;
+
+import org.sonatype.aether.version.Version;
+import org.sonatype.aether.version.VersionRange;
+
+public class SemanticRangePoint extends SemanticRangeBase {
+
+	private final Version version;
+
+	public SemanticRangePoint(Version version) {
+		this.version = version;
+	}
+
+	@Override
+	public boolean containsVersion(Version version) {
+		return this.version.equals(version);
+	}
+
+	@Override
+	public Bound getLowerBound() {
+		return new Bound(version, true);
+	}
+
+	@Override
+	public Bound getUpperBound() {
+		return new Bound(version, true);
+	}
+
+	public String toString() {
+		return "[" + version + "," + version + "]";
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/SemanticRangeSpan.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/SemanticRangeSpan.java
@@ -1,0 +1,38 @@
+package org.apache.karaf.tooling.semantic.range;
+
+import org.apache.karaf.tooling.semantic.ReflectUtil;
+import org.sonatype.aether.version.Version;
+import org.sonatype.aether.version.VersionRange;
+
+public class SemanticRangeSpan extends SemanticRangeBase {
+
+	private final VersionRange range;
+
+	public SemanticRangeSpan(VersionRange range) {
+		this.range = range;
+	}
+
+	@Override
+	public boolean containsVersion(Version version) {
+		return range.containsVersion(version);
+	}
+
+	@Override
+	public Bound getLowerBound() {
+		Version version = ReflectUtil.readField(range, "lowerBound");
+		boolean inclusive = ReflectUtil.readField(range, "lowerBoundInclusive");
+		return new Bound(version, inclusive);
+	}
+
+	@Override
+	public Bound getUpperBound() {
+		Version version = ReflectUtil.readField(range, "upperBound");
+		boolean inclusive = ReflectUtil.readField(range, "upperBoundInclusive");
+		return new Bound(version, inclusive);
+	}
+
+	public String toString() {
+		return range.toString();
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/VersionType.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/VersionType.java
@@ -1,0 +1,33 @@
+package org.apache.karaf.tooling.semantic.range;
+
+import org.sonatype.aether.version.VersionConstraint;
+
+public enum VersionType {
+
+	/***/
+	RANGE, //
+
+	/***/
+	VALUE, //
+
+	/***/
+	WRONG, //
+
+	;
+
+	public static VersionType form(final VersionConstraint constraint) {
+		if (constraint == null) {
+			return WRONG;
+		}
+		boolean hasRange = !constraint.getRanges().isEmpty();
+		boolean hasValue = constraint.getVersion() != null;
+		if (hasRange && !hasValue) {
+			return RANGE;
+		}
+		if (!hasRange && hasValue) {
+			return VALUE;
+		}
+		return WRONG;
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/package-info.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/range/package-info.java
@@ -1,0 +1,2 @@
+package org.apache.karaf.tooling.semantic.range;
+

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/xform/BaseTransformer.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/xform/BaseTransformer.java
@@ -1,0 +1,63 @@
+package org.apache.karaf.tooling.semantic.xform;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.karaf.tooling.semantic.range.SemanticRange;
+import org.apache.karaf.tooling.semantic.range.SemanticRangeFactory;
+import org.apache.karaf.tooling.semantic.range.SemanticRangeList;
+import org.apache.karaf.tooling.semantic.range.VersionType;
+import org.sonatype.aether.RepositoryException;
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.collection.DependencyGraphTransformationContext;
+import org.sonatype.aether.collection.DependencyGraphTransformer;
+import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.util.graph.transformer.TransformationContextKeys;
+import org.sonatype.aether.version.Version;
+import org.sonatype.aether.version.VersionConstraint;
+
+/**
+ * "Object" of "Conflict ID" is an artifact key, that is, artifact w/o version.
+ * <p>
+ * equality == group:artifact:classifier:extensions
+ * <p>
+ * identity == unique instance
+ * <p>
+ * Conflict list and map must be produced by previous transformers.
+ * 
+ * @author Andrei Pozolotin
+ */
+public abstract class BaseTransformer implements DependencyGraphTransformer {
+
+	/**
+	 * Topologically sorted artifact keys.
+	 */
+	@SuppressWarnings("unchecked")
+	public List<Object> conflictList(
+			DependencyGraphTransformationContext context) {
+		final List<Object> conflictList = (List<Object>) context
+				.get(TransformationContextKeys.SORTED_CONFLICT_IDS);
+		return conflictList;
+	}
+
+	/**
+	 * Mapping from versioned artifact into artifact keys.
+	 */
+	@SuppressWarnings("unchecked")
+	public Map<DependencyNode, Object> conflictMap(
+			DependencyGraphTransformationContext context) {
+		final Map<DependencyNode, Object> conflictMap = (Map<DependencyNode, Object>) context
+				.get(TransformationContextKeys.CONFLICT_IDS);
+		return conflictMap;
+	}
+
+	protected void log(String text) {
+		System.err.println(text);
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/xform/ExperimentalTransformer.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/xform/ExperimentalTransformer.java
@@ -1,0 +1,218 @@
+package org.apache.karaf.tooling.semantic.xform;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.karaf.tooling.semantic.range.SemanticRange;
+import org.apache.karaf.tooling.semantic.range.SemanticRangeFactory;
+import org.apache.karaf.tooling.semantic.range.SemanticRangeList;
+import org.apache.karaf.tooling.semantic.range.VersionType;
+import org.sonatype.aether.RepositoryException;
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.collection.DependencyGraphTransformationContext;
+import org.sonatype.aether.collection.DependencyGraphTransformer;
+import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.util.graph.transformer.TransformationContextKeys;
+import org.sonatype.aether.version.Version;
+import org.sonatype.aether.version.VersionConstraint;
+
+/**
+ * @author Andrei Pozolotin
+ */
+public class ExperimentalTransformer extends BaseTransformer {
+
+	/** FIXME */
+	public static boolean isSnapshot(Version version) {
+		return version.toString().endsWith("-SNAPSHOT");
+	}
+
+	// private Map<DependencyNode, SemanticRange> rangeMap = new
+	// HashMap<DependencyNode, SemanticRange>();
+
+	/**
+	 * "Object" is a "conflict" or a wrapper for maven artifact.
+	 * <p>
+	 * equality == group:artifact:classifier:extensions
+	 * <p>
+	 * identity == unique instance
+	 * <p>
+	 * Conflict list and map are produced by previous transformers.
+	 */
+
+	/**
+	 * [conflict-key : range-list ]
+	 */
+	private Map<Object, SemanticRangeList> rangeMap = new HashMap<Object, SemanticRangeList>();
+
+	public SemanticRangeList list(Object key) {
+		SemanticRangeList list = rangeMap.get(key);
+		if (list == null) {
+			list = new SemanticRangeList();
+			rangeMap.put(key, list);
+		}
+		return list;
+	}
+
+	/**
+	 * Remove snapshots.
+	 */
+	public void listClean(DependencyNode root,
+			DependencyGraphTransformationContext context) {
+
+		Iterator<DependencyNode> iterator = root.getChildren().iterator();
+
+		while (iterator.hasNext()) {
+
+			DependencyNode node = iterator.next();
+
+			VersionType versionType = VersionType.form(node
+					.getVersionConstraint());
+
+			boolean isSnapshot = node.getDependency().getArtifact()
+					.isSnapshot();
+
+			switch (versionType) {
+			case RANGE:
+				break;
+			case VALUE:
+				break;
+			default:
+				throw new IllegalStateException("Wrong version type = "
+						+ versionType);
+			}
+
+			if (isSnapshot) {
+				iterator.remove();
+			}
+
+			listClean(node, context);
+		}
+
+	}
+
+	public void listCreate(DependencyNode root,
+			DependencyGraphTransformationContext context) {
+
+		Map<DependencyNode, Object> conflictMap = conflictMap(context);
+
+		for (DependencyNode node : root.getChildren()) {
+
+			Object key = conflictMap.get(node);
+
+			SemanticRange range = SemanticRangeFactory.from(node);
+
+			SemanticRangeList list = list(key);
+
+			list.addIfAbsent(range);
+
+			listCreate(node, context);
+
+		}
+
+	}
+
+	/**
+	 * Sort by lower bound.
+	 */
+	public void listSort(DependencyNode root,
+			DependencyGraphTransformationContext context) {
+
+		Map<DependencyNode, Object> conflictMap = conflictMap(context);
+
+		for (DependencyNode node : root.getChildren()) {
+
+			Object key = conflictMap.get(node);
+
+			SemanticRangeList list = list(key);
+
+		}
+
+	}
+
+	public DependencyNode transformGraph(DependencyNode root,
+			DependencyGraphTransformationContext context)
+			throws RepositoryException {
+
+		listClean(root, context);
+
+		listCreate(root, context);
+
+		listSort(root, context);
+
+		// for (Map.Entry<DependencyNode, Object> entry :
+		// conflictMap.entrySet()) {
+		// listCreate(entry.getKey(), context);
+		// }
+
+		log("rangeMap=" + rangeMap);
+
+		return root;
+
+	}
+
+	public DependencyNode transformGraphXXX(DependencyNode node,
+			DependencyGraphTransformationContext context)
+			throws RepositoryException {
+
+		log("node=" + node);
+
+		final List<Object> conflictList = conflictList(context);
+
+		for (Object key : conflictList) {
+			log("\t 1 key=" + key);
+		}
+
+		@SuppressWarnings("unchecked")
+		final Map<DependencyNode, Object> conflictMap = (Map<DependencyNode, Object>) context
+				.get(TransformationContextKeys.CONFLICT_IDS);
+
+		final Object key = conflictMap.get(node);
+		log("\t 2 key=" + key);
+		final Dependency dependency = node.getDependency();
+
+		for (Map.Entry<DependencyNode, Object> entry : conflictMap.entrySet()) {
+			log("\t 3 node=" + entry.getKey() + " key=" + entry.getValue());
+		}
+
+		final VersionConstraint constraint = node.getVersionConstraint();
+		log("\t 4 constraint=" + constraint);
+
+		final Artifact artifact = dependency.getArtifact();
+		log("\t 5 artifact=" + artifact);
+
+		Iterator<DependencyNode> iterator = node.getChildren().iterator();
+		while (iterator.hasNext()) {
+
+			DependencyNode item = iterator.next();
+			log("\t 6 item=" + item);
+
+			VersionConstraint itemConstraint = item.getVersionConstraint();
+			log("\t 7 constraint=" + itemConstraint);
+
+			Version itemVersion = item.getVersion();
+			log("\t 8 version=" + itemVersion);
+
+			switch (VersionType.form(itemConstraint)) {
+			case RANGE:
+				log("\t 9 ranges=" + itemConstraint.getRanges());
+				break;
+			case VALUE:
+				log("\t 10 version=" + itemVersion);
+				break;
+			}
+
+			if (item.getDependency().getArtifact().isSnapshot()) {
+				iterator.remove();
+			}
+		}
+
+		return node;
+
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/xform/NearestTransformer.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/xform/NearestTransformer.java
@@ -1,0 +1,267 @@
+package org.apache.karaf.tooling.semantic.xform;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.sonatype.aether.RepositoryException;
+import org.sonatype.aether.collection.DependencyGraphTransformationContext;
+import org.sonatype.aether.collection.DependencyGraphTransformer;
+import org.sonatype.aether.collection.UnsolvableVersionConflictException;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.util.graph.transformer.ConflictIdSorter;
+import org.sonatype.aether.util.graph.transformer.TransformationContextKeys;
+import org.sonatype.aether.version.Version;
+import org.sonatype.aether.version.VersionConstraint;
+
+/**
+ * A dependency graph transformer that resolves version conflicts using the
+ * nearest-wins strategy. For a given set of conflicting nodes, one node will be
+ * chosen as the winner and the other nodes are removed from the dependency
+ * graph.
+ * 
+ * @author Benjamin Bentmann
+ */
+public class NearestTransformer extends BaseTransformer {
+
+	static final class ConflictGroup {
+
+		final Map<DependencyNode, Position> candidates = new IdentityHashMap<DependencyNode, Position>(
+				32);
+
+		final Collection<VersionConstraint> constraints = new HashSet<VersionConstraint>();
+
+		final Object key;
+
+		Position position;
+
+		final Collection<Position> positions = new LinkedHashSet<Position>();
+
+		boolean pruned;
+
+		Version version;
+
+		public ConflictGroup(Object key) {
+			this.key = key;
+			this.position = new Position(null, Integer.MAX_VALUE);
+		}
+
+		@Override
+		public String toString() {
+			return key + " > " + version;
+		}
+
+	}
+
+	static final class Position {
+
+		final int depth;
+
+		final int hash;
+
+		final DependencyNode parent;
+
+		public Position(DependencyNode parent, int depth) {
+			this.parent = parent;
+			this.depth = depth;
+			hash = 31 * System.identityHashCode(parent) + depth;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			} else if (!(obj instanceof Position)) {
+				return false;
+			}
+			Position that = (Position) obj;
+			return this.parent == that.parent && this.depth == that.depth;
+		}
+
+		@Override
+		public int hashCode() {
+			return hash;
+		}
+
+		@Override
+		public String toString() {
+			return depth + " > " + parent;
+		}
+
+	}
+
+	private void backtrack(ConflictGroup group)
+			throws UnsolvableVersionConflictException {
+		group.version = null;
+
+		for (Iterator<Map.Entry<DependencyNode, Position>> it = group.candidates
+				.entrySet().iterator(); it.hasNext();) {
+			Map.Entry<DependencyNode, Position> entry = it.next();
+
+			Version version = entry.getKey().getVersion();
+			Position pos = entry.getValue();
+
+			if (!isAcceptable(group, version)) {
+				it.remove();
+			} else if (group.version == null
+					|| isNearer(pos, version, group.position, group.version)) {
+				group.version = version;
+				group.position = pos;
+			}
+		}
+
+		if (group.version == null) {
+			throw newFailure(group);
+		}
+
+	}
+
+	private boolean isAcceptable(ConflictGroup group, Version version) {
+		for (VersionConstraint constraint : group.constraints) {
+			if (!constraint.containsVersion(version)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean isNearer(Position pos1, Version ver1, Position pos2,
+			Version ver2) {
+		if (pos1.depth < pos2.depth) {
+			return true;
+		} else if (pos1.depth == pos2.depth && pos1.parent == pos2.parent
+				&& ver1.compareTo(ver2) > 0) {
+			return true;
+		}
+		return false;
+	}
+
+	private UnsolvableVersionConflictException newFailure(ConflictGroup group) {
+
+		Collection<String> versions = new LinkedHashSet<String>();
+
+		for (VersionConstraint constraint : group.constraints) {
+			versions.add(constraint.toString());
+		}
+
+		return new UnsolvableVersionConflictException(group.key, versions);
+
+	}
+
+	private void pruneNonSelectedVersions(ConflictGroup group,
+			Map<DependencyNode, Object> conflictMap) {
+
+		for (Position pos : group.positions) {
+			for (Iterator<DependencyNode> iterator = pos.parent.getChildren()
+					.iterator(); iterator.hasNext();) {
+
+				DependencyNode node = iterator.next();
+
+				Object key = conflictMap.get(node);
+
+				if (group.key.equals(key)) {
+					if (!group.pruned && group.position.depth == pos.depth
+							&& group.version.equals(node.getVersion())) {
+						group.pruned = true;
+					} else {
+						iterator.remove();
+					}
+				}
+			}
+		}
+	}
+
+	private void selectVersion(//
+			DependencyNode node, //
+			DependencyNode root, //
+			int depth, //
+			Map<DependencyNode, Integer> depthMap, //
+			ConflictGroup group, //
+			Map<DependencyNode, Object> conflictMap //
+	) throws RepositoryException {
+
+		Integer smallestDepth = depthMap.get(node);
+
+		if (smallestDepth == null || smallestDepth.intValue() > depth) {
+			depthMap.put(node, Integer.valueOf(depth));
+		} else {
+			return;
+		}
+
+		Object key = conflictMap.get(node);
+
+		if (group.key.equals(key)) {
+
+			Position pos = new Position(root, depth);
+
+			if (root != null) {
+				group.positions.add(pos);
+			}
+
+			VersionConstraint constraint = node.getVersionConstraint();
+
+			boolean backtrack = false;
+			boolean hardConstraint = !constraint.getRanges().isEmpty();
+
+			if (hardConstraint) {
+				if (group.constraints.add(constraint)) {
+					if (group.version != null
+							&& !constraint.containsVersion(group.version)) {
+						backtrack = true;
+					}
+				}
+			}
+
+			if (isAcceptable(group, node.getVersion())) {
+				group.candidates.put(node, pos);
+
+				if (backtrack) {
+					backtrack(group);
+				} else if (group.version == null
+						|| isNearer(pos, node.getVersion(), group.position,
+								group.version)) {
+					group.version = node.getVersion();
+					group.position = pos;
+				}
+			} else {
+				if (backtrack) {
+					backtrack(group);
+				}
+				return;
+			}
+		}
+
+		depth++;
+
+		for (DependencyNode child : node.getChildren()) {
+			selectVersion(child, node, depth, depthMap, group, conflictMap);
+		}
+	}
+
+	public DependencyNode transformGraph(//
+			DependencyNode node, //
+			DependencyGraphTransformationContext context //
+	) throws RepositoryException {
+
+		List<Object> conflictList = conflictList(context);
+
+		Map<DependencyNode, Object> conflictMap = conflictMap(context);
+
+		Map<DependencyNode, Integer> depthMap = new IdentityHashMap<DependencyNode, Integer>(
+				conflictMap.size());
+
+		for (Object key : conflictList) {
+			ConflictGroup group = new ConflictGroup(key);
+			depthMap.clear();
+			selectVersion(node, null, 0, depthMap, group, conflictMap);
+			pruneNonSelectedVersions(group, conflictMap);
+		}
+
+		return node;
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/xform/SnapshotTransformer.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/xform/SnapshotTransformer.java
@@ -1,0 +1,61 @@
+package org.apache.karaf.tooling.semantic.xform;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.karaf.tooling.semantic.range.VersionType;
+import org.sonatype.aether.RepositoryException;
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.collection.DependencyGraphTransformationContext;
+import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyNode;
+
+public class SnapshotTransformer extends BaseTransformer {
+
+	public static final String ENABLE_RANGE_SNAPSHOT = "enableRangeSnapshot";
+
+	private boolean enableRangeSnapshot;
+
+	public SnapshotTransformer(Map<String, String> resolverSettings) {
+
+		this.enableRangeSnapshot = Boolean
+				.parseBoolean((String) resolverSettings
+						.get("enableRangeSnapshot"));
+
+	}
+
+	public DependencyNode transformGraph(DependencyNode node,
+			DependencyGraphTransformationContext context)
+			throws RepositoryException {
+
+		if (!this.enableRangeSnapshot) {
+			removeRangeSnapshot(node, context);
+		}
+
+		return node;
+	}
+
+	protected void removeRangeSnapshot(DependencyNode root,
+			DependencyGraphTransformationContext context) {
+
+		Iterator<DependencyNode> iterator = root.getChildren().iterator();
+
+		while (iterator.hasNext()) {
+			DependencyNode node = (DependencyNode) iterator.next();
+
+			VersionType versionType = VersionType.form(node
+					.getVersionConstraint());
+
+			switch (versionType) {
+			case RANGE:
+				if (node.getDependency().getArtifact().isSnapshot()) {
+					iterator.remove();
+				}
+				break;
+			}
+
+			removeRangeSnapshot(node, context);
+		}
+	}
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/xform/package-info.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/semantic/xform/package-info.java
@@ -1,0 +1,2 @@
+package org.apache.karaf.tooling.semantic.xform;
+

--- a/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/semantic/DependencyHelperTest.java
+++ b/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/semantic/DependencyHelperTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.karaf.tooling.semantic;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLStreamException;
+
+import org.apache.karaf.features.FeaturesNamespaces;
+import org.apache.karaf.features.internal.model.Features;
+import org.apache.karaf.features.internal.model.Feature;
+import org.apache.karaf.features.internal.model.JaxbUtil;
+import org.apache.karaf.tooling.features.DependencyHelper;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.internal.MavenRepositorySystemSession;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.sonatype.aether.RepositorySystem;
+import org.sonatype.aether.RepositorySystemSession;
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.collection.CollectRequest;
+import org.sonatype.aether.collection.CollectResult;
+import org.sonatype.aether.collection.DependencyGraphTransformer;
+import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.graph.Exclusion;
+import org.sonatype.aether.repository.RemoteRepository;
+import org.sonatype.aether.resolution.DependencyRequest;
+import org.sonatype.aether.resolution.DependencyResult;
+import org.sonatype.aether.util.DefaultRepositorySystemSession;
+import org.sonatype.aether.util.artifact.DefaultArtifact;
+import org.sonatype.aether.util.graph.PreorderNodeListGenerator;
+import org.sonatype.aether.util.graph.selector.AndDependencySelector;
+import org.sonatype.aether.util.graph.selector.ExclusionDependencySelector;
+import org.sonatype.aether.util.graph.selector.OptionalDependencySelector;
+import org.sonatype.aether.util.graph.selector.ScopeDependencySelector;
+import org.sonatype.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
+import org.sonatype.aether.util.graph.transformer.ConflictMarker;
+import org.sonatype.aether.util.graph.transformer.JavaDependencyContextRefiner;
+import org.sonatype.aether.util.graph.transformer.JavaEffectiveScopeCalculator;
+
+public class DependencyHelperTest {
+
+	DependencyHelper newHelper() throws Exception {
+
+		final List<RemoteRepository> remoteList = new ArrayList<RemoteRepository>();
+		remoteList.add(UnitHelp.newRepoRemote());
+
+		final List<RemoteRepository> projectRepos = remoteList;
+		final RepositorySystem system = UnitHelp.newSystem();
+		final RepositorySystemSession session = UnitHelp.newSession(system);
+
+		final DependencyHelper helper = new DependencyHelper(projectRepos, session, system);
+
+		return helper;
+
+	}
+
+	@Test
+	public void dependency() throws Exception {
+
+		final String uri = "com.carrotgarden.osgi:carrot-osgi-anno-scr-make:pom:1.1.3";
+
+		final DependencyHelper helper = newHelper();
+
+		final MavenProject project = UnitHelp.newProject(uri);
+
+		Collection<String> included = null;
+		Collection<String> excluded = null;
+
+		helper.getDependencies(project, true);
+
+		final String report = helper.getTreeListing();
+
+		System.out.println("\n" + report);
+
+	}
+
+	public static void main(String[] args) throws Exception {
+
+		final String uri = "com.carrotgarden.osgi:carrot-osgi-anno-scr-make:jar:1.1.3";
+
+		final Artifact artifact = new DefaultArtifact(uri);
+
+		Dependency dependency = new Dependency(artifact, "compile");
+
+		CollectRequest collectRequest = new CollectRequest(dependency, null);
+
+		RepositorySystem system = UnitHelp.newSystem();
+
+		MavenRepositorySystemSession session = UnitHelp.newSession(system);
+
+		session.setOffline(true);
+
+		Collection<String> scopeIncluded = new ArrayList<String>();
+		Collection<String> scopeExcluded = new ArrayList<String>();
+
+		scopeIncluded.add("provided");
+
+		scopeExcluded.add("test");
+
+		session.setDependencySelector( //
+		new AndDependencySelector(//
+				new OptionalDependencySelector(), //
+				new ScopeDependencySelector(scopeIncluded, scopeExcluded), //
+				new ExclusionDependencySelector()) //
+		);
+
+		CollectResult collectResult = system.collectDependencies(session,
+				collectRequest);
+
+		DependencyNode collectNode = collectResult.getRoot();
+
+		final DependencyRequest dependencyRequest = new DependencyRequest(
+				collectNode, null);
+
+		final DependencyResult result = system.resolveDependencies(session,
+				dependencyRequest);
+
+		final DependencyNode resolveNode = result.getRoot();
+
+		final PreorderNodeListGenerator generator = new PreorderNodeListGenerator();
+
+		resolveNode.accept(generator);
+
+		List<Artifact> list = generator.getArtifacts(true);
+
+		for (Artifact item : list) {
+			System.out.println("item = " + item );
+		}
+
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/semantic/GenerateSemanticMojoTest.java
+++ b/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/semantic/GenerateSemanticMojoTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.karaf.tooling.semantic;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.karaf.tooling.semantic.GenerateSemanticMojo;
+import org.apache.karaf.tooling.semantic.MojoContext;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.logging.Logger;
+import org.junit.Test;
+import org.sonatype.aether.RepositorySystem;
+import org.sonatype.aether.RepositorySystemSession;
+import org.sonatype.aether.artifact.Artifact;
+
+public class GenerateSemanticMojoTest {
+
+	@Test
+	public void dependency1() throws Exception {
+
+		Logger logger = UnitHelp.logger();
+
+		logger.info("===");
+
+		String uri = "com.carrotgarden.osgi:carrot-osgi-anno-scr-make:pom:1.1.3";
+
+		MavenProject project = UnitHelp.newProject(uri);
+
+		Set<String> scopeIncluded;
+		{
+			scopeIncluded = new HashSet<String>();
+			scopeIncluded.add("compile");
+			scopeIncluded.add("runtime");
+		}
+
+		Set<String> scopeExcluded;
+		{
+			scopeExcluded = new HashSet<String>();
+			scopeExcluded.add("provided");
+			scopeExcluded.add("system");
+			scopeExcluded.add("test");
+		}
+
+		RepositorySystem system = UnitHelp.newSystem();
+		RepositorySystemSession session = UnitHelp.newSession(system);
+
+		Map<String, String> resolverSettings = new HashMap<String, String>();
+
+		Set<String> packagingIncluded = new HashSet<String>();
+		{
+			packagingIncluded.add("bundle");
+		}
+
+		MojoContext context = new MojoContext(logger, project, scopeIncluded,
+				scopeExcluded, system, session, UnitHelp.newRepoRemoteList(),
+				resolverSettings, packagingIncluded);
+
+		Map<Artifact, String> dependencyMap = GenerateSemanticMojo
+				.prepare(context);
+
+		for (Map.Entry<Artifact, String> entry : dependencyMap.entrySet()) {
+			Artifact artifact = entry.getKey();
+			String scope = entry.getValue();
+			logger.info(artifact + " @ " + scope);
+		}
+
+		assertEquals(1, dependencyMap.size());
+
+	}
+
+	@Test
+	public void dependency2() throws Exception {
+
+		Logger logger = UnitHelp.logger();
+
+		logger.info("===");
+
+		String uri = "com.carrotgarden.osgi:carrot-osgi-anno-scr-make:pom:1.1.3";
+
+		MavenProject project = UnitHelp.newProject(uri);
+
+		Set<String> scopeIncluded;
+		{
+			scopeIncluded = new HashSet<String>();
+			scopeIncluded.add("provided");
+			scopeIncluded.add("runtime");
+		}
+
+		Set<String> scopeExcluded;
+		{
+			scopeExcluded = new HashSet<String>();
+			scopeExcluded.add("compile");
+			scopeExcluded.add("system");
+			scopeExcluded.add("test");
+		}
+
+		RepositorySystem system = UnitHelp.newSystem();
+		RepositorySystemSession session = UnitHelp.newSession(system);
+
+		Map<String, String> resolverSettings = new HashMap<String, String>();
+
+		Set<String> packagingIncluded = new HashSet<String>();
+		{
+			packagingIncluded.add("bundle");
+		}
+
+		MojoContext context = new MojoContext(logger, project, scopeIncluded,
+				scopeExcluded, system, session, UnitHelp.newRepoRemoteList(),
+				resolverSettings, packagingIncluded);
+
+		Map<Artifact, String> dependencyMap = GenerateSemanticMojo
+				.prepare(context);
+
+		for (Map.Entry<Artifact, String> entry : dependencyMap.entrySet()) {
+			Artifact artifact = entry.getKey();
+			String scope = entry.getValue();
+			logger.info(artifact + " @ " + scope);
+		}
+
+		assertEquals(5, dependencyMap.size());
+
+	}
+
+	@Test
+	public void dependency3() throws Exception {
+
+		Logger logger = UnitHelp.logger();
+
+		logger.info("===");
+
+		String uri = "com.barchart.version.tester:tester-one-zoo:pom:1.0.7";
+
+		MavenProject project = UnitHelp.newProject(uri);
+
+		Set<String> scopeIncluded;
+		{
+			scopeIncluded = new HashSet<String>();
+			scopeIncluded.add("compile");
+		}
+
+		Set<String> scopeExcluded;
+		{
+			scopeExcluded = new HashSet<String>();
+			scopeExcluded.add("runtime");
+			scopeExcluded.add("provided");
+			scopeExcluded.add("system");
+			scopeExcluded.add("test");
+		}
+
+		RepositorySystem system = UnitHelp.newSystem();
+		RepositorySystemSession session = UnitHelp.newSession(system);
+
+		Map<String, String> resolverSettings = new HashMap<String, String>();
+
+		Set<String> packagingIncluded = new HashSet<String>();
+		{
+			packagingIncluded.add("bundle");
+		}
+
+		MojoContext context = new MojoContext(logger, project, scopeIncluded,
+				scopeExcluded, system, session, UnitHelp.newRepoRemoteList(),
+				resolverSettings, packagingIncluded);
+
+		Map<Artifact, String> dependencyMap = GenerateSemanticMojo
+				.prepare(context);
+
+		for (Map.Entry<Artifact, String> entry : dependencyMap.entrySet()) {
+			Artifact artifact = entry.getKey();
+			String scope = entry.getValue();
+			logger.info(artifact + " @ " + scope);
+		}
+
+		assertEquals(3, dependencyMap.size());
+
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/semantic/KarafDependencySelector.java
+++ b/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/semantic/KarafDependencySelector.java
@@ -1,0 +1,44 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.tooling.semantic;
+
+import java.util.Collection;
+
+import org.sonatype.aether.collection.DependencyCollectionContext;
+import org.sonatype.aether.collection.DependencySelector;
+import org.sonatype.aether.graph.Dependency;
+
+public class KarafDependencySelector implements DependencySelector {
+
+	public KarafDependencySelector(Collection<String> included,
+			Collection<String> excluded) {
+	}
+
+	public boolean selectDependency(Dependency dependency) {
+		System.out.println("dependency : "+ dependency);
+		return true;
+	}
+
+	@Override
+	public DependencySelector deriveChildSelector(
+			DependencyCollectionContext context) {
+		System.out.println("context    : "+ context);
+		return this;
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/semantic/SimpleWagonProvider.java
+++ b/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/semantic/SimpleWagonProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.karaf.tooling.semantic;
+
+import org.apache.maven.wagon.Wagon;
+import org.apache.maven.wagon.providers.http.LightweightHttpWagon;
+import org.apache.maven.wagon.providers.http.LightweightHttpsWagon;
+import org.sonatype.aether.connector.wagon.WagonProvider;
+
+public class SimpleWagonProvider implements WagonProvider {
+
+	public Wagon lookup(String roleHint) throws Exception {
+
+		if (roleHint.startsWith("file")) {
+			return null;
+		}
+
+		if (roleHint.startsWith("http")) {
+			return new LightweightHttpWagon();
+		}
+
+		if (roleHint.startsWith("https")) {
+			return new LightweightHttpsWagon();
+		}
+
+		return null;
+
+	}
+
+	public void release(Wagon wagon) {
+	}
+
+}

--- a/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/semantic/UnitHelp.java
+++ b/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/semantic/UnitHelp.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.karaf.tooling.semantic;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.ops4j.pax.url.mvn.internal.ManualWagonProvider;
+import org.sonatype.aether.RepositorySystem;
+import org.sonatype.aether.RepositorySystemSession;
+
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.collection.CollectRequest;
+import org.sonatype.aether.connector.wagon.WagonProvider;
+import org.sonatype.aether.connector.wagon.WagonRepositoryConnectorFactory;
+import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyFilter;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.impl.ArtifactDescriptorReader;
+import org.sonatype.aether.impl.VersionRangeResolver;
+import org.sonatype.aether.impl.VersionResolver;
+import org.sonatype.aether.impl.internal.DefaultRepositorySystem;
+import org.sonatype.aether.impl.internal.DefaultServiceLocator;
+import org.sonatype.aether.repository.LocalRepository;
+import org.sonatype.aether.repository.RemoteRepository;
+import org.sonatype.aether.resolution.ArtifactRequest;
+import org.sonatype.aether.resolution.ArtifactResolutionException;
+import org.sonatype.aether.resolution.ArtifactResult;
+import org.sonatype.aether.resolution.DependencyRequest;
+import org.sonatype.aether.resolution.DependencyResult;
+import org.sonatype.aether.spi.connector.RepositoryConnectorFactory;
+import org.sonatype.aether.util.artifact.DefaultArtifact;
+import org.sonatype.aether.util.filter.ScopeDependencyFilter;
+import org.sonatype.aether.util.graph.PreorderNodeListGenerator;
+import org.apache.maven.RepositoryUtils;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.DefaultModelReader;
+import org.apache.maven.model.io.ModelReader;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.internal.DefaultArtifactDescriptorReader;
+import org.apache.maven.repository.internal.DefaultVersionRangeResolver;
+import org.apache.maven.repository.internal.DefaultVersionResolver;
+import org.apache.maven.repository.internal.MavenRepositorySystemSession;
+import org.apache.maven.wagon.Wagon;
+import org.apache.maven.wagon.providers.http.LightweightHttpWagon;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+
+public class UnitHelp {
+
+	private static volatile Logger logger;
+
+	public static final String URL_CENTRAL = "http://repo1.maven.org/maven2/";
+
+	public static final String URL_SONATYPE = "http://oss.sonatype.org/content/groups/public/";
+
+	public static Logger logger() {
+		if (logger == null) {
+			logger = new ConsoleLogger();
+		}
+		return logger;
+	}
+
+	/**
+	 * Verify operation manually.
+	 */
+	public static void main(String[] args) throws Exception {
+
+		final Logger log = logger();
+
+		final RepositorySystem system = newSystem();
+
+		final RepositorySystemSession session = newSession(system);
+
+		// String uri = "jmock:jmock:pom:1.1.0";
+		String uri = "org.apache.maven:maven-profile:2.2.1";
+
+		final Artifact artifact = new DefaultArtifact(uri);
+
+		final Dependency dependency = new Dependency(artifact, "compile");
+
+		final RemoteRepository central = newRepoRemote();
+
+		final CollectRequest collectRequest = new CollectRequest();
+		collectRequest.setRoot(dependency);
+		collectRequest.addRepository(central);
+
+		final DependencyNode collectNode = system.collectDependencies(session,
+				collectRequest).getRoot();
+
+		final List<String> include = new ArrayList<String>();
+		final List<String> exclude = new ArrayList<String>();
+
+		final DependencyFilter filter = new ScopeDependencyFilter(include,
+				exclude);
+
+		final DependencyRequest dependencyRequest = new DependencyRequest(
+				collectNode, filter);
+
+		final DependencyResult result = system.resolveDependencies(session,
+				dependencyRequest);
+
+		final DependencyNode resolveNode = result.getRoot();
+
+		final PreorderNodeListGenerator generator = new PreorderNodeListGenerator();
+
+		resolveNode.accept(generator);
+
+		final String[] pathArray = generator.getClassPath().split(
+				File.pathSeparator);
+
+		for (String path : pathArray) {
+			log.info("path = " + path);
+		}
+
+		//
+
+		final MavenProject project = newProject("org.apache.maven:maven-model:pom:3.0");
+
+		log.info("project = " + project);
+
+	}
+
+	/**
+	 * Resolve maven URI into maven artifact.
+	 */
+	public static Artifact newArtifact(String mavenURI) throws Exception {
+
+		final RepositorySystem system = newSystem();
+		final RepositorySystemSession session = newSession(system);
+		final RemoteRepository central = newRepoRemote();
+
+		final ArtifactRequest request = new ArtifactRequest();
+		request.setArtifact(new DefaultArtifact(mavenURI));
+		request.addRepository(central);
+
+		final ArtifactResult result = system.resolveArtifact(session, request);
+
+		final Artifact artifact = result.getArtifact();
+
+		return artifact;
+
+	}
+
+	/**
+	 * Resolve maven URI into maven project.
+	 * <p>
+	 * Provides only model and artifact.
+	 */
+	public static MavenProject newProject(String mavenURI) throws Exception {
+
+		final Artifact artifact = newArtifact(mavenURI);
+
+		final File input = artifact.getFile();
+
+		final ModelReader reader = new DefaultModelReader();
+
+		final Model model = reader.read(input, null);
+
+		final MavenProject project = new MavenProject(model);
+
+		project.setArtifact(RepositoryUtils.toArtifact(artifact));
+
+		return project;
+
+	}
+
+	/**
+	 * Local user repository.
+	 */
+	public static File newRepoFolder() throws Exception {
+		final File home = new File(System.getProperty("user.home"));
+		final File repo = new File(home, ".m2/repository");
+		return repo;
+	}
+
+	/**
+	 * Local user repository.
+	 */
+	public static LocalRepository newRepoLocal() throws Exception {
+		return new LocalRepository(newWorkFolder());
+	}
+
+	/**
+	 * Remote central repository.
+	 */
+	public static RemoteRepository newRepoRemote() throws Exception {
+		final RemoteRepository central = new RemoteRepository("central",
+				"default", URL_CENTRAL);
+		return central;
+	}
+
+	/**
+	 * Remote central repository as list.
+	 */
+	public static List<RemoteRepository> newRepoRemoteList() throws Exception {
+		return Collections.singletonList(newRepoRemote());
+	}
+
+	/**
+	 * Default repository session.
+	 */
+	public static RepositorySystemSession newSession() throws Exception {
+		return newSession(newSystem());
+	}
+
+	/**
+	 * Default repository session.
+	 */
+	public static MavenRepositorySystemSession newSession(
+			RepositorySystem system) throws Exception {
+
+		final LocalRepository localRepo = newRepoLocal();
+
+		final MavenRepositorySystemSession session = new MavenRepositorySystemSession();
+
+		session.setLocalRepositoryManager(system
+				.newLocalRepositoryManager(localRepo));
+
+		return session;
+
+	}
+
+	/**
+	 * Default repository system.
+	 */
+	public static RepositorySystem newSystem() throws Exception {
+
+		DefaultServiceLocator locator = new DefaultServiceLocator();
+
+		locator.addService(VersionResolver.class, DefaultVersionResolver.class);
+
+		locator.addService(VersionRangeResolver.class,
+				DefaultVersionRangeResolver.class);
+
+		locator.addService(ArtifactDescriptorReader.class,
+				DefaultArtifactDescriptorReader.class);
+
+		locator.addService(WagonProvider.class, SimpleWagonProvider.class);
+
+		locator.addService(RepositoryConnectorFactory.class,
+				WagonRepositoryConnectorFactory.class);
+
+		return locator.getService(RepositorySystem.class);
+
+	}
+
+	/**
+	 * Local repository.
+	 */
+	public static File newWorkFolder() throws Exception {
+		final File work = new File(System.getProperty("user.dir"));
+		final File target = new File(work, "target");
+		// final File repo = new File(target, "repo-" +
+		// System.currentTimeMillis());
+		final File repo = new File(target, "repo-local");
+		repo.mkdirs();
+		repo.deleteOnExit();
+		return repo;
+	}
+
+}


### PR DESCRIPTION
The standard feature descriptor generator includes all matching bundle versions, which makes deployment a bit of a headache when your projects use semantic versioning and ranged dependencies.

The features-generate-semantic goal included in this pull request resolves this by choosing only the best version match within a range that satisfies all dependencies. Ideally this would be configurable behavior on the standard features generator, but there were enough behavioral differences that we gave it is own goal at this time.
