### PR TITLE
[KARAF-4127] Missing license in Karaf-maven-plugin test-rename-main-f…

### DIFF
--- a/tooling/karaf-maven-plugin/src/it/test-rename-main-feature/control.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-rename-main-feature/control.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" name="test-rename-project-artifact">
     <feature name="test-feature" description="test-rename-project-artifact" version="1.0.0.SNAPSHOT">
         <bundle>mvn:test/test-rename-project-artifact/1.0-SNAPSHOT</bundle>


### PR DESCRIPTION
…eature file

Hi all,

This PR is related to:
https://issues.apache.org/jira/browse/KARAF-4127

Andrea