### PR TITLE
[KARAF-3344] Fix karaf-maven-plugin non-standard URLs handling

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/InstallKarsMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/InstallKarsMojo.java
@@ -430,23 +430,11 @@ public class InstallKarsMojo extends MojoSupport {
         } else {
             getLog().info("== Installing bundle " + bundle.getLocation());
             String bundleLocation = bundle.getLocation();
-            // cleanup prefixes
-            if (bundleLocation.startsWith("wrap:")) {
-                bundleLocation = bundleLocation.substring("wrap:".length());
-                int index = bundleLocation.indexOf("$");
-                if (index != -1) {
-                    bundleLocation = bundleLocation.substring(0, index);
-                }
-            }
-            if (bundleLocation.startsWith("blueprint:")) {
-                bundleLocation = bundleLocation.substring("blueprint:".length());
-            }
-            if (bundleLocation.startsWith("webbundle:")) {
-                bundleLocation = bundleLocation.substring("webbundle:".length());
-            }
-            if (bundleLocation.startsWith("war:")) {
-                bundleLocation = bundleLocation.substring("war:".length());
-            }
+
+            // cleanup prefixes and headers after '$'
+            bundleLocation = bundleLocation.replaceFirst("^(wrap|blueprint|webbundle|war):", "");
+            bundleLocation = bundleLocation.replaceFirst("\\$.*", "");
+
             File bundleFile;
             if (bundleLocation.startsWith("mvn:")) {
                 if (bundleLocation.endsWith("/")) {

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/InstallKarsMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/InstallKarsMojo.java
@@ -431,9 +431,9 @@ public class InstallKarsMojo extends MojoSupport {
             getLog().info("== Installing bundle " + bundle.getLocation());
             String bundleLocation = bundle.getLocation();
 
-            // cleanup prefixes and headers after '$'
+            // cleanup prefixes and headers after '?'
             bundleLocation = bundleLocation.replaceFirst("^(wrap|blueprint|webbundle|war):", "");
-            bundleLocation = bundleLocation.replaceFirst("\\$.*", "");
+            bundleLocation = bundleLocation.replaceFirst("\\?.*", "");
 
             File bundleFile;
             if (bundleLocation.startsWith("mvn:")) {


### PR DESCRIPTION
74515f50fa5c1f86c97a7c46688d253f7b2d60fd fixed only "wrap:" URL options handling.
I extended it to other URLs types and simplified implementation by using RegExp.
