### PR TITLE
allow reference to fqdn for use of ldaploginmodule within active directo...

### DIFF
--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPLoginModule.java
@@ -191,6 +191,7 @@ public class LDAPLoginModule extends AbstractKarafLoginModule {
         }
         logger.debug("Get the user DN.");
         String userDN;
+        String userDNNamespace;
         DirContext context = null;
         try {
             logger.debug("Initialize the JNDI LDAP Dir Context.");
@@ -224,6 +225,7 @@ public class LDAPLoginModule extends AbstractKarafLoginModule {
             //
             // the second escapes the slashes correctly.
             userDN = result.getNameInNamespace().replace("," + userBaseDN, "");
+            userDNNamespace = (String) result.getNameInNamespace();
             
             namingEnumeration.close();
         } catch (Exception e) {
@@ -288,6 +290,7 @@ public class LDAPLoginModule extends AbstractKarafLoginModule {
             roleFilter = roleFilter.replaceAll(Pattern.quote("%u"), Matcher.quoteReplacement(user));
             roleFilter = roleFilter.replaceAll(Pattern.quote("%dn"), Matcher.quoteReplacement(userDN));
             roleFilter = roleFilter.replaceAll(Pattern.quote("%fqdn"), Matcher.quoteReplacement(userDN + "," + userBaseDN));
+            roleFilter = roleFilter.replaceAll(Pattern.quote("%nsdn"), Matcher.quoteReplacement(userDNNamespace));
             roleFilter = roleFilter.replace("\\", "\\\\");
             logger.debug("  filter: " + roleFilter);
             NamingEnumeration namingEnumeration = context.search(roleBaseDN, roleFilter, controls);


### PR DESCRIPTION
When trying to configure LDAPLoginModule for use with Active Directory, I could not find a way with the current configuration to have the authorization work properly due to the use of the member attribute in AD.  I saw the %fqdn but unfortunately that would not work properly when search subtree is set to true.   I think %fqdn should actually be removed and replaced with my code, but didn't want to touch it just in case.  I put in 2.3.x branch as I want to see this make it into the next Fuse6.x release
