### PR TITLE
Improve feature construction in karaf-maven-plugin

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/model/Dependency.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/model/Dependency.java
@@ -59,6 +59,15 @@ public class Dependency implements org.apache.karaf.features.Dependency {
     @XmlAttribute
     protected String version;
 
+    public Dependency() {
+        // Nothing to do
+    }
+
+    public Dependency(String name, String version) {
+        this.value = name;
+        this.version = version;
+    }
+
     /**
      * 
      * Feature name should be non empty string.
@@ -116,6 +125,26 @@ public class Dependency implements org.apache.karaf.features.Dependency {
     public String toString() {
     	String ret = getName() + Feature.SPLIT_FOR_NAME_AND_VERSION + getVersion();
     	return ret;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Dependency dependency = (Dependency) o;
+
+        if (value != null ? !value.equals(dependency.value) : dependency.value != null) return false;
+        if (version != null ? !version.equals(dependency.version) : dependency.version != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = value != null ? value.hashCode() : 0;
+        result = 31 * result + (version != null ? version.hashCode() : 0);
+        return result;
     }
 
 }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -49,6 +49,7 @@ import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.xml.sax.SAXException;
 
 import static org.apache.karaf.deployer.kar.KarArtifactInstaller.FEATURE_CLASSIFIER;
@@ -338,51 +339,60 @@ public class GenerateDescriptorMojo extends AbstractLogEnabled implements Mojo {
             }
             feature.getBundle().add(bundle);
         }
-        for (Map.Entry<?, String> entry : localDependencies.entrySet()) {
-            Object artifact = entry.getKey();
 
+        // First pass to look for features
+        // Track other features we depend on
+        Map<Dependency, Feature> otherFeatures = new HashMap<Dependency, Feature>();
+        for (Object artifact : localDependencies.keySet()) {
             if (excludedArtifactIds.contains(this.dependencyHelper.getArtifactId(artifact))) {
                 continue;
             }
 
-            if (this.dependencyHelper.isArtifactAFeature(artifact)) {
-                if (aggregateFeatures && FEATURE_CLASSIFIER.equals(this.dependencyHelper.getClassifier(artifact))) {
-                    File featuresFile = this.dependencyHelper.resolve(artifact, getLog());
-                    if (featuresFile == null || !featuresFile.exists()) {
-                        throw new MojoExecutionException("Cannot locate file for feature: " + artifact + " at " + featuresFile);
-                    }
-                    Features includedFeatures = readFeaturesFile(featuresFile);
-                    //TODO check for duplicates?
-                    features.getFeature().addAll(includedFeatures.getFeature());
-                }
-            } else if (addBundlesToPrimaryFeature) {
-                String bundleName = this.dependencyHelper.artifactToMvn(artifact);
-                File bundleFile = this.dependencyHelper.resolve(artifact, getLog());
-                Manifest manifest = getManifest(bundleFile);
+            processFeatureArtifact(features, feature, otherFeatures, artifact, true);
+        }
 
-                if (manifest == null || !ManifestUtils.isBundle(getManifest(bundleFile))) {
-                    bundleName = "wrap:" + bundleName;
+        // Second pass to look for bundles
+        if (addBundlesToPrimaryFeature) {
+            for (Map.Entry<?, String> entry : localDependencies.entrySet()) {
+                Object artifact = entry.getKey();
+
+                if (excludedArtifactIds.contains(this.dependencyHelper.getArtifactId(artifact))) {
+                    continue;
                 }
 
-                Bundle bundle = null;
-                for (Bundle b : feature.getBundle()) {
-                    if (bundleName.equals(b.getLocation())) {
-                        bundle = b;
-                        break;
+                if (!this.dependencyHelper.isArtifactAFeature(artifact)) {
+                    String bundleName = this.dependencyHelper.artifactToMvn(artifact);
+                    File bundleFile = this.dependencyHelper.resolve(artifact, getLog());
+                    Manifest manifest = getManifest(bundleFile);
+
+                    if (manifest == null || !ManifestUtils.isBundle(getManifest(bundleFile))) {
+                        bundleName = "wrap:" + bundleName;
                     }
-                }
-                if (bundle == null) {
-                    bundle = objectFactory.createBundle();
-                    bundle.setLocation(bundleName);
-                    if (!"provided".equals(entry.getValue()) || !ignoreScopeProvided) {
-                        feature.getBundle().add(bundle);
+
+                    Bundle bundle = null;
+                    for (Bundle b : feature.getBundle()) {
+                        if (bundleName.equals(b.getLocation())) {
+                            bundle = b;
+                            break;
+                        }
                     }
-                }
-                if ("runtime".equals(entry.getValue())) {
-                    bundle.setDependency(true);
-                }
-                if (startLevel != null && bundle.getStartLevel() == 0) {
-                    bundle.setStartLevel(startLevel);
+                    if (bundle == null) {
+                        bundle = objectFactory.createBundle();
+                        bundle.setLocation(bundleName);
+                        // Check the features this feature depends on don't already contain the dependency
+                        // TODO Perhaps only for transitive dependencies?
+                        boolean includedTransitively =
+                                isBundleIncludedTransitively(feature, otherFeatures, bundle);
+                        if (!includedTransitively && (!"provided".equals(entry.getValue()) || !ignoreScopeProvided)) {
+                            feature.getBundle().add(bundle);
+                        }
+                    }
+                    if ("runtime".equals(entry.getValue())) {
+                        bundle.setDependency(true);
+                    }
+                    if (startLevel != null && bundle.getStartLevel() == 0) {
+                        bundle.setStartLevel(startLevel);
+                    }
                 }
             }
         }
@@ -398,6 +408,57 @@ public class GenerateDescriptorMojo extends AbstractLogEnabled implements Mojo {
             throw new MojoExecutionException("Features contents have changed", e);
         }
         getLogger().info("...done!");
+    }
+
+    private void processFeatureArtifact(Features features, Feature feature, Map<Dependency, Feature> otherFeatures,
+                                        Object artifact, boolean add)
+            throws MojoExecutionException, XMLStreamException, JAXBException, IOException {
+        if (this.dependencyHelper.isArtifactAFeature(artifact) && FEATURE_CLASSIFIER.equals(
+                this.dependencyHelper.getClassifier(artifact))) {
+            File featuresFile = this.dependencyHelper.resolve(artifact, getLog());
+            if (featuresFile == null || !featuresFile.exists()) {
+                throw new MojoExecutionException(
+                        "Cannot locate file for feature: " + artifact + " at " + featuresFile);
+            }
+            Features includedFeatures = readFeaturesFile(featuresFile);
+            for (String repository : includedFeatures.getRepository()) {
+                processFeatureArtifact(features, feature, otherFeatures,
+                        new DefaultArtifact(MavenUtil.mvnToAether(repository)), false);
+            }
+            for (Feature includedFeature : includedFeatures.getFeature()) {
+                Dependency dependency = new Dependency(includedFeature.getName(), includedFeature.getVersion());
+                // We musn't de-duplicate here, we may have seen a feature in !add mode
+                otherFeatures.put(dependency, includedFeature);
+                if (add) {
+                    if (!feature.getFeature().contains(dependency)) {
+                        feature.getFeature().add(dependency);
+                    }
+                    if (aggregateFeatures) {
+                        features.getFeature().add(includedFeature);
+                    } else {
+                        // Add the feature to the repositories, if it isn't already there
+                        String mvn = this.dependencyHelper.artifactToMvn(artifact);
+                        if (!features.getRepository().contains(mvn)) {
+                            features.getRepository().add(mvn);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean isBundleIncludedTransitively(Feature feature, Map<Dependency, Feature> otherFeatures,
+                                                 Bundle bundle) {
+        for (Dependency dependency : feature.getFeature()) {
+            Feature otherFeature = otherFeatures.get(dependency);
+            if (otherFeature != null) {
+                if (isBundleIncludedTransitively(otherFeature, otherFeatures,
+                        bundle) || otherFeature.getBundle().contains(bundle)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
This adds the following features when processing a Maven project to
produce a feature:
* features the project depends on are processed first, so their
  dependencies can be taken into account;
* transitively-depended-on features are loaded;
* bundles are only added if the included features don't already
  include them;
* when not aggregating, features are added to the repositories
  (de-duplicated) [KARAF-1583].

Signed-off-by: Stephen Kitt <skitt@redhat.com>