### PR TITLE
[KARAF-3100] - Add support for redirecting feature configs to file

### DIFF
--- a/assemblies/features/framework/src/main/filtered-resources/resources/etc/org.apache.karaf.features.cfg
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/etc/org.apache.karaf.features.cfg
@@ -47,3 +47,8 @@ featuresBoot=config,standard,region,package,kar,ssh,management
 # Defines if the boot features are started in asynchronous mode (in a dedicated thread)
 #
 featuresBootAsynchronous=false
+
+#
+# Determine if feature configurations should be output to file instead of added directly to config admin
+#
+featuresRedirectConfigsToFile=false

--- a/features/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -36,6 +36,8 @@
             <ext:property name="respectStartLvlDuringFeatureUninstall" value="true"/>
             <ext:property name="featuresBootAsynchronous" value="false"/>
             <ext:property name="overrides" value="file:$(karaf.etc)/overrides.properties"/>
+            <ext:property name="featuresRedirectConfigsToFile" value="false"/>
+            <ext:property name="featuresRedirectConfigDir" value="$(karaf.etc)"/>
         </ext:default-properties>
         <ext:location>file:$(karaf.etc)/org.apache.karaf.features.cfg</ext:location>
     </ext:property-placeholder>
@@ -62,6 +64,8 @@
     </bean>
     <bean id="configInstaller" class="org.apache.karaf.features.internal.FeatureConfigInstaller">
         <argument ref="configAdmin"/>
+        <property name="redirectFeatureConfigsToFile" value="$[featuresRedirectConfigsToFile]" />
+        <property name="featureConfigsOutputDir" value="$[featuresRedirectConfigDir]" />
     </bean>
     <bean id="featuresService" class="org.apache.karaf.features.internal.FeaturesServiceImpl" init-method="start"
           destroy-method="stop">


### PR DESCRIPTION
This is what I was asking about adding here:

http://karaf.922171.n3.nabble.com/Problems-With-Factory-Configurations-In-Karaf-3-0-1-td4033921i20.html

By being able to redirect configurations defined in feature files to file (rather than direct to configuration admin) makes these configurations much easier to manage. I have tested it myself and everything appears to work as expected. The default behaviour will be to work as before (i.e. the feature configs go direct to config admin).