### PR TITLE
KARAF-3968: KARAF-3969: add offline to the assembly mojo.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2086,7 +2086,8 @@
         <profile>
             <id>fastinstall</id>
             <properties>
-                <maven.test.skip>true</maven.test.skip>
+              <maven.test.skip>true</maven.test.skip>
+              <invoker.skip>true</invoker.skip>
             </properties>
         </profile>
         <profile>

--- a/tooling/karaf-maven-plugin/pom.xml
+++ b/tooling/karaf-maven-plugin/pom.xml
@@ -204,7 +204,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <version>1.6</version>
+                <version>2.0.0</version>
                 <configuration>
                     <debug>true</debug>
                     <projectsDirectory>src/it</projectsDirectory>
@@ -229,6 +229,18 @@
                             <goal>install</goal>
                             <goal>run</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>test-offline</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <invokerPropertiesFile>src/test/offline.properties</invokerPropertiesFile>
+                            <pomExcludes>
+                                <pomExclude>test-check-dependencies-failure/pom.xml</pomExclude>
+                            </pomExcludes>
+                        </configuration>
                     </execution>
                 </executions>
                 <dependencies>

--- a/tooling/karaf-maven-plugin/src/it/test-assembly/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-assembly/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>test-basic-generation</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>karaf-assembly</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>framework</artifactId>
+            <version>@pom.version@</version>
+            <type>kar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>standard</artifactId>
+            <version>@pom.version@</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+                <version>@pom.version@</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <finalName>${project.artifactId}</finalName>
+                    <bootFeatures>
+                        <feature>bundle</feature>
+                        <feature>config</feature>
+                        <feature>diagnostic</feature>
+                        <feature>feature</feature>
+                        <feature>jaas</feature>
+                        <feature>shell</feature>
+                        <feature>log</feature>
+                        <feature>management</feature>
+                        <feature>package</feature>
+                        <feature>shell-compat</feature>
+                        <feature>ssh</feature>
+                        <feature>system</feature>
+                        <feature>wrap</feature>
+                    </bootFeatures>
+                    <archiveZip>false</archiveZip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
@@ -160,6 +160,12 @@ public class AssemblyMojo extends MojoSupport {
     @Parameter
     protected Builder.KarafVersion karafVersion = Builder.KarafVersion.v4x;
 
+    /**
+     * Specify the version of Java SE to be assumed for osgi.ee.
+     */
+    @Parameter(defaultValue = "1.7")
+    protected String javase;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
@@ -205,6 +211,7 @@ public class AssemblyMojo extends MojoSupport {
 
         Builder builder = Builder.newInstance();
         builder.offline(mavenSession.isOffline());
+        builder.javase(javase);
 
         // Set up blacklisted items
         builder.blacklistBundles(blacklistedBundles);

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
@@ -204,6 +204,7 @@ public class AssemblyMojo extends MojoSupport {
         }
 
         Builder builder = Builder.newInstance();
+        builder.offline(mavenSession.isOffline());
 
         // Set up blacklisted items
         builder.blacklistBundles(blacklistedBundles);

--- a/tooling/karaf-maven-plugin/src/test/offline.properties
+++ b/tooling/karaf-maven-plugin/src/test/offline.properties
@@ -1,0 +1,15 @@
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+invoker.offline = true


### PR DESCRIPTION
Propagate the Maven offline flag down to the aether session created by the assembly mojo.

Add integration testing of offline mode.

Add a <javase> parameter to the assembly goal, to permit builds for other than 1.7!
