### PR TITLE
KARAF-3566 updated the jre.properties on the 2.x branch to have the correct versions for the javax.annotations packages

### DIFF
--- a/assemblies/apache-karaf/src/main/filtered-resources/etc/jre.properties
+++ b/assemblies/apache-karaf/src/main/filtered-resources/etc/jre.properties
@@ -27,8 +27,8 @@ jre-1.6= \
  javax.accessibility, \
  javax.activation;version="1.1", \
  javax.activity, \
- javax.annotation;version="1.1", \
- javax.annotation.processing;version="1.1", \
+ javax.annotation;version="1.0", \
+ javax.annotation.processing;version="1.0", \
  javax.crypto, \
  javax.crypto.interfaces, \
  javax.crypto.spec, \
@@ -190,8 +190,8 @@ jre-1.7= \
  javax.accessibility, \
  javax.activation;version="1.1", \
  javax.activity, \
- javax.annotation;version="1.1", \
- javax.annotation.processing;version="1.1", \
+ javax.annotation;version="1.0", \
+ javax.annotation.processing;version="1.0", \
  javax.crypto, \
  javax.crypto.interfaces, \
  javax.crypto.spec, \
@@ -351,8 +351,8 @@ jre-1.8= \
  javax.accessibility, \
  javax.activation;version="1.1", \
  javax.activity, \
- javax.annotation;version="1.2", \
- javax.annotation.processing;version="1.2", \
+ javax.annotation;version="1.0", \
+ javax.annotation.processing;version="1.0", \
  javax.crypto, \
  javax.crypto.interfaces, \
  javax.crypto.spec, \


### PR DESCRIPTION
This is the same code that was placed on master, but it was never applied to the 2.x branch

The KARAF-3566 ticket has more details on the reason the versions need to be adjusted to 1.0 instead of 1.1 or 1.2.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/karaf/70)
<!-- Reviewable:end -->
