### PR TITLE
KARAF-3590: Don't log Passwords in clear text

### DIFF
--- a/instance/src/main/java/org/apache/karaf/instance/core/internal/osgi/Activator.java
+++ b/instance/src/main/java/org/apache/karaf/instance/core/internal/osgi/Activator.java
@@ -19,6 +19,8 @@ package org.apache.karaf.instance.core.internal.osgi;
 import org.apache.karaf.instance.core.InstanceService;
 import org.apache.karaf.instance.core.internal.InstanceServiceImpl;
 import org.apache.karaf.instance.core.internal.InstancesMBeanImpl;
+import org.apache.karaf.shell.api.console.CommandLoggingFilter;
+import org.apache.karaf.shell.support.RegexCommandLoggingFilter;
 import org.apache.karaf.util.tracker.BaseActivator;
 import org.apache.karaf.util.tracker.annotation.ProvideService;
 import org.apache.karaf.util.tracker.annotation.Services;
@@ -30,6 +32,11 @@ public class Activator extends BaseActivator {
     protected void doStart() throws Exception {
         InstanceService instanceService = new InstanceServiceImpl();
         register(InstanceService.class, instanceService);
+
+        RegexCommandLoggingFilter filter = new RegexCommandLoggingFilter();
+        filter.addCommandOption("--password", "connect");
+        filter.addCommandOption("-p", "connect");
+        register(CommandLoggingFilter.class, filter);
 
         InstancesMBeanImpl mbean = new InstancesMBeanImpl(instanceService);
         registerMBean(mbean, "type=instance");

--- a/jms/src/main/resources/OSGI-INF/blueprint/jms-core.xml
+++ b/jms/src/main/resources/OSGI-INF/blueprint/jms-core.xml
@@ -38,4 +38,18 @@
         </service-properties>
     </service>
 
+    <!-- Lets try to filter passwords out of the logs -->
+    <service auto-export="interfaces">
+        <bean class="org.apache.karaf.shell.support.RegexCommandLoggingFilter">
+            <property name="pattern" value="create +.*?--password ([^ ]+)"/>
+            <property name="group" value="2"/>
+        </bean>
+    </service>
+    <service auto-export="interfaces">
+        <bean class="org.apache.karaf.shell.support.RegexCommandLoggingFilter">
+            <property name="pattern" value="create +.*?-p ([^ ]+)"/>
+            <property name="group" value="2"/>
+        </bean>
+    </service>
+
 </blueprint>

--- a/shell/core/src/main/java/org/apache/karaf/shell/api/console/CommandLoggingFilter.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/api/console/CommandLoggingFilter.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.shell.api.console;
+
+/**
+ * Used to filter a command before it gets logged.
+ */
+public interface CommandLoggingFilter {
+
+    CharSequence filter(CharSequence command);
+
+}

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/osgi/LoggingCommandSessionListener.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/osgi/LoggingCommandSessionListener.java
@@ -18,8 +18,13 @@
  */
 package org.apache.karaf.shell.impl.console.osgi;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.felix.gogo.api.CommandSessionListener;
 import org.apache.felix.service.command.CommandSession;
+import org.apache.karaf.shell.api.console.CommandLoggingFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,19 +32,45 @@ public class LoggingCommandSessionListener implements CommandSessionListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingCommandSessionListener.class);
 
+    private Collection<CommandLoggingFilter> filters = Collections.emptyList();
+
+    public Collection<CommandLoggingFilter> getFilters() {
+        return filters;
+    }
+
+    public void setFilters(Collection<CommandLoggingFilter> filters) {
+        this.filters = filters;
+    }
+
+    private CharSequence filter(CharSequence command) {
+        for (CommandLoggingFilter filter : filters) {
+            command = filter.filter(command);
+        }
+        return command;
+    }
+
     public void beforeExecute(CommandSession session, CharSequence command) {
-        LOGGER.debug("Executing command: '" + command + "'");
+        if ( LOGGER.isDebugEnabled() ) {
+            command = filter(command);
+            LOGGER.debug("Executing command: '" + command + "'");
+        }
     }
 
     public void afterExecute(CommandSession session, CharSequence command, Exception exception) {
-        if (LOGGER.isTraceEnabled()) {
-            LOGGER.debug("Command: '" + command + "' failed", exception);
-        } else {
-            LOGGER.debug("Command: '" + command + "' failed: " + exception);
+        if (LOGGER.isDebugEnabled()) {
+            command = filter(command);
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.debug("Command: '" + command + "' failed", exception);
+            } else {
+                LOGGER.debug("Command: '" + command + "' failed: " + exception);
+            }
         }
     }
 
     public void afterExecute(CommandSession session, CharSequence command, Object result) {
-        LOGGER.debug("Command: '" + command + "' returned '" + result + "'");
+        if (LOGGER.isDebugEnabled()) {
+            command = filter(command);
+            LOGGER.debug("Command: '" + command + "' returned '" + result + "'");
+        }
     }
 }

--- a/shell/core/src/main/java/org/apache/karaf/shell/support/RegexCommandLoggingFilter.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/support/RegexCommandLoggingFilter.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.shell.support;
+
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.karaf.shell.api.console.CommandLoggingFilter;
+
+
+/**
+ *
+ */
+public class RegexCommandLoggingFilter implements CommandLoggingFilter {
+
+    public static final String DEFAULT_REPLACEMENT = "*****";
+
+    private static class ReplaceRegEx {
+        private Pattern pattern;
+        private int group=1;
+        private String replacement;
+
+        public ReplaceRegEx(String pattern, int group, String replacement) {
+            this.pattern = Pattern.compile(";* *"+pattern);
+            this.group = group;
+            this.replacement = replacement;
+        }
+
+        public CharSequence filter(CharSequence command) {
+            Matcher m = pattern.matcher(command);
+            int offset = 0;
+            while( m.find() ) {
+                int origLen = command.length();
+                command = new StringBuilder(command).replace(m.start(group)+offset, m.end(group)+offset, replacement).toString();
+                offset += command.length() - origLen;
+            }
+            return command;
+        }
+    }
+
+    private String pattern;
+    private int group=1;
+    private String replacement=DEFAULT_REPLACEMENT;
+
+    ArrayList<ReplaceRegEx> regexs = new ArrayList<ReplaceRegEx>();
+
+    public CharSequence filter(CharSequence command) {
+        if( pattern!=null ) {
+            command = new ReplaceRegEx(pattern, group, replacement).filter(command);
+        }
+        for (ReplaceRegEx regex : regexs) {
+            command = regex.filter(command);
+        }
+        return command;
+    }
+
+    public void addRegEx(String pattern) {
+        addRegEx(pattern, 1);
+    }
+    public void addRegEx(String pattern, int group) {
+        addRegEx(pattern, group, DEFAULT_REPLACEMENT);
+    }
+
+    public void addRegEx(String pattern, int group, String replacement) {
+        regexs.add(new ReplaceRegEx(pattern, group, replacement));
+    }
+
+    public void addCommandOption(String option, String...commands) {
+        String pattern = "(";
+        for (String command : commands) {
+            if( pattern.length() > 1 ) {
+                pattern += "|";
+            }
+            pattern += Pattern.quote(command);
+        }
+        pattern += ") +.*?"+Pattern.quote(option)+" +([^ ]+)";
+        regexs.add(new ReplaceRegEx(pattern, 2, DEFAULT_REPLACEMENT));
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public String getReplacement() {
+        return replacement;
+    }
+
+    public void setReplacement(String replacement) {
+        this.replacement = replacement;
+    }
+
+    public int getGroup() {
+        return group;
+    }
+
+    public void setGroup(int group) {
+        this.group = group;
+    }
+}

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/Activator.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/Activator.java
@@ -22,8 +22,10 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import org.apache.karaf.shell.api.action.lifecycle.Manager;
+import org.apache.karaf.shell.api.console.CommandLoggingFilter;
 import org.apache.karaf.shell.api.console.Session;
 import org.apache.karaf.shell.api.console.SessionFactory;
+import org.apache.karaf.shell.support.RegexCommandLoggingFilter;
 import org.apache.karaf.util.tracker.BaseActivator;
 import org.apache.karaf.util.tracker.annotation.Managed;
 import org.apache.karaf.util.tracker.annotation.RequireService;
@@ -89,6 +91,16 @@ public class Activator extends BaseActivator implements ManagedService {
         if (sf == null) {
             return;
         }
+
+        RegexCommandLoggingFilter filter = new RegexCommandLoggingFilter();
+        filter.setPattern("ssh (.*?)-P +([^ ]+)");
+        filter.setGroup(2);
+        register(CommandLoggingFilter.class, filter);
+
+        filter = new RegexCommandLoggingFilter();
+        filter.setPattern("ssh (.*?)--password +([^ ]+)");
+        filter.setGroup(2);
+        register(CommandLoggingFilter.class, filter);
 
         sessionFactory = sf;
         sessionFactory.getRegistry().getService(Manager.class).register(SshAction.class);


### PR DESCRIPTION
* Bundles can now register CommandLoggingFilter objects in the OSGi registry to get a chance to filter out sensitve data data from logs before the logging happens.