### PR TITLE
[KARAF-4600] RBAC - MBean fails to resolve ACL if the order of properties in object name differs

### DIFF
--- a/management/server/src/main/java/org/apache/karaf/management/KarafMBeanServerGuard.java
+++ b/management/server/src/main/java/org/apache/karaf/management/KarafMBeanServerGuard.java
@@ -405,7 +405,7 @@ public class KarafMBeanServerGuard implements InvocationHandler {
         segments.add(objectName.getDomain());
         // TODO can an ObjectName property contain a comma as key or value ?
         // TODO support quoting as described in http://docs.oracle.com/javaee/1.4/api/javax/management/ObjectName.html
-        for (String s : objectName.getKeyPropertyListString().split("[,]")) {
+        for (String s : objectName.getCanonicalKeyPropertyListString().split("[,]")) {
             int index = s.indexOf('=');
             if (index < 0) {
                 continue;
@@ -417,7 +417,7 @@ public class KarafMBeanServerGuard implements InvocationHandler {
                 segments.add(key);
             }
         }
-        
+
         return segments;
     }
 

--- a/management/server/src/test/java/org/apache/karaf/management/KarafMBeanServerGuardTest.java
+++ b/management/server/src/test/java/org/apache/karaf/management/KarafMBeanServerGuardTest.java
@@ -353,6 +353,27 @@ public class KarafMBeanServerGuardTest extends TestCase {
                 guard.getRequiredRoles(on3, "foo", new Object[]{}, new String[]{}));
     }
 
+    public void testRequiredRolesHierarchyCanonical() throws Exception {
+        Dictionary<String, Object> conf = new Hashtable<String, Object>();
+        conf.put("foo", "viewer");
+        conf.put(Constants.SERVICE_PID, "jmx.acl.foo.bar.Test.AAA.BBB");
+        ConfigurationAdmin ca = getMockConfigAdmin2(conf);
+
+        KarafMBeanServerGuard guard = new KarafMBeanServerGuard();
+        guard.setConfigAdmin(ca);
+
+        // Canonical object name
+        ObjectName on1 = ObjectName.getInstance("foo.bar:prop1=AAA,prop2=BBB,type=Test");
+        assertEquals("Canonical ObjectName should work",
+                Collections.singletonList("viewer"),
+                guard.getRequiredRoles(on1, "foo", new String[]{}));
+        // Non-canonical object name
+        ObjectName on2 = ObjectName.getInstance("foo.bar:type=Test,prop2=BBB,prop1=AAA");
+        assertEquals("Non-canonical ObjectName should also work",
+                Collections.singletonList("viewer"),
+                guard.getRequiredRoles(on2, "foo", new String[]{}));
+    }
+
     public void testRequiredRolesMethodNameWildcard() throws Exception {
         Dictionary<String, Object> configuration = new Hashtable<String, Object>();
         configuration.put("getFoo", "viewer");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KARAF-4600

This fix makes `KarafMBeanServerGuard` always use the canonical object name when resolving ACL.