### PR TITLE
Fix karaf-maven-plugin attaching the same artifact multiple times

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/ArchiveMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/ArchiveMojo.java
@@ -118,10 +118,22 @@ public class ArchiveMojo extends MojoSupport {
     }
 
     @SuppressWarnings("deprecation")
-	private void archive(String type) throws IOException {
+    private void archive(String type) throws IOException {
         Artifact artifact1 = factory.createArtifactWithClassifier(project.getArtifact().getGroupId(), project.getArtifact().getArtifactId(), project.getArtifact().getVersion(), type, "bin");
         File target1 = archive(targetServerDirectory, destDir, artifact1);
-        projectHelper.attachArtifact( project, artifact1.getType(), null, target1 );
+
+        // artifact1 is created with explicit classifier "bin", which is dropped below when attachArtifact is called
+        // which means we can't use artifact1.equals(artifact) directly with artifact1
+        Artifact artifact2 = factory.createArtifact(artifact1.getGroupId(), artifact1.getArtifactId(), artifact1.getVersion(), artifact1.getScope(), artifact1.getType());
+        for (Artifact artifact : project.getAttachedArtifacts()) {
+            if (artifact2.equals(artifact))
+            {
+                getLog().debug("Artifact " + artifact2 + " already attached");
+                return;
+            }
+        }
+
+        projectHelper.attachArtifact(project, artifact1.getType(), null, target1);
     }
 
     public File archive(File source, File dest, Artifact artifact) throws //ArchiverException,


### PR DESCRIPTION
The problem occurs when creating assemblies with karaf-maven-plugin version 4.0.4 (and I assume later on by looking at the code). One can examine the output of mvn -X and look for the attachedArtifacts list to confirm that assembly artifacts appears twice.

The effect is that maven-install-plugin installs each artifact (zip and tar.gz, for instance) twice in the local repository, which does not cause any visible problem. It also seems to check if the artifacts are the same and skip duplicates.

However, maven-deploy-plugin fails when attempting to upload a release version twice (if the repository server is configured to reject release overwrites), which in turn failed my run of maven-release-plugin.

I hope the above explains the changes I submitted to you, and that you will consider applying them.