### PR TITLE
KARAF-4566 "karaf" script invokes /bin/sh but requires /bin/bash functions

### DIFF
--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/client
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/client
@@ -162,7 +162,7 @@ setupNativePath() {
 }
 
 pathCanonical() {
-    local dst="${1}"
+    dst="${1}"
     while [ -h "${dst}" ] ; do
         ls=`ls -ld "${dst}"`
         link=`expr "$ls" : '.*-> \(.*\)$'`
@@ -172,8 +172,8 @@ pathCanonical() {
             dst="`dirname "${dst}"`/$link"
         fi
     done
-    local bas=`basename "${dst}"`
-    local dir=`dirname "${dst}"`
+    bas=`basename "${dst}"`
+    dir=`dirname "${dst}"`
     if [ "$bas" != "$dir" ]; then
         dst="`pathCanonical "$dir"`/$bas"
     fi

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/instance
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/instance
@@ -162,7 +162,7 @@ setupNativePath() {
 }
 
 pathCanonical() {
-    local dst="${1}"
+    dst="${1}"
     while [ -h "${dst}" ] ; do
         ls=`ls -ld "${dst}"`
         link=`expr "$ls" : '.*-> \(.*\)$'`
@@ -172,8 +172,8 @@ pathCanonical() {
             dst="`dirname "${dst}"`/$link"
         fi
     done
-    local bas=`basename "${dst}"`
-    local dir=`dirname "${dst}"`
+    bas=`basename "${dst}"`
+    dir=`dirname "${dst}"`
     if [ "$bas" != "$dir" ]; then
         dst="`pathCanonical "$dir"`/$bas"
     fi

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/shell
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/shell
@@ -162,7 +162,7 @@ setupNativePath() {
 }
 
 pathCanonical() {
-    local dst="${1}"
+    dst="${1}"
     while [ -h "${dst}" ] ; do
         ls=`ls -ld "${dst}"`
         link=`expr "$ls" : '.*-> \(.*\)$'`
@@ -172,8 +172,8 @@ pathCanonical() {
             dst="`dirname "${dst}"`/$link"
         fi
     done
-    local bas=`basename "${dst}"`
-    local dir=`dirname "${dst}"`
+    bas=`basename "${dst}"`
+    dir=`dirname "${dst}"`
     if [ "$bas" != "$dir" ]; then
         dst="`pathCanonical "$dir"`/$bas"
     fi

--- a/assemblies/features/framework/src/main/resources/resources/bin/karaf
+++ b/assemblies/features/framework/src/main/resources/resources/bin/karaf
@@ -165,7 +165,7 @@ setupNativePath() {
 }
 
 pathCanonical() {
-    local dst="${1}"
+    dst="${1}"
     while [ -h "${dst}" ] ; do
         ls=`ls -ld "${dst}"`
         link=`expr "$ls" : '.*-> \(.*\)$'`
@@ -175,8 +175,8 @@ pathCanonical() {
             dst="`dirname "${dst}"`/$link"
         fi
     done
-    local bas=`basename "${dst}"`
-    local dir=`dirname "${dst}"`
+    bas=`basename "${dst}"`
+    dir=`dirname "${dst}"`
     if [ "$bas" != "$dir" ]; then
       dst="`pathCanonical "$dir"`/$bas"
     fi


### PR DESCRIPTION
The bin/karaf script uses the "local" command which is a shell builtin of bash and similar shells, but is not required for POSIX-compliance in sh. When I attempt to run karaf on a Solaris system, I see the following output:

root@solaris:/opendaylight/bin# ./karaf
./karaf[172]: local: not found [No such file or directory]
./karaf[182]: local: not found [No such file or directory]
./karaf[183]: local: not found [No such file or directory]

Lines 172, 182 and 183 invoke "local" to make local variables to the function. According to "man bash", this is a shell builtin. However, bin/karaf is invoked as:

#!/bin/sh

On most flavors of linux, this resolves to bash or dash which probably runs in a restricted environment after checking to see that its $0 is sh. But on Solaris's /bin/sh is actually ksh93 for backwards compatibility.

Since "local" is not part of a POSIX-compliant /bin/sh, depending on it in a script that is invoked with /bin/sh is a bug.

(this explaination is borrowed from https://issues.apache.org/jira/browse/MNG-5852)


Signed-off-by: Alexis de Talhouët <adetalhouet@inocybe.com>