### PR TITLE
Fixes KARAF-4091: Support restarting the Karaf JVM and updating it's …

### DIFF
--- a/assemblies/features/base/src/main/resources/resources/bin/karaf
+++ b/assemblies/features/base/src/main/resources/resources/bin/karaf
@@ -417,7 +417,42 @@ run() {
     fi
     cd "$KARAF_BASE"
 
-    exec "$JAVA" $JAVA_OPTS -Djava.endorsed.dirs="${JAVA_ENDORSED_DIRS}" -Djava.ext.dirs="${JAVA_EXT_DIRS}" -Dkaraf.instances="${KARAF_HOME}/instances" -Dkaraf.home="$KARAF_HOME" -Dkaraf.base="$KARAF_BASE" -Dkaraf.data="$KARAF_DATA" -Dkaraf.etc="$KARAF_ETC" -Djava.io.tmpdir="$KARAF_DATA/tmp" -Djava.util.logging.config.file="$KARAF_BASE/etc/java.util.logging.properties" $KARAF_OPTS $OPTS -classpath "$CLASSPATH" $MAIN "$@"
+    if [ -z "$KARAF_EXEC" ]; then
+        KARAF_EXEC=""
+        JAVA_OPTS="$JAVA_OPTS -Dkaraf.restart.jvm.supported=true"
+    fi
+    while true; do
+ 
+        # When users want to update the lib version of, they just need to create
+        # a lib.next directory and on the new restart, it will replace the current lib directory.
+        if [ -d ${KARAF_HOME}/lib.next ] ; then
+            echo "Updating libs..."
+            rm -rf "${KARAF_HOME}/lib"
+            mv -f "${KARAF_HOME}/lib.next" "${KARAF_HOME}/lib"
+        fi
+ 
+        $KARAF_EXEC "$JAVA" $JAVA_OPTS \
+           -classpath "$CLASSPATH" \
+           -Djava.endorsed.dirs="${JAVA_ENDORSED_DIRS}" \
+           -Djava.ext.dirs="${JAVA_EXT_DIRS}" \
+           -Dkaraf.instances="${KARAF_HOME}/instances" \
+           -Dkaraf.home="$KARAF_HOME" \
+           -Dkaraf.base="$KARAF_BASE" \
+           -Dkaraf.data="$KARAF_DATA" \
+           -Dkaraf.etc="$KARAF_ETC" \
+           -Djava.io.tmpdir="$KARAF_DATA/tmp" \
+           -Djava.util.logging.config.file="$KARAF_BASE/etc/java.util.logging.properties" \
+           $KARAF_OPTS $OPTS \
+           $MAIN "$@"
+
+        KARAF_RC=$?
+        if [ "$KARAF_RC" -eq 10 ]; then
+           echo "Restarting JVM..."
+        else
+           exit $KARAF_RC
+        fi
+    done
+
 }
 
 main() {

--- a/assemblies/features/base/src/main/resources/resources/bin/karaf.bat
+++ b/assemblies/features/base/src/main/resources/resources/bin/karaf.bat
@@ -327,7 +327,34 @@ if "%KARAF_PROFILER%" == "" goto :RUN
     SET ARGS=%1 %2 %3 %4 %5 %6 %7 %8
     rem Execute the Java Virtual Machine
     cd "%KARAF_BASE%"
-    "%JAVA%" %JAVA_OPTS% %OPTS% -classpath "%CLASSPATH%" -Djava.endorsed.dirs="%JAVA_HOME%\jre\lib\endorsed;%JAVA_HOME%\lib\endorsed;%KARAF_HOME%\lib\endorsed" -Djava.ext.dirs="%JAVA_HOME%\jre\lib\ext;%JAVA_HOME%\lib\ext;%KARAF_HOME%\lib\ext" -Dkaraf.instances="%KARAF_HOME%\instances" -Dkaraf.home="%KARAF_HOME%" -Dkaraf.base="%KARAF_BASE%" -Dkaraf.etc="%KARAF_ETC%" -Djava.io.tmpdir="%KARAF_DATA%\tmp" -Dkaraf.data="%KARAF_DATA%" -Djava.util.logging.config.file="%KARAF_BASE%\etc\java.util.logging.properties" %KARAF_OPTS% %MAIN% %ARGS%
+
+    rem When users want to update the lib version of, they just need to create
+    rem a lib.next directory and on the new restart, it will replace the current lib directory.
+    if exist "%KARAF_HOME%\lib.next" (
+        echo Updating libs...
+        RD /S /Q "%KARAF_HOME%\lib"
+        MOVE /Y "%KARAF_HOME%\lib.next" "%KARAF_HOME%\lib"
+    )
+    
+    "%JAVA%" %JAVA_OPTS% %OPTS% ^
+      -classpath "%CLASSPATH%" ^
+      -Dkaraf.restart.jvm.supported=true ^
+      -Djava.endorsed.dirs="%JAVA_HOME%\jre\lib\endorsed;%JAVA_HOME%\lib\endorsed;%KARAF_HOME%\lib\endorsed" ^
+      -Djava.ext.dirs="%JAVA_HOME%\jre\lib\ext;%JAVA_HOME%\lib\ext;%KARAF_HOME%\lib\ext" ^
+      -Dkaraf.instances="%KARAF_HOME%\instances" ^
+      -Dkaraf.home="%KARAF_HOME%" ^
+      -Dkaraf.base="%KARAF_BASE%" ^
+      -Dkaraf.etc="%KARAF_ETC%" ^
+      -Djava.io.tmpdir="%KARAF_DATA%\tmp" ^
+      -Dkaraf.data="%KARAF_DATA%" ^
+      -Djava.util.logging.config.file="%KARAF_BASE%\etc\java.util.logging.properties" ^
+      %KARAF_OPTS% ^
+      %MAIN% %ARGS%
+
+    if ERRORLEVEL 10 (
+        echo Restarting JVM...
+        goto EXECUTE
+    )
 
 rem # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/main/src/main/java/org/apache/karaf/main/Main.java
+++ b/main/src/main/java/org/apache/karaf/main/Main.java
@@ -169,6 +169,9 @@ public class Main {
     public static void main(String[] args) throws Exception {
         while (true) {
             boolean restart = false;
+            boolean restartJvm = false;
+            // karaf.restart.jvm take priority over karaf.restart
+            System.setProperty("karaf.restart.jvm", "false");
             System.setProperty("karaf.restart", "false");
             final Main main = new Main(args);
             try {
@@ -185,6 +188,7 @@ public class Main {
                 main.awaitShutdown();
                 boolean stopped = main.destroy();
                 restart = Boolean.getBoolean("karaf.restart");
+                restartJvm = Boolean.getBoolean("karaf.restart.jvm");
                 main.updateInstancePidAfterShutdown();
                 if (!stopped) {
                     if (restart) {
@@ -199,7 +203,9 @@ public class Main {
                 System.err.println("Error occurred shutting down framework: " + ex);
                 ex.printStackTrace();
             } finally {
-                if (!restart) {
+                if ( restartJvm) {
+                    System.exit(10);
+                } else if (!restart) {
                     System.exit(main.getExitCode());
                 } else {
                     System.gc();


### PR DESCRIPTION
…lib directory

The karaf.restart.jvm.supported=true system property will be set if restarting the JVM is supported.  If karaf is shutdown and the karaf.restart.jvm=true system property is set, then karaf will exit with error code = 10.  The shell scripts will check for this error code and restart Karaf.

On unix, sometimes it's desirable to give up this feature so that the JVM process can be 'exec'ed by the shell script for simpler process management (For example if your running in a Docker container).  In these cases you can set the KARAF_EXEC=exec env var to return to the current behavior of using exec to launch the java process.