### PR TITLE
[KARAF-4241] Karaf clean doesn't work if KARAF_DATA and KARAF_BASE point to same dir

### DIFF
--- a/assemblies/features/base/src/main/resources/resources/bin/karaf
+++ b/assemblies/features/base/src/main/resources/resources/bin/karaf
@@ -369,7 +369,7 @@ run() {
     while [ "$1" != "" ]; do
         case $1 in
             'clean')
-                rm -Rf "$KARAF_DATA"
+                rm -Rf "$KARAF_DATA/**"
                 shift
                 ;;
             'debug')

--- a/assemblies/features/base/src/main/resources/resources/bin/karaf.bat
+++ b/assemblies/features/base/src/main/resources/resources/bin/karaf.bat
@@ -314,7 +314,7 @@ if "%KARAF_PROFILER%" == "" goto :RUN
     goto :RUN_LOOP
 
 :EXECUTE_CLEAN
-    rmdir /S /Q "%KARAF_DATA%"
+    pushd "%KARAF_DATA%" && (rmdir /S /Q "%KARAF_DATA%" 2>nul & popd)
     shift
     goto :RUN_LOOP
 


### PR DESCRIPTION
Delete only the content of KARAF_DATA and not the folder itself when starting with clean option.

Signed-off-by: Davy Vanherbergen <davy.vanherbergen@gmail.com>