### PR TITLE
karaf-service should return 0 on start when service is already running

### DIFF
--- a/wrapper/src/main/resources/org/apache/karaf/wrapper/internal/unix/karaf-service
+++ b/wrapper/src/main/resources/org/apache/karaf/wrapper/internal/unix/karaf-service
@@ -422,7 +422,7 @@ start() {
         exec $COMMAND_LINE
     else
         echo "$APP_LONG_NAME is already running."
-        exit 1
+        exit 0
     fi
 }
 


### PR DESCRIPTION
tools like puppet have problems with a service not returning 0 on start when it is already running.