### PR TITLE
Upgrade to eclipselink 2.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <commons-io.version>2.4</commons-io.version>
 
         <dom4j.bundle.version>1.6.1_5</dom4j.bundle.version>
-        <eclipselink.version>2.6.1</eclipselink.version>
+        <eclipselink.version>2.6.4</eclipselink.version>
         <jasypt.bundle.version>1.9.2_1</jasypt.bundle.version>
         <jolokia.version>1.3.3</jolokia.version>
         <serp.bundle.version>1.14.1_1</serp.bundle.version>


### PR DESCRIPTION
Karaf 4.0.4 is giving me a nasty exception during startup when using eclipselink 2.6.1:

`.jpa.EntityManagerFactoryImpl.close(EntityManagerFactoryImpl.java:288)[243:org.eclipse.persistence.jpa:2.6.1.v20150916-55dc7c3]
        at org.apache.aries.jpa.container.impl.PersistenceProviderTracker.createAndCloseDummyEMF(PersistenceProviderTracker.java:106)[79:org.apache.aries.jpa.container:2.3.0]
        at org.apache.aries.jpa.container.impl.PersistenceProviderTracker.addingService(PersistenceProviderTracker.java:85)[79:org.apache.aries.jpa.container:2.3.0]
        at org.apache.aries.jpa.container.impl.PersistenceProviderTracker.addingService(PersistenceProviderTracker.java:44)[79:org.apache.aries.jpa.container:2.3.0]
        at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:941)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:870)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.AbstractTracked.trackAdding(AbstractTracked.java:256)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.AbstractTracked.trackInitial(AbstractTracked.java:183)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.ServiceTracker.open(ServiceTracker.java:318)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.ServiceTracker.open(ServiceTracker.java:261)[org.osgi.core-6.0.0.jar:]
        at org.apache.aries.jpa.container.impl.PersistenceBundleTracker.trackProvider(PersistenceBundleTracker.java:106)[79:org.apache.aries.jpa.container:2.3.0]
        at org.apache.aries.jpa.container.impl.PersistenceBundleTracker.findPersistenceUnits(PersistenceBundleTracker.java:90)[79:org.apache.aries.jpa.container:2.3.0]
        at org.apache.aries.jpa.container.impl.PersistenceBundleTracker.addingBundle(PersistenceBundleTracker.java:69)[79:org.apache.aries.jpa.container:2.3.0]
        at org.apache.aries.jpa.container.impl.PersistenceBundleTracker.addingBundle(PersistenceBundleTracker.java:40)[79:org.apache.aries.jpa.container:2.3.0]
        at org.osgi.util.tracker.BundleTracker$Tracked.customizerAdding(BundleTracker.java:469)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.BundleTracker$Tracked.customizerAdding(BundleTracker.java:415)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.AbstractTracked.trackAdding(AbstractTracked.java:256)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.AbstractTracked.track(AbstractTracked.java:229)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.BundleTracker$Tracked.bundleChanged(BundleTracker.java:444)[org.osgi.core-6.0.0.jar:]
        at org.apache.felix.framework.util.EventDispatcher.invokeBundleListenerCallback(EventDispatcher.java:916)[org.apache.felix.framework-5.4.0.jar:]
        at org.apache.felix.framework.util.EventDispatcher.fireEventImmediately(EventDispatcher.java:835)[org.apache.felix.framework-5.4.0.jar:]
        at org.apache.felix.framework.util.EventDispatcher.fireBundleEvent(EventDispatcher.java:517)[org.apache.felix.framework-5.4.0.jar:]
        at org.apache.felix.framework.Felix.fireBundleEvent(Felix.java:4541)[org.apache.felix.framework-5.4.0.jar:]
        at org.apache.felix.framework.Felix.activateBundle(Felix.java:2216)[org.apache.felix.framework-5.4.0.jar:]
        at org.apache.felix.framework.Felix.startBundle(Felix.java:2144)[org.apache.felix.framework-5.4.0.jar:]
        at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:998)[org.apache.felix.framework-5.4.0.jar:]
        at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:984)[org.apache.felix.framework-5.4.0.jar:]
        at org.apache.karaf.features.internal.service.FeaturesServiceImpl.startBundle(FeaturesServiceImpl.java:1199)[10:org.apache.karaf.features.core:4.0.4]
        at org.apache.karaf.features.internal.service.Deployer.deploy(Deployer.java:840)[10:org.apache.karaf.features.core:4.0.4]
        at org.apache.karaf.features.internal.service.FeaturesServiceImpl.doProvision(FeaturesServiceImpl.java:1089)[10:org.apache.karaf.features.core:4.0.4]
        at org.apache.karaf.features.internal.service.FeaturesServiceImpl$1.call(FeaturesServiceImpl.java:985)[10:org.apache.karaf.features.core:4.0.4]
        at java.util.concurrent.FutureTask.run(FutureTask.java:262)[:1.7.0_99]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)[:1.7.0_99]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)[:1.7.0_99]
        at java.lang.Thread.run(Thread.java:745)[:1.7.0_99]`

This could be solved by updating to eclipselink greater than 2.6.2:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=463629

Eclipselink 2.6.4 is already out, so I suggest to update to it directly.
