### PR TITLE
Update installation.adoc

### DIFF
--- a/manual/src/main/asciidoc/users-guide/installation.adoc
+++ b/manual/src/main/asciidoc/users-guide/installation.adoc
@@ -22,11 +22,11 @@
 :numbered:
 
 
-Apache Karaf is a lightweight container, very easy to install and administrate, on both Unix and Windows platforms.
+Apache Karaf is a lightweight container, very easy to install and administer, on both Unix and Windows platforms.
 
 ==  Requirements
 
-Hardware: ::
+Storage: ::
 
 * 50 MB of free disk space for the Apache Karaf binary distribution.
 
@@ -38,30 +38,24 @@ Operating Systems: ::
 Environment: ::
 
 * Java SE 1.7.x or greater ([http://www.oracle.com/technetwork/java/javase/]).
-* The JAVA_HOME environment variable must be set to the directory where the Java runtime is installed,
+* The Java SE "bin" directory has to be in the `PATH` environment variable, or the `JAVA_HOME` environment variable must be set to point to the directory where the Java SE distribution is installed.
 
 ==  Using Apache Karaf binary distributions
 
-Apache Karaf is available in two distributions, both as a tar.gz and zip archives.
+Apache Karaf is available in two distributions, and in either a "tar.gz" or "zip" format.
 
+The "default" distribution is a "ready to use" distribution, with everything provided in the distribution archive.
 
-The "default" distribution is a "ready to use" distribution.
-The "default" distribution provides the following features enabled.
-
-The "minimal" distribution is like the minimal distributions that you can find for most of Unix distributions.
-Only the core layer is packaged, most of the features and bundles are downloaded from Internet at bootstrap.
-It means that Apache Karaf minimal distribution requires an Internet connection to start correctly.
-The features provided by the "minimal" distribution are exactly the same as in the "default" distribution, the difference
-is that the minimal distribution will download the features from Internet.
+The "minimal" distribution is like many minimal distributions for other applications.
+Only the core layer is provided, and most of the features and bundles are downloaded from the Internet at bootstrap.
+This means that the Apache Karaf minimal distribution requires an Internet connection to fully install itself. Once the "minimal" distribution fully installs, it provides all the same features as the "default" distribution.
 
 === Installation on Windows platform
 
-NB: the JAVA_HOME environment variable has to be correctly defined. To accomplish that, press Windows key and Break key together, switch to "Advanced" tab and click on "Environment Variables".
-
 . From a browser, navigate to [http://karaf.apache.org/index/community/download.html].
-. Download Apache Karaf binary distribution in the zip format: `apache-karaf-3.0.0.zip`.
-. Extract the files from the zip file into a directory of your choice (it's the `KARAF_HOME`.
-NB: remember the restrictions concerning illegal characters in Java paths, e.g. \!, % etc.
+. Download Apache Karaf binary distribution in the zip format: `apache-karaf-n.n.n.zip` (like `apache-karaf-4.0.1.zip`).
+. Extract the files from the zip file into a directory of your choice (where `KARAF_HOME` points to).
+Note: remember the restrictions concerning illegal characters in Java paths, e.g. \!, % etc.
 . Apache Karaf is now installed.
 
 [TIP]
@@ -74,31 +68,26 @@ so your Karaf root directory is S: --- which works for sure and is short to type
 
 === Installation on Unix platforms
 
-NB: the JAVA_HOME environment variable has to be correctly defined. Check the current value using
+. From a browser, navigate to [http://karaf.apache.org/index/community/download.html].
+. Download Apache Karaf binary distribution in the tar.gz format: `apache-karaf-n.n.n.tar.gz`  (like `apache-karaf-4.0.1.tar.gz`).
+. Extract the files from the tar.gz file into a directory of your choice (where `KARAF_HOME` points to). For example:
 ----
-echo $JAVA_HOME
-----
-If it's not correct, fix it using:
-----
-export JAVA_HOME=....
+gunzip apache-karaf-n.n.n.tar.gz
+tar xvf apache-karaf-n.n.n.tar
 ----
 
-. From a browser, navigate to [http://karaf.apache.org/index/community/download.html].
-. Download Apache Karaf binary distribution in the tar.gz format: `apache-karaf-3.0.0.tar.gz`.
-. Extract the files from the tar.gz file into a directory of your choice (it's the `KARAF_HOME`). For example:
+or
 ----
-gunzip apache-karaf-3.0.0.tar.gz
-tar xvf apache-karaf-3.0.0.tar
+tar xvzf apache.karaf-n.n.n.tar.gz
 ----
-NB: remember the restrictions concerning illegal characters in Java paths, e.g. \!, % etc.
+Note: remember the restrictions concerning illegal characters in Java paths, e.g. \!, % etc.
 . Apache Karaf is now installed.
 
 ==  Post-Installation steps
 
-Thought it is not always required, it is strongly advised to set up the `JAVA_HOME` environment property to point to the JDK you want Apache Karaf to use before starting it.
-This property is used to locate the `java` executable and should be configured to point to the home directory of the Java SE 7 installation.
+Apache Karaf uses Java, so it has to be able to find the "java" executable.  No matter what platform you're on, this is done by either putting the "bin" directory of the Java SE distribution into the `PATH` environment variable, or by setting the `JAVA_HOME` environment variable to point to the root of the Java SE distribution.
 
-By default, all Apache Karaf files are "gather" in one directory: the `KARAF_HOME`.
+By default, all Apache Karaf files are available in one directory: the `KARAF_HOME`.
 
 You can define your own directory layout, by using some Karaf environment variables:
 
@@ -110,19 +99,19 @@ You can define your own directory layout, by using some Karaf environment variab
 
 If you intend to build Apache Karaf from the sources, the requirements are a bit different:
 
-Hardware: ::
+Storage: ::
 
-* 500 MB of free disk space for the Apache Karaf source distributions or SVN checkout, the Maven build and the dependencies Maven downloads.
+* 500 MB of free disk space for the Apache Karaf source, the Maven build outputs, and the external dependencies downloaded by Maven.
 
 Environment: ::
 
 * Java SE Development Kit 1.7.x or greater ([http://www.oracle.com/technetwork/java/javase/]).
-* Apache Maven 3.0.4 ([http://maven.apache.org/download.html]).
+* Apache Maven 3.0.3 (or newer) ([http://maven.apache.org/download.html]).
 
 === Building on Windows platform
 
 . You can get the Apache Karaf sources from:
-* the sources distribution `apache-karaf-3.0.0-src.zip` available at [http://karaf.apache.org/index/community/download.html]. Extract the files in the directory of your choice.
+* the sources distribution `apache-karaf-n.n.n-src.zip` available at [http://karaf.apache.org/index/community/download.html]. Extract the files in the directory of your choice.
 * by checkout of the git repository:
 ----
 git clone https://git-wip-us.apache.org/repos/asf/karaf.git karaf
@@ -131,16 +120,16 @@ git clone https://git-wip-us.apache.org/repos/asf/karaf.git karaf
 ----
 mvn clean install
 ----
-NB: you can speed up the build by bypassing the unit tests:
+Note: you can speed up the build by bypassing the unit and integration tests:
 ----
 mvn clean install -DskipTests
 ----
-. You can find the built binary distribution in `assemblies\apache-karaf\target\apache-karaf-3.0.0.zip`. You can install and use it as explained in the "Using Apache Karaf binary distributions" section.
+. You can find the built binary distribution in `assemblies\apache-karaf\target\apache-karaf-n.n.n.zip`. You can install and use it as explained in the "Using Apache Karaf binary distributions" section.
 
 === Building on Unix platforms
 
 . You can get the Apache Karaf sources from:
-* the sources distribution `apache-karaf-3.0.0-src.tar.gz` available at [http://karaf.apache.org/index/community/download.html]. Extract the files in the directory of your choice.
+* the sources distribution `apache-karaf-n.n.n-src.tar.gz` available at [http://karaf.apache.org/index/community/download.html]. Extract the files in the directory of your choice.
 * by checkout of the git repository:
 ----
 git clone https://git-wip-us.apache.org/repos/asf/karaf.git karaf
@@ -149,8 +138,8 @@ git clone https://git-wip-us.apache.org/repos/asf/karaf.git karaf
 ----
 mvn clean install
 ----
-NB: you can speed up the build by bypassing the unit tests:
+Note: you can speed up the build by bypassing the unit and integration tests:
 ----
 mvn clean install -DskipTests
 ----
-. You can find the built binary distribution in `assemblies/apache-karaf/target/apache-karaf-3.0.0.tar.gz`. You can install and use it as explained in the "Using Apache Karaf binary distributions" section.
+. You can find the built binary distribution in `assemblies/apache-karaf/target/apache-karaf-n.n.n.tar.gz`. You can install and use it as explained in the "Using Apache Karaf binary distributions" section.


### PR DESCRIPTION
Fixed miscellaneous phrasing issues. Clarified PATH vs. JAVA_HOME install requirements, and moved this to "post-install", as it's not required for installation.  Replaced explicit reference to "3.0.0" in the version to "n.n.n". Changed Maven version requirement from 3.0.4 to 3.0.3 (or newer). Changed "NB" to more common "Note".