### PR TITLE
[KARAF-3262] feature configfile: substitution

### DIFF
--- a/features/core/src/test/java/org/apache/karaf/features/internal/service/FeatureConfigInstallerTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/service/FeatureConfigInstallerTest.java
@@ -1,0 +1,35 @@
+package org.apache.karaf.features.internal.service;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+public class FeatureConfigInstallerTest {
+    
+    private void substEqual(final String src, final String subst) {
+        assertEquals(FeatureConfigInstaller.substFinalName(src), subst);
+    }
+
+    @Test
+    public void testSubstFinalName() {
+        final String karafBase = "/tmp/karaf.base";
+        final String foo = "/foo";
+        
+        System.setProperty("karaf.base", karafBase);
+        System.setProperty("foo", foo);
+        
+        substEqual("etc/test.cfg", karafBase + File.separator + "etc/test.cfg");
+        substEqual("/etc/test.cfg", karafBase + File.separator + "/etc/test.cfg");
+        substEqual("${karaf.base}/etc/test.cfg", karafBase + "/etc/test.cfg");
+        substEqual("etc/${foo}/test.cfg", karafBase + File.separator + "etc/" + foo + "/test.cfg");
+        substEqual("${foo}/test.cfg", foo + "/test.cfg");
+        substEqual("etc${bar}/${bar}test.cfg", karafBase + File.separator + "etc/test.cfg");
+        substEqual("${bar}/etc/test.cfg${bar}", karafBase + File.separator + "/etc/test.cfg");
+        substEqual("${karaf.base}${bar}/etc/test.cfg", karafBase + "/etc/test.cfg");
+        substEqual("etc${}/${foo}/test.cfg", karafBase + File.separator + "etc//test.cfg");
+        substEqual("${foo}${bar}/${bar}${foo}", foo + "/" + foo);
+    }
+
+}


### PR DESCRIPTION
Add variable substitution to the configfile finalname of a feature.

Old situation:
* All ${...} are removed from the config file name and not used.
* The given path is prefixed with / relative to ${karaf.base} on
  installation

New behaviour:
* If the final name starts not with "${", the path is prefixed with /
  relative to karaf.base.
* All ${...} are substituted.
* If the substituted string starts with an variable (the first one
* has
  been unknown), it is prefixed with / relative to karaf.base.
* All unknown variables are removed from the resulting final name.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>

Here some testing:
```java
public static void main(String[] args) {
    System.setProperty("karaf.base", "/tmp/karaf.base");
    System.setProperty("foo1", "/foo1");
    
    final String[] finalNames = {
            "etc/test.cfg",
            "/etc/test.cfg",
            "${karaf.base}/etc/test.cfg",
            "etc/${foo1}/test.cfg",
            "${foo1}/test.cfg",
            "etc${foo2}/${foo2}test.cfg",
            "${foo2}/etc/test.cfg${foo2}",
            "${karaf.base}${foo2}/etc/test.cfg",
            "etc${}/${foo1}/test.cfg",
            "${foo1}/test.cfg",
    };
    
    for (final String finalName : finalNames) {
        System.out.println(finalName + " => " + substFinalName(finalName));
    }
}
```

Result (the exception is catched, kept logging):
```java
etc/test.cfg => /tmp/karaf.base/etc/test.cfg
/etc/test.cfg => /tmp/karaf.base//etc/test.cfg
${karaf.base}/etc/test.cfg => /tmp/karaf.base/etc/test.cfg
etc/${foo1}/test.cfg => /tmp/karaf.base/etc//foo1/test.cfg
${foo1}/test.cfg => /foo1/test.cfg
etc${foo2}/${foo2}test.cfg => /tmp/karaf.base/etc/test.cfg
${foo2}/etc/test.cfg${foo2} => /tmp/karaf.base//etc/test.cfg
${karaf.base}${foo2}/etc/test.cfg => /tmp/karaf.base/etc/test.cfg
etc${}/${foo1}/test.cfg => /tmp/karaf.base/etc//test.cfg
Oct 06, 2015 10:57:43 AM org.apache.karaf.features.internal.service.FeatureConfigInstaller substFinalName
WARNING: Skip substitution of variables of configuration final name (etc${}/${foo1}/test.cfg).
java.lang.IllegalArgumentException: recursive variable reference: 
	at org.apache.felix.utils.properties.InterpolationHelper.doSubstVars(InterpolationHelper.java:319)
	at org.apache.felix.utils.properties.InterpolationHelper.substVars(InterpolationHelper.java:235)
	at org.apache.karaf.features.internal.service.FeatureConfigInstaller.substFinalName(FeatureConfigInstaller.java:180)
	at org.apache.karaf.features.internal.service.FeatureConfigInstaller.main(FeatureConfigInstaller.java:157)

${foo1}/test.cfg => /foo1/test.cfg
```