### PR TITLE
[KARAF-3811] Exception thrown when including the feature "feature" in Maven karaf:assembly goal

### DIFF
--- a/profile/src/main/java/org/apache/karaf/profile/assembly/AssemblyDeployCallback.java
+++ b/profile/src/main/java/org/apache/karaf/profile/assembly/AssemblyDeployCallback.java
@@ -209,8 +209,17 @@ public class AssemblyDeployCallback implements Deployer.DeployCallback {
             Files.copy(is, bundleSystemFile, StandardCopyOption.REPLACE_EXISTING);
 
             Hashtable<String, String> headers = new Hashtable<>();
-            JarFile jar = new JarFile(bundleSystemFile.toFile());
-            Attributes attributes = jar.getManifest().getMainAttributes();
+            JarFile jar = null;
+            Attributes attributes;
+            try {
+                jar = new JarFile(bundleSystemFile.toFile());
+                attributes = jar.getManifest().getMainAttributes();
+            }
+            finally {
+                if (jar != null) {
+                    jar.close();
+                }
+            }
             for (Map.Entry attr : attributes.entrySet()) {
                 headers.put(attr.getKey().toString(), attr.getValue().toString());
             }


### PR DESCRIPTION
The JarFile object was not being closed.  For some reason, this only seems to have caused a problem on the Windows HotSpot JVM.