### PR TITLE
[KARAF-4330] Instance script doesn't return correct PID number if roo…

### DIFF
--- a/main/src/main/java/org/apache/karaf/main/InstanceHelper.java
+++ b/main/src/main/java/org/apache/karaf/main/InstanceHelper.java
@@ -95,14 +95,12 @@ public class InstanceHelper {
                             int count = Integer.parseInt(props.getProperty("count"));
                             for (int i = 0; i < count; i++) {
                                 String name = props.getProperty("item." + i + ".name");
-                                if (name.equals(instanceName)) {
+                                boolean isRootInstance = Boolean.parseBoolean(props.getProperty("item." + i + ".root"));
+                                if (name.equals(instanceName) && !isRootInstance) {
                                     props.setProperty("item." + i + ".pid", pid);
                                     return;
                                 }
                             }
-                            // it's not found, let assume it's the root instance, so 0
-                            props.setProperty("item.0.name", instanceName);
-                            props.setProperty("item.0.pid", pid);
                         }
                     }
                 }, true);


### PR DESCRIPTION
…t instance is started two times

I submit this little PR for review. In case we start root instance two times, the instance script trace the second instance PID even if the process is hanging because of the first instance.

If it's ok for everyone I'll push this on master, 4.0.x and perhaps on 3.0.x.

I'm waiting for your feedback :-) Thanks.

Andrea