### PR TITLE
KARAF-4564 Can't start karaf using symbolic link

### DIFF
--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/client
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/client
@@ -16,8 +16,9 @@
 #    limitations under the License.
 #
 
-DIRNAME=`dirname "$0"`
-PROGNAME=`basename "$0"`
+REALNAME=`realpath -e "$0"`
+DIRNAME=`dirname "$REALNAME"`
+PROGNAME=`basename "$REALNAME"`
 
 #
 # Sourcing environment settings for karaf similar to tomcats setenv

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/client
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/client
@@ -16,7 +16,7 @@
 #    limitations under the License.
 #
 
-REALNAME=`realpath -e "$0"`
+REALNAME=`readlink -e "$0"`
 DIRNAME=`dirname "$REALNAME"`
 PROGNAME=`basename "$REALNAME"`
 

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/instance
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/instance
@@ -16,8 +16,9 @@
 #    limitations under the License.
 #
 
-DIRNAME=`dirname "$0"`
-PROGNAME=`basename "$0"`
+REALNAME=`realpath -e "$0"`
+DIRNAME=`dirname "$REALNAME"`
+PROGNAME=`basename "$REALNAME"`
 
 #
 # Sourcing environment settings for karaf similar to tomcats setenv

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/instance
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/instance
@@ -16,7 +16,7 @@
 #    limitations under the License.
 #
 
-REALNAME=`realpath -e "$0"`
+REALNAME=`readlink -e "$0"`
 DIRNAME=`dirname "$REALNAME"`
 PROGNAME=`basename "$REALNAME"`
 

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/shell
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/shell
@@ -16,8 +16,9 @@
 #    limitations under the License.
 #
 
-DIRNAME=`dirname "$0"`
-PROGNAME=`basename "$0"`
+REALNAME=`realpath -e "$0"`
+DIRNAME=`dirname "$REALNAME"`
+PROGNAME=`basename "$REALNAME"`
 
 #
 # Sourcing environment settings for karaf similar to tomcats setenv

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/shell
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/shell
@@ -16,7 +16,7 @@
 #    limitations under the License.
 #
 
-REALNAME=`realpath -e "$0"`
+REALNAME=`readlink -e "$0"`
 DIRNAME=`dirname "$REALNAME"`
 PROGNAME=`basename "$REALNAME"`
 

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/start
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/start
@@ -16,8 +16,9 @@
 #    limitations under the License.
 #
 
-DIRNAME=`dirname "$0"`
-PROGNAME=`basename "$0"`
+REALNAME=`realpath -e "$0"`
+DIRNAME=`dirname "$REALNAME"`
+PROGNAME=`basename "$REALNAME"`
 
 #
 # Sourcing environment settings for karaf similar to tomcats setenv 

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/start
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/start
@@ -16,7 +16,7 @@
 #    limitations under the License.
 #
 
-REALNAME=`realpath -e "$0"`
+REALNAME=`readlink -e "$0"`
 DIRNAME=`dirname "$REALNAME"`
 PROGNAME=`basename "$REALNAME"`
 

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/status
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/status
@@ -16,8 +16,9 @@
 #    limitations under the License.
 #
 
-DIRNAME=`dirname "$0"`
-PROGNAME=`basename "$0"`
+REALNAME=`realpath -e "$0"`
+DIRNAME=`dirname "$REALNAME"`
+PROGNAME=`basename "$REALNAME"`
 
 #
 # Sourcing environment settings for karaf similar to tomcats setenv 

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/status
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/status
@@ -16,7 +16,7 @@
 #    limitations under the License.
 #
 
-REALNAME=`realpath -e "$0"`
+REALNAME=`readlink -e "$0"`
 DIRNAME=`dirname "$REALNAME"`
 PROGNAME=`basename "$REALNAME"`
 

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/stop
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/stop
@@ -16,8 +16,9 @@
 #    limitations under the License.
 #
 
-DIRNAME=`dirname "$0"`
-PROGNAME=`basename "$0"`
+REALNAME=`realpath -e "$0"`
+DIRNAME=`dirname "$REALNAME"`
+PROGNAME=`basename "$REALNAME"`
 
 #
 # Sourcing environment settings for karaf similar to tomcats setenv 

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/stop
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/stop
@@ -16,7 +16,7 @@
 #    limitations under the License.
 #
 
-REALNAME=`realpath -e "$0"`
+REALNAME=`readlink -e "$0"`
 DIRNAME=`dirname "$REALNAME"`
 PROGNAME=`basename "$REALNAME"`
 

--- a/assemblies/features/framework/src/main/resources/resources/bin/karaf
+++ b/assemblies/features/framework/src/main/resources/resources/bin/karaf
@@ -16,8 +16,9 @@
 #    limitations under the License.
 #
 
-DIRNAME=`dirname "$0"`
-PROGNAME=`basename "$0"`
+REALNAME=`realpath -e "$0"`
+DIRNAME=`dirname "$REALNAME"`
+PROGNAME=`basename "$REALNAME"`
 
 #
 # Sourcing environment settings for karaf similar to tomcats setenv

--- a/assemblies/features/framework/src/main/resources/resources/bin/karaf
+++ b/assemblies/features/framework/src/main/resources/resources/bin/karaf
@@ -16,7 +16,8 @@
 #    limitations under the License.
 #
 
-REALNAME=`realpath -e "$0"`
+
+REALNAME=`readlink -e "$0"`
 DIRNAME=`dirname "$REALNAME"`
 PROGNAME=`basename "$REALNAME"`
 

--- a/assemblies/features/framework/src/main/resources/resources/bin/karaf
+++ b/assemblies/features/framework/src/main/resources/resources/bin/karaf
@@ -16,7 +16,6 @@
 #    limitations under the License.
 #
 
-
 REALNAME=`readlink -e "$0"`
 DIRNAME=`dirname "$REALNAME"`
 PROGNAME=`basename "$REALNAME"`


### PR DESCRIPTION
When executing the karaf script, it gets the DIRNAME based on $0 which is the path used to start the script. This DIRNAME is then used to set the KARAF_HOME and multiple other KARAF_* env variables. 
Using a symbolic link, you would have, for instance, usr/bin/karaf redirecting to /opt/opendaylight/bin/karaf. So $0 would be usr/bin and not /opt/opendaylight/bin so the locateHome function isn't setting the right path for the KARAF_HOME. 

This ends up failing to start ODL with following 
ERROR: Error: Could not find or load main class org.apache.karaf.main.Main

Signed-off-by: Alexis de Talhouët <adetalhouet@inocybe.com>