### PR TITLE
KARAF-4581 Fixes typo in UserDeleteCommand description.

### DIFF
--- a/jaas/command/src/main/java/org/apache/karaf/jaas/command/UserDeleteCommand.java
+++ b/jaas/command/src/main/java/org/apache/karaf/jaas/command/UserDeleteCommand.java
@@ -20,7 +20,7 @@ import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 
-@Command(scope = "jaas", name = "user-delete", description = "Delete a usergit s")
+@Command(scope = "jaas", name = "user-delete", description = "Delete a user")
 @Service
 public class UserDeleteCommand extends JaasCommandSupport {
 


### PR DESCRIPTION
A small copy paste error was introduced recently; this fixes it.