### PR TITLE
MavenEntries will not be transferred

### DIFF
--- a/tooling/features-maven-plugin/src/main/java/org/apache/karaf/tooling/features/CreateKarMojo.java
+++ b/tooling/features-maven-plugin/src/main/java/org/apache/karaf/tooling/features/CreateKarMojo.java
@@ -154,6 +154,7 @@ public class CreateKarMojo extends MojoSupport {
 
         MavenArchiver archiver = new MavenArchiver();
         MavenArchiveConfiguration configuration = new MavenArchiveConfiguration();
+        configuration.addManifestEntries(archive.getManifestEntries());
         archiver.setArchiver(jarArchiver);
         archiver.setOutputFile(archiveFile);
 


### PR DESCRIPTION
Hi!

It seems that the `MavenArchiveConfiguration` which i configured in my pom.xml will not be transferred in the final `MANIFEST.MF`. This should fix it.
