### PR TITLE
[KARAF-4720] Prevent NamespaceHandler implementations from hijacking namespaces

### DIFF
--- a/jaas/blueprint/config/src/main/java/org/apache/karaf/jaas/blueprint/config/impl/NamespaceHandler.java
+++ b/jaas/blueprint/config/src/main/java/org/apache/karaf/jaas/blueprint/config/impl/NamespaceHandler.java
@@ -47,11 +47,16 @@ import org.w3c.dom.NodeList;
 
 public class NamespaceHandler implements org.apache.aries.blueprint.NamespaceHandler {
 
+    public static final String KARAF_JAAS_NAMESPACE_1_0_0 = "http://karaf.apache.org/xmlns/jaas/v1.0.0";
+    public static final String KARAF_JAAS_NAMESPACE_1_1_0 = "http://karaf.apache.org/xmlns/jaas/v1.1.0";
+
     public URL getSchemaLocation(String namespace) {
-        if ("http://karaf.apache.org/xmlns/jaas/v1.0.0".equals(namespace)) {
+        if (KARAF_JAAS_NAMESPACE_1_0_0.equals(namespace)) {
             return getClass().getResource("/org/apache/karaf/jaas/blueprint/config/karaf-jaas-1.0.0.xsd");
-        } else {
+        } else if (KARAF_JAAS_NAMESPACE_1_1_0.equals(namespace)) {
             return getClass().getResource("/org/apache/karaf/jaas/blueprint/config/karaf-jaas-1.1.0.xsd");
+        } else {
+            return null;
         }
     }
 

--- a/jaas/blueprint/jasypt/src/main/java/org/apache/karaf/jaas/blueprint/jasypt/handler/NamespaceHandler.java
+++ b/jaas/blueprint/jasypt/src/main/java/org/apache/karaf/jaas/blueprint/jasypt/handler/NamespaceHandler.java
@@ -53,7 +53,11 @@ public class NamespaceHandler implements org.apache.aries.blueprint.NamespaceHan
     private int idCounter;
 
     public URL getSchemaLocation(String s) {
-        return getClass().getResource("/org/apache/karaf/jaas/blueprint/jasypt/handler/karaf-jasypt-1.0.0.xsd");
+        if (JASYPT_NAMESPACE_1_0.equals(s)) {
+            return getClass().getResource("/org/apache/karaf/jaas/blueprint/jasypt/handler/karaf-jasypt-1.0.0.xsd");
+        } else {
+            return null;
+        }
     }
 
     public Set<Class> getManagedClasses() {


### PR DESCRIPTION
NamespaceHandler implementations in Karaf will return a schema location from getSchemaLocation even for namespaces they don't own, essentially replacing the xsd that corresponds to the requested namespace. That leads to errors that make no sense and inability to use the bundles that implement the handlers.

Triggered by https://issues.apache.org/jira/browse/ARIES-1503 and https://github.com/apache/aries/commit/9a1ff22cbd29006d24a42e3e1274dfa493501ed9 in particular.

The error I was seeing when trying to use the JAAS module:

```
18:07:39,892 ERROR  16 ntainer.BlueprintContainerImpl [pool-9-thread-1 ] Unable to start blueprint container for bundle org.apache.brooklyn.rest-resources/0.10.0.SNAPSHOT
org.xml.sax.SAXParseException; systemId: bundle://31.0:1/org/apache/karaf/jaas/blueprint/config/karaf-jaas-1.1.0.xsd; lineNumber: 24; columnNumber: 66; src-import.3.1: The namespace attribute, 'http://cxf.apache.org/configuration/beans', of an <import> element information item must be identical to the targetNamespace attribute, 'http://karaf.apache.org/xmlns/jaas/v1.1.0', of the imported document.
    at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.createSAXParseException(ErrorHandlerWrapper.java:198)[:1.7.0_80]
    at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.error(ErrorHandlerWrapper.java:134)[:1.7.0_80]
    at com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:437)[:1.7.0_80]
    at com.sun.org.apache.xerces.internal.impl.xs.traversers.XSDHandler.reportSchemaErr(XSDHandler.java:4162)[:1.7.0_80]
    at com.sun.org.apache.xerces.internal.impl.xs.traversers.XSDHandler.reportSchemaError(XSDHandler.java:4145)[:1.7.0_80]
    at com.sun.org.apache.xerces.internal.impl.xs.traversers.XSDHandler.constructTrees(XSDHandler.java:822)[:1.7.0_80]
    at com.sun.org.apache.xerces.internal.impl.xs.traversers.XSDHandler.constructTrees(XSDHandler.java:1120)[:1.7.0_80]
    at com.sun.org.apache.xerces.internal.impl.xs.traversers.XSDHandler.parseSchema(XSDHandler.java:620)[:1.7.0_80]
    at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaLoader.loadSchema(XMLSchemaLoader.java:617)[:1.7.0_80]
    at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaLoader.loadGrammar(XMLSchemaLoader.java:575)[:1.7.0_80]
    at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaLoader.loadGrammar(XMLSchemaLoader.java:541)[:1.7.0_80]
    at com.sun.org.apache.xerces.internal.jaxp.validation.XMLSchemaFactory.newSchema(XMLSchemaFactory.java:252)[:1.7.0_80]
    at org.apache.aries.blueprint.namespace.NamespaceHandlerRegistryImpl$NamespaceHandlerSetImpl.createSchema(NamespaceHandlerRegistryImpl.java:641)[16:org.apache.aries.blueprint.core:1.6.2]
    at org.apache.aries.blueprint.namespace.NamespaceHandlerRegistryImpl$NamespaceHandlerSetImpl.doGetSchema(NamespaceHandlerRegistryImpl.java:458)[16:org.apache.aries.blueprint.core:1.6.2]
    at org.apache.aries.blueprint.namespace.NamespaceHandlerRegistryImpl$NamespaceHandlerSetImpl.getSchema(NamespaceHandlerRegistryImpl.java:443)[16:org.apache.aries.blueprint.core:1.6.2]
    at org.apache.aries.blueprint.container.BlueprintContainerImpl.doRun(BlueprintContainerImpl.java:343)[16:org.apache.aries.blueprint.core:1.6.2]
    at org.apache.aries.blueprint.container.BlueprintContainerImpl.run(BlueprintContainerImpl.java:276)[16:org.apache.aries.blueprint.core:1.6.2]
    at org.apache.aries.blueprint.container.BlueprintExtender.createContainer(BlueprintExtender.java:300)[16:org.apache.aries.blueprint.core:1.6.2]
    at org.apache.aries.blueprint.container.BlueprintExtender.createContainer(BlueprintExtender.java:269)[16:org.apache.aries.blueprint.core:1.6.2]
    at org.apache.aries.blueprint.container.BlueprintExtender.createContainer(BlueprintExtender.java:265)[16:org.apache.aries.blueprint.core:1.6.2]
    at org.apache.aries.blueprint.container.BlueprintExtender.modifiedBundle(BlueprintExtender.java:255)[16:org.apache.aries.blueprint.core:1.6.2]
    at org.apache.aries.util.tracker.hook.BundleHookBundleTracker$Tracked.customizerModified(BundleHookBundleTracker.java:500)[20:org.apache.aries.util:1.1.1]
    at org.apache.aries.util.tracker.hook.BundleHookBundleTracker$Tracked.customizerModified(BundleHookBundleTracker.java:433)[20:org.apache.aries.util:1.1.1]
    at org.apache.aries.util.tracker.hook.BundleHookBundleTracker$AbstractTracked.track(BundleHookBundleTracker.java:725)[20:org.apache.aries.util:1.1.1]
    at org.apache.aries.util.tracker.hook.BundleHookBundleTracker$Tracked.bundleChanged(BundleHookBundleTracker.java:463)[20:org.apache.aries.util:1.1.1]
    at org.apache.aries.util.tracker.hook.BundleHookBundleTracker$BundleEventHook.event(BundleHookBundleTracker.java:422)[20:org.apache.aries.util:1.1.1]
    at org.apache.felix.framework.util.SecureAction.invokeBundleEventHook(SecureAction.java:1179)[org.apache.felix.framework-5.4.0.jar:]
    at org.apache.felix.framework.util.EventDispatcher.createWhitelistFromHooks(EventDispatcher.java:731)[org.apache.felix.framework-5.4.0.jar:]
    at org.apache.felix.framework.util.EventDispatcher.fireBundleEvent(EventDispatcher.java:486)[org.apache.felix.framework-5.4.0.jar:]
    at org.apache.felix.framework.Felix.fireBundleEvent(Felix.java:4541)[org.apache.felix.framework-5.4.0.jar:]
    at org.apache.felix.framework.Felix.startBundle(Felix.java:2172)[org.apache.felix.framework-5.4.0.jar:]
    at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:998)[org.apache.felix.framework-5.4.0.jar:]
    at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:984)[org.apache.felix.framework-5.4.0.jar:]
    at org.apache.karaf.features.internal.service.FeaturesServiceImpl.startBundle(FeaturesServiceImpl.java:1286)[10:org.apache.karaf.features.core:4.0.6]
    at org.apache.karaf.features.internal.service.Deployer.deploy(Deployer.java:846)[10:org.apache.karaf.features.core:4.0.6]
    at org.apache.karaf.features.internal.service.FeaturesServiceImpl.doProvision(FeaturesServiceImpl.java:1176)[10:org.apache.karaf.features.core:4.0.6]
    at org.apache.karaf.features.internal.service.FeaturesServiceImpl$1.call(FeaturesServiceImpl.java:1074)[10:org.apache.karaf.features.core:4.0.6]
    at java.util.concurrent.FutureTask.run(FutureTask.java:262)[:1.7.0_80]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)[:1.7.0_80]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)[:1.7.0_80]
    at java.lang.Thread.run(Thread.java:745)[:1.7.0_80]

```
