### PR TITLE
Fix typo in wrapper install output message

### DIFF
--- a/wrapper/src/main/java/org/apache/karaf/wrapper/commands/Install.java
+++ b/wrapper/src/main/java/org/apache/karaf/wrapper/commands/Install.java
@@ -134,7 +134,7 @@ public class Install implements Action {
                 System.out.println("");
                 System.out.println("  To uninstall the service :");
                 System.out.println("    $ chkconfig " + serviceFile.getName() + " --del");
-                System.out.println("    $ rm /etc/init.d/" + serviceFile.getPath());
+                System.out.println("    $ rm /etc/init.d/" + serviceFile.getName());
             } else if (debianVersion.exists()) {
                 System.out.println("");
                 System.out.println(INTENSITY_BOLD + "Ubuntu/Debian Linux system detected (SystemV):" + INTENSITY_NORMAL);


### PR DESCRIPTION
Fix the `rm` command to use the karaf-service file instead of the complete path