### PR TITLE
[KARAF-4218] Mark Principal classes as Serializable

### DIFF
--- a/jaas/boot/src/main/java/org/apache/karaf/jaas/boot/principal/GroupPrincipal.java
+++ b/jaas/boot/src/main/java/org/apache/karaf/jaas/boot/principal/GroupPrincipal.java
@@ -14,17 +14,19 @@
  */
 package org.apache.karaf.jaas.boot.principal;
 
+import java.io.Serializable;
 import java.security.Principal;
 import java.security.acl.Group;
 import java.util.Enumeration;
 import java.util.Hashtable;
 
-public class GroupPrincipal implements Group {
+public class GroupPrincipal implements Group, Serializable {
+    private static final long serialVersionUID = 1L;
 
     private String name;
 
     private Hashtable<String,Principal> members = new Hashtable<String, Principal>();
-    
+
     public GroupPrincipal(String name) {
         assert name != null;
         this.name = name;

--- a/jaas/boot/src/main/java/org/apache/karaf/jaas/boot/principal/RolePrincipal.java
+++ b/jaas/boot/src/main/java/org/apache/karaf/jaas/boot/principal/RolePrincipal.java
@@ -16,9 +16,11 @@
  */
 package org.apache.karaf.jaas.boot.principal;
 
+import java.io.Serializable;
 import java.security.Principal;
 
-public class RolePrincipal implements Principal {
+public class RolePrincipal implements Principal, Serializable {
+    private static final long serialVersionUID = 1L;
 
     private final String name;
 

--- a/jaas/boot/src/main/java/org/apache/karaf/jaas/boot/principal/UserPrincipal.java
+++ b/jaas/boot/src/main/java/org/apache/karaf/jaas/boot/principal/UserPrincipal.java
@@ -16,9 +16,11 @@
  */
 package org.apache.karaf.jaas.boot.principal;
 
+import java.io.Serializable;
 import java.security.Principal;
 
-public class UserPrincipal implements Principal {
+public class UserPrincipal implements Principal, Serializable {
+    private static final long serialVersionUID = 1L;
 
     private final String name;
 


### PR DESCRIPTION
This fixes an issue regarding serializability of sessions when using karaf along with hawtio.  I am sure a number of other applications that would require some sort of clustering involving serialized instances of javax.security.auth.Subject (container of Principal) would benefit as well.