### PR TITLE
K40x - CommandTracker: handle getDescription() fallback consistently

### DIFF
--- a/shell/console/src/main/java/org/apache/karaf/shell/compat/CommandTracker.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/compat/CommandTracker.java
@@ -190,7 +190,7 @@ public class CommandTracker implements ServiceTrackerCustomizer<Object, Object> 
                             if (property != null) {
                                 return property.toString();
                             } else {
-                                return null;
+                                return getName();
                             }
                         }
 


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/KARAF-4270?focusedCommentId=15141760
Related to: #129