### PR TITLE
Cloudyle 3.0.x

### DIFF
--- a/tooling/karaf-maven-plugin/pom.xml
+++ b/tooling/karaf-maven-plugin/pom.xml
@@ -24,11 +24,13 @@
     <parent>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>tooling</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <groupId>com.cloudyle.karaf.tooling</groupId>
     <artifactId>karaf-maven-plugin</artifactId>
+    <version>3.0.3</version>
     <packaging>maven-plugin</packaging>
     <name>Apache Karaf :: Tooling :: Maven Karaf Plugin</name>
 

--- a/tooling/karaf-maven-plugin/pom.xml
+++ b/tooling/karaf-maven-plugin/pom.xml
@@ -232,5 +232,4 @@
         </plugins>
     </reporting>
 
-    <groupId>org.apache.karaf.tooling</groupId>
 </project>

--- a/tooling/karaf-maven-plugin/pom.xml
+++ b/tooling/karaf-maven-plugin/pom.xml
@@ -232,4 +232,5 @@
         </plugins>
     </reporting>
 
+    <groupId>org.apache.karaf.tooling</groupId>
 </project>

--- a/tooling/karaf-maven-plugin/src/it/test-aggregate-features/aggregate-features/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-aggregate-features/aggregate-features/pom.xml
@@ -72,7 +72,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <extensions>true</extensions>

--- a/tooling/karaf-maven-plugin/src/it/test-aggregate-features/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-aggregate-features/pom.xml
@@ -49,7 +49,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-basic-generation/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-basic-generation/pom.xml
@@ -39,7 +39,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-check-dependencies-failure/dependencies-features/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-check-dependencies-failure/dependencies-features/pom.xml
@@ -72,7 +72,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <extensions>true</extensions>

--- a/tooling/karaf-maven-plugin/src/it/test-check-dependencies-failure/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-check-dependencies-failure/pom.xml
@@ -45,7 +45,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-check-dependencies/dependencies-features/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-check-dependencies/dependencies-features/pom.xml
@@ -72,7 +72,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <extensions>true</extensions>

--- a/tooling/karaf-maven-plugin/src/it/test-check-dependencies/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-check-dependencies/pom.xml
@@ -46,7 +46,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-dependency-properties/control.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-dependency-properties/control.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.2.1" name="test-input-file">
+    <feature description="Test Description" version="1.0-SNAPSHOT" name="test-input-file">
+        <details>Test Description</details>
+        <bundle>mvn:test/test-input-file/1.0-SNAPSHOT</bundle>
+    </feature>
+</features>

--- a/tooling/karaf-maven-plugin/src/it/test-dependency-properties/control.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-dependency-properties/control.xml
@@ -21,6 +21,10 @@
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.2.1" name="test-input-file">
     <feature description="Test Description" version="1.0-SNAPSHOT" name="test-input-file">
         <details>Test Description</details>
-        <bundle>mvn:test/test-input-file/1.0-SNAPSHOT</bundle>
+        <configfile finalname="etc/test.cfg" override="false">mvn:test/dependency-module-c/1.0-SNAPSHOT/cfg</configfile>
+        <bundle>mvn:test/test-dependency-properties/1.0-SNAPSHOT</bundle>
+        <bundle>mvn:test/dependency-module-c/1.0-SNAPSHOT</bundle>
+        <bundle>mvn:test/dependency-module-a/1.0-SNAPSHOT</bundle>
+        <bundle>mvn:test/dependency-module-b/1.0-SNAPSHOT</bundle>
     </feature>
 </features>

--- a/tooling/karaf-maven-plugin/src/it/test-dependency-properties/control.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-dependency-properties/control.xml
@@ -18,8 +18,8 @@
   ~ under the License.
   -->
 
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.2.1" name="test-input-file">
-    <feature description="Test Description" version="1.0-SNAPSHOT" name="test-input-file">
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.2.1" name="test-dependency-properties">
+    <feature description="Test Description" version="1.0-SNAPSHOT" name="test-dependency-properties">
         <details>Test Description</details>
         <configfile finalname="etc/test.cfg" override="false">mvn:test/dependency-module-c/1.0-SNAPSHOT/cfg</configfile>
         <bundle>mvn:test/test-dependency-properties/1.0-SNAPSHOT</bundle>

--- a/tooling/karaf-maven-plugin/src/it/test-dependency-properties/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-dependency-properties/pom.xml
@@ -50,7 +50,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-dependency-properties/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-dependency-properties/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>test-dependency-properties</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <description>Test Description</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+	    <dependency>
+            <groupId>test</groupId>
+            <artifactId>dependency-module-c</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+                <version>@pom.version@</version>
+                <executions>
+                    <execution>
+                        <id>generate-features-file</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>features-generate-descriptor</goal>
+                        </goals>
+                        <configuration>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-dependency-properties/src/main/feature/feature.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-dependency-properties/src/main/feature/feature.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.0.0" name="${project.artifactId}">
+    <feature name="${project.artifactId}" version="${project.version}" description="${project.description}">
+	    <configfile finalname="etc/test.cfg" override="false">mvn:test/dependency-module-c/${test.dependency-module-c.version}/cfg</configfile>		
+        <bundle>mvn:${project.groupId}/${project.artifactId}/${project.version}</bundle>
+    </feature>
+</features>

--- a/tooling/karaf-maven-plugin/src/it/test-dependency-properties/src/main/java/test/App.java
+++ b/tooling/karaf-maven-plugin/src/it/test-dependency-properties/src/main/java/test/App.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test;
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/tooling/karaf-maven-plugin/src/it/test-dependency-properties/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-dependency-properties/verify.bsh
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.custommonkey.xmlunit.*;
+import java.io.*;
+import java.lang.*;
+
+Reader r = new FileReader(new File(basedir, "control.xml"));
+
+// load the features file pushed to the repository
+File generated = new File( localRepositoryPath, "test/test-input-file/1.0-SNAPSHOT/test-input-file-1.0-SNAPSHOT-features.xml" );
+if (generated.exists()) {
+    try {
+        XMLAssert.assertXMLEqual(r, new FileReader(generated));
+        return true;
+    } catch (Throwable ignored) { }
+}
+
+return false;

--- a/tooling/karaf-maven-plugin/src/it/test-dependency-properties/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-dependency-properties/verify.bsh
@@ -24,7 +24,7 @@ import java.lang.*;
 Reader r = new FileReader(new File(basedir, "control.xml"));
 
 // load the features file pushed to the repository
-File generated = new File( localRepositoryPath, "test/test-input-file/1.0-SNAPSHOT/test-input-file-1.0-SNAPSHOT-features.xml" );
+File generated = new File( localRepositoryPath, "test/test-dependency-properties/1.0-SNAPSHOT/test-dependency-properties-1.0-SNAPSHOT-features.xml" );
 if (generated.exists()) {
     try {
         XMLAssert.assertXMLEqual(r, new FileReader(generated));

--- a/tooling/karaf-maven-plugin/src/it/test-include-project-artifact/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-include-project-artifact/pom.xml
@@ -38,7 +38,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-input-file/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-input-file/pom.xml
@@ -45,7 +45,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-kar-classifier/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-kar-classifier/pom.xml
@@ -29,7 +29,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-kar-multiple-kars/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-kar-multiple-kars/pom.xml
@@ -29,7 +29,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-kar-packaging/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-kar-packaging/pom.xml
@@ -29,7 +29,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <extensions>true</extensions>

--- a/tooling/karaf-maven-plugin/src/it/test-kar-with-pom-packaging/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-kar-with-pom-packaging/pom.xml
@@ -30,7 +30,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-recursive/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-recursive/pom.xml
@@ -45,7 +45,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-type-classifier/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-type-classifier/pom.xml
@@ -40,7 +40,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>com.cloudyle.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/tooling/karaf-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -30,7 +30,7 @@
                         <id>default</id>
                         <phases>
                             <compile>
-                                org.apache.karaf.tooling:karaf-maven-plugin:features-generate-descriptor
+                                com.cloudyle.karaf.tooling:karaf-maven-plugin:features-generate-descriptor
                             </compile>
                             <install>
                                 org.apache.maven.plugins:maven-install-plugin:install
@@ -69,10 +69,10 @@
                                 org.apache.maven.plugins:maven-resources-plugin:resources
                             </process-resources>
                             <compile>
-                                org.apache.karaf.tooling:karaf-maven-plugin:features-generate-descriptor
+                                com.cloudyle.karaf.tooling:karaf-maven-plugin:features-generate-descriptor
                             </compile>
                             <package>
-                                org.apache.karaf.tooling:karaf-maven-plugin:features-create-kar
+                                com.cloudyle.karaf.tooling:karaf-maven-plugin:features-create-kar
                             </package>
                             <install>
                                 org.apache.maven.plugins:maven-install-plugin:install
@@ -115,12 +115,12 @@
                         <phases>
                             <process-resources>
                                 org.apache.maven.plugins:maven-resources-plugin:resources,
-                                org.apache.karaf.tooling:karaf-maven-plugin:install-kars
+                                com.cloudyle.karaf.tooling:karaf-maven-plugin:install-kars
                             </process-resources>
                             <compile>
                             </compile>
                             <package>
-                                org.apache.karaf.tooling:karaf-maven-plugin:instance-create-archive
+                                com.cloudyle.karaf.tooling:karaf-maven-plugin:instance-create-archive
                             </package>
                             <install>
                                 org.apache.maven.plugins:maven-install-plugin:install


### PR DESCRIPTION
I added the function to karaf maven plugin to allow replacing dependency versions in feature.xml.
This is useful to add configuration files from maven artifacts. For each dependency in the pom.xml a property is created automatically during plugin execution. The properties are named artifactId.version (or groupId.artifactId.version).
This allows a syntax in feature.xml like this:
<configfile finalname="etc/test.cfg" override="false">mvn:test/dependency-module-c/${test.dependency-module-c.version}/cfg</configfile>
