### PR TITLE
Fix to allow for relative URLs from a Cave repository.

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/region/SubsystemResolveContext.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/region/SubsystemResolveContext.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import org.apache.karaf.features.FeaturesService;
 import org.apache.karaf.features.internal.download.Downloader;
 import org.apache.karaf.features.internal.repository.BaseRepository;
+import org.apache.karaf.features.internal.repository.XmlRepository;
 import org.apache.karaf.features.internal.resolver.CapabilityImpl;
 import org.apache.karaf.features.internal.resolver.RequirementImpl;
 import org.apache.karaf.features.internal.resolver.ResolverUtil;
@@ -50,6 +51,7 @@ import org.osgi.service.resolver.HostedCapability;
 import org.osgi.service.resolver.ResolveContext;
 
 import static org.apache.karaf.features.internal.resolver.ResourceUtils.addIdentityRequirement;
+import static org.apache.karaf.features.internal.resolver.ResourceUtils.addRepoLocation;
 import static org.apache.karaf.features.internal.resolver.ResourceUtils.getUri;
 import static org.eclipse.equinox.region.RegionFilter.VISIBLE_BUNDLE_NAMESPACE;
 import static org.osgi.framework.Constants.BUNDLE_SYMBOLICNAME_ATTRIBUTE;
@@ -371,8 +373,14 @@ public class SubsystemResolveContext extends ResolveContext {
             }
             addIdentityRequirement(wrapped, subsystem, false);
             resToSub.put(wrapped, subsystem);
-            // TODO: use RepositoryContent ?
-            try {
+            // If the repository if of type XmlRepository, then it is our own internal format
+            if (repository instanceof XmlRepository) {
+                XmlRepository xmlRepository = (XmlRepository)repository;
+                String url = xmlRepository.getUrl();
+                String location = url.substring(0, url.lastIndexOf( "/" ) + 1);
+                addRepoLocation( wrapped, location );
+            }
+            try {                
                 downloader.download(getUri(wrapped), null);
             } catch (MalformedURLException e) {
                 throw new IllegalStateException("Unable to download resource: " + getUri(wrapped));

--- a/features/core/src/main/java/org/apache/karaf/features/internal/resolver/ResourceUtils.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/resolver/ResourceUtils.java
@@ -16,6 +16,8 @@
  */
 package org.apache.karaf.features.internal.resolver;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +44,8 @@ public final class ResourceUtils {
 
     public static final String TYPE_FEATURE = "karaf.feature";
 
+    public static final String REPO_NAMESPACE = "karaf.repo";
+
     private ResourceUtils() {
     }
 
@@ -55,14 +59,42 @@ public final class ResourceUtils {
         return null;
     }
 
+    public static void addRepoLocation(ResourceImpl resource, String location)
+    {
+        Map<String, String> dirs = new HashMap<>();
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(CAPABILITY_URL_ATTRIBUTE, location);
+        CapabilityImpl capability = new CapabilityImpl( resource, REPO_NAMESPACE, dirs, attrs );
+        resource.addCapability( capability );
+    }
+
+    // TODO: Correct name should probably be toUrl
     public static String getUri(Resource resource) {
         List<Capability> caps = resource.getCapabilities(null);
+        String location = null;
+        String url = null;
         for (Capability cap : caps) {
+            if (cap.getNamespace().equals(REPO_NAMESPACE)) {
+                location = cap.getAttributes().get(CAPABILITY_URL_ATTRIBUTE).toString();
+            }
             if (cap.getNamespace().equals(CONTENT_NAMESPACE)) {
-                return cap.getAttributes().get(CAPABILITY_URL_ATTRIBUTE).toString();
+                url = cap.getAttributes().get(CAPABILITY_URL_ATTRIBUTE).toString();
             }
         }
-        return null;
+
+        // If there is no location value, then just return the saved URL
+        if (location == null) {
+            return url;
+        }
+
+        // If the saved is absolute (i.e. well-formed), then return it
+        try {
+            new URL(url);
+            return url;
+        } catch (MalformedURLException e) {
+            // The URL is relative, so return the absolute URL 
+            return location + url;
+        }
     }
 
     public static String getFeatureId(Resource resource) {


### PR DESCRIPTION
Perhaps the correct fix would be to somehow have the Repository service serve the correct URLs, but since this is internal to the bundle, and since this fix is much simpler, I went with this approach.

It does not break the existing tests, and it works for me, but perhaps more thorough testing may be required at some point.