### PR TITLE
[KARAF-3660] Setting JMX SSL causes StringIndexOutOfBoundsException when...

### DIFF
--- a/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/ResourceKeystoreInstance.java
+++ b/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/ResourceKeystoreInstance.java
@@ -130,7 +130,9 @@ public class ResourceKeystoreInstance implements KeystoreInstance {
             for (int i = 0; i < keys.length; i++) {
                 String key = keys[i];
                 int pos = key.indexOf('=');
-                this.keyPasswords.put(key.substring(0, pos), key.substring(pos + 1).toCharArray());
+                if (pos > 0) {
+                    this.keyPasswords.put(key.substring(0, pos), key.substring(pos + 1).toCharArray());
+                }
             }
         }
     }


### PR DESCRIPTION
... setting keyPasswords without = symbol

https://issues.apache.org/jira/browse/KARAF-3660