### PR TITLE
[KARAF-4524] Add missing jdk's sctp classes to jre.properties

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
+++ b/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
@@ -345,7 +345,8 @@ jre-1.7= \
  org.w3c.dom.xpath, \
  org.xml.sax, \
  org.xml.sax.ext, \
- org.xml.sax.helpers
+ org.xml.sax.helpers, \
+ com.sun.nio.sctp
 
 jre-1.8= \
  javax.accessibility, \
@@ -539,4 +540,5 @@ jre-1.8= \
  org.w3c.dom.xpath, \
  org.xml.sax, \
  org.xml.sax.ext, \
- org.xml.sax.helpers
+ org.xml.sax.helpers, \
+ com.sun.nio.sctp

--- a/assemblies/features/base/src/main/resources/resources/bin/contrib/karaf-service-template.solaris-smf
+++ b/assemblies/features/base/src/main/resources/resources/bin/contrib/karaf-service-template.solaris-smf
@@ -38,7 +38,7 @@
         <method_context>
             <method_credential user='${KARAF_SERVICE_USER}' group='${KARAF_SERVICE_GROUP}'/>
             <method_environment>
-                <envvar name="JAVA_HOME" value="/usr/java"/>
+                <envvar name="JAVA_HOME" value="${JAVA_HOME}"/>
             </method_environment>
         </method_context>
 

--- a/assemblies/features/base/src/main/resources/resources/bin/contrib/karaf-service.sh
+++ b/assemblies/features/base/src/main/resources/resources/bin/contrib/karaf-service.sh
@@ -137,7 +137,22 @@ function generate_service_descriptor {
 if [[ ! $KARAF_SERVICE_TEMPLATE ]]; then
     case $(uname | tr [:upper:] [:lower:]) in
         sunos)
-            # smc vs initv
+            # add KARAF_ENV vars to envirioment
+            for var in "${KARAF_ENV[@]}"; do
+                export $var
+            done
+
+            # Default java path if not set
+            if [[ ! $JAVA_HOME ]]; then
+                export JAVA_HOME=/usr/java
+            fi
+
+            # escape spaces in path
+            export KARAF_SERVICE_PATH="$(echo $KARAF_SERVICE_PATH | sed 's/ /\\ /g')"
+            export KARAF_SERVICE_DATA="$(echo $KARAF_SERVICE_DATA | sed 's/ /\\ /g')"
+            export KARAF_SERVICE_CONF="$(echo $KARAF_SERVICE_CONF | sed 's/ /\\ /g')"
+            export KARAF_SERVICE_PIDFILE="$(echo $KARAF_SERVICE_PIDFILE | sed 's/ /\\ /g')"
+            
             generate_service_descriptor \
                 "$SOLARIS_SMF_TEMPLATE" \
                 "${PWD}/${KARAF_SERVICE_NAME}.xml"

--- a/main/src/test/resources/test-karaf-home/etc/jre.properties
+++ b/main/src/test/resources/test-karaf-home/etc/jre.properties
@@ -345,7 +345,8 @@ jre-1.7= \
  org.w3c.dom.xpath, \
  org.xml.sax, \
  org.xml.sax.ext, \
- org.xml.sax.helpers
+ org.xml.sax.helpers, \
+ com.sun.nio.sctp
 
 jre-1.8= \
  javax.accessibility, \
@@ -539,4 +540,5 @@ jre-1.8= \
  org.w3c.dom.xpath, \
  org.xml.sax, \
  org.xml.sax.ext, \
- org.xml.sax.helpers
+ org.xml.sax.helpers, \
+ com.sun.nio.sctp


### PR DESCRIPTION
JDK is using com.sun.nio.sctp package for sctp support which is not in jre.properties.