### PR TITLE
[KARAF-4156] [karaf-3.0.x] set 'karaf.clean.all' as true will cause d…

### DIFF
--- a/main/src/main/java/org/apache/karaf/main/ConfigProperties.java
+++ b/main/src/main/java/org/apache/karaf/main/ConfigProperties.java
@@ -197,24 +197,6 @@ public class ConfigProperties {
         }
         PropertiesLoader.loadSystemProperties(new File(karafEtc, SYSTEM_PROPERTIES_FILE_NAME));
 
-        File cleanAllIndicatorFile = new File(karafData, "clean_all");
-        File cleanCacheIndicatorFile = new File(karafData, "clean_cache");
-        if (Boolean.getBoolean("karaf.clean.all") || cleanAllIndicatorFile.exists()) {
-            if (cleanAllIndicatorFile.exists()) {
-                cleanAllIndicatorFile.delete();
-            }
-            Utils.deleteDirectory(this.karafData);
-            this.karafData = Utils.getKarafDirectory(PROP_KARAF_DATA, ENV_KARAF_DATA, new File(karafBase, "data"), true, true);
-        } else {
-            if (Boolean.getBoolean("karaf.clean.cache") || cleanCacheIndicatorFile.exists()) {
-                if (cleanCacheIndicatorFile.exists()) {
-                    cleanCacheIndicatorFile.delete();
-                }
-                File karafCache = Utils.validateDirectoryExists(new File(karafData, "cache").getPath(), "Invalid cache directory", true, true);
-                Utils.deleteDirectory(karafCache);
-            }
-        }
-
         File file = new File(karafEtc, CONFIG_PROPERTIES_FILE_NAME);
         this.props = PropertiesLoader.loadConfigProperties(file);
 
@@ -254,6 +236,26 @@ public class ConfigProperties {
             }
         }
     }
+
+	public void conditionalCleanDataFolder() throws IOException {
+		File cleanAllIndicatorFile = new File(karafData, "clean_all");
+        File cleanCacheIndicatorFile = new File(karafData, "clean_cache");
+        if (Boolean.getBoolean("karaf.clean.all") || cleanAllIndicatorFile.exists()) {
+            if (cleanAllIndicatorFile.exists()) {
+                cleanAllIndicatorFile.delete();
+            }
+            Utils.deleteDirectory(this.karafData);
+            this.karafData = Utils.getKarafDirectory(PROP_KARAF_DATA, ENV_KARAF_DATA, new File(karafBase, "data"), true, true);
+        } else {
+            if (Boolean.getBoolean("karaf.clean.cache") || cleanCacheIndicatorFile.exists()) {
+                if (cleanCacheIndicatorFile.exists()) {
+                    cleanCacheIndicatorFile.delete();
+                }
+                File karafCache = Utils.validateDirectoryExists(new File(karafData, "cache").getPath(), "Invalid cache directory", true, true);
+                Utils.deleteDirectory(karafCache);
+            }
+        }
+	}
     
     private String getPropertyOrFail(String propertyName) {
         String value = props.getProperty(propertyName);

--- a/main/src/main/java/org/apache/karaf/main/Main.java
+++ b/main/src/main/java/org/apache/karaf/main/Main.java
@@ -231,6 +231,7 @@ public class Main {
 
     public void launch() throws Exception {
         config = new ConfigProperties();
+        config.conditionalCleanDataFolder();
         if (config.delayConsoleStart) {
             System.out.println(config.startupMessage);
         }
@@ -296,7 +297,7 @@ public class Main {
         framework.init();
         framework.getBundleContext().addFrameworkListener(lockCallback);
         framework.start();
-
+        
         FrameworkStartLevel sl = framework.adapt(FrameworkStartLevel.class);
         sl.setInitialBundleStartLevel(config.defaultBundleStartlevel);
 


### PR DESCRIPTION
…ata folder cleaned while checking status

Hi all,

This PR is related to:
https://issues.apache.org/jira/browse/KARAF-4156

I hope it is better than the last one :-)

I think it has to be merged on karaf-3.0.x branch too.

Andrea