### PR TITLE
javax.annotation version 1.2 is not supported by JDK8, downgrading to ve...

### DIFF
--- a/assemblies/features/framework/src/main/filtered-resources/resources/etc/jre.properties
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/etc/jre.properties
@@ -351,8 +351,8 @@ jre-1.8= \
  javax.accessibility, \
  javax.activation;version="1.1", \
  javax.activity, \
- javax.annotation;version="1.2", \
- javax.annotation.processing;version="1.2", \
+ javax.annotation;version="1.1", \
+ javax.annotation.processing;version="1.1", \
  javax.crypto, \
  javax.crypto.interfaces, \
  javax.crypto.spec, \


### PR DESCRIPTION
With the current jre.properties file and JDK8, the "system" is supposedly providing version 1.2 of package javax.annotation.  However, JDK8 does not support version 1.2 of javax.annotation (it's missing javax.annotation.Priority).  We need to "downgrade" this to version 1.1 in order to let the proper javax.annotation version 1.2 resolve from elsewhere.