### PR TITLE
KARAF-4457 - Upgrade pax web to version 3.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <pax.logging.version>1.8.4</pax.logging.version>
         <pax.base.version>1.5.0</pax.base.version>
         <pax.url.version>2.4.5</pax.url.version>
-        <pax.web.version>3.2.6</pax.web.version>
+        <pax.web.version>3.2.7</pax.web.version>
         <pax.tinybundle.version>2.1.0</pax.tinybundle.version>
         <portlet-api.version>2.0</portlet-api.version>
         <slf4j.version>1.7.12</slf4j.version>


### PR DESCRIPTION
Version 3.2.7 of pax web includes the capability to blacklist certain crypto
protocols.  This is extremely useful from a security perspective, as it allows
blacklisting of SSLv3 and TLS, which are vulnerable to exploit.

Signed-off-by: Ryan Goulding <ryandgoulding@gmail.com>