### PR TITLE
[KARAF-4487] - Gssapi

### DIFF
--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModule.java
@@ -10,6 +10,7 @@ import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.kerberos.KerberosPrincipal;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
@@ -118,6 +119,13 @@ public class GSSAPILdapLoginModule extends AbstractKarafLoginModule {
     @Override
     public boolean abort() throws LoginException {
         return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        boolean ret = super.commit();
+        principals.addAll(subject.getPrincipals(KerberosPrincipal.class));
+        return ret;
     }
 
     @Override

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModule.java
@@ -1,0 +1,58 @@
+package org.apache.karaf.jaas.modules.ldap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Specific LDAPLoginModule to be used with GSSAPI. Uses the specified realm as login context.
+ */
+public class GSSAPILdapLoginModule extends LDAPLoginModule {
+
+    private static Logger logger = LoggerFactory.getLogger(LDAPLoginModule.class);
+
+    public static final String REALM_PROPERTY = "gssapiRealm";
+
+    private LoginContext context;
+
+    @Override
+    public boolean login() throws LoginException {
+        if (!options.containsKey(REALM_PROPERTY)) {
+            logger.warn(REALM_PROPERTY + " is not set");
+            throw new LoginException("cannot authenticate through the delegating realm");
+        }
+
+        context = new LoginContext((String) options.get(REALM_PROPERTY), this.subject, this.callbackHandler);
+        context.login();
+
+        try {
+            return Subject.doAs(context.getSubject(), (PrivilegedExceptionAction<Boolean>) () -> doLogin());
+        } catch (PrivilegedActionException pExcp) {
+            logger.error("error with delegated authentication", pExcp);
+            throw new LoginException(pExcp.getMessage());
+        }
+    }
+
+    @Override
+    protected boolean doLogin() throws LoginException {
+
+        //force GSSAPI for login
+        Map<String, Object> opts = new HashMap<>(this.options);
+        opts.put(LDAPOptions.AUTHENTICATION, "GSSAPI");
+
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        try {
+            return super.doLogin();
+        } finally {
+            ManagedSSLSocketFactory.setSocketFactory(null);
+            Thread.currentThread().setContextClassLoader(tccl);
+        }
+    }
+}

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModule.java
@@ -1,26 +1,39 @@
 package org.apache.karaf.jaas.modules.ldap;
 
+import org.apache.karaf.jaas.boot.principal.RolePrincipal;
+import org.apache.karaf.jaas.boot.principal.UserPrincipal;
+import org.apache.karaf.jaas.modules.AbstractKarafLoginModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
+import java.io.IOException;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 /**
  * Specific LDAPLoginModule to be used with GSSAPI. Uses the specified realm as login context.
  */
-public class GSSAPILdapLoginModule extends LDAPLoginModule {
+public class GSSAPILdapLoginModule extends AbstractKarafLoginModule {
 
     private static Logger logger = LoggerFactory.getLogger(LDAPLoginModule.class);
 
     public static final String REALM_PROPERTY = "gssapiRealm";
 
     private LoginContext context;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        super.initialize(subject, callbackHandler, options);
+    }
 
     @Override
     public boolean login() throws LoginException {
@@ -40,7 +53,6 @@ public class GSSAPILdapLoginModule extends LDAPLoginModule {
         }
     }
 
-    @Override
     protected boolean doLogin() throws LoginException {
 
         //force GSSAPI for login
@@ -49,10 +61,69 @@ public class GSSAPILdapLoginModule extends LDAPLoginModule {
 
         ClassLoader tccl = Thread.currentThread().getContextClassLoader();
         try {
-            return super.doLogin();
+            LDAPOptions lOptions = new LDAPOptions(opts);
+
+            NameCallback[] callbacks = new NameCallback[1];
+            callbacks[0] = new NameCallback("Username: ");
+
+            try {
+                callbackHandler.handle(callbacks);
+            } catch (IOException ioException) {
+                logger.error("error with callback handler", ioException);
+                throw new LoginException(ioException.getMessage());
+            } catch (UnsupportedCallbackException unsupportedCallbackException) {
+                logger.error("error with callback handler", unsupportedCallbackException);
+                throw new LoginException(unsupportedCallbackException.getMessage() + " not available to obtain information from user.");
+            }
+
+            user = callbacks[0].getName();
+
+            principals = new HashSet<>();
+
+            String[] userDnAndNamespace;
+            try (LDAPCache cache = LDAPCache.getCache(lOptions)) {
+
+                try {
+                    logger.debug("Get the user DN.");
+                    userDnAndNamespace = cache.getUserDnAndNamespace(user);
+
+                } catch (Exception e) {
+                    logger.warn("Can't connect to the LDAP server: {}", e.getMessage(), e);
+                    throw new LoginException("Can't connect to the LDAP server: " + e.getMessage());
+                }
+
+                if (userDnAndNamespace == null) {
+                    return false;
+                }
+
+                principals.add(new UserPrincipal(user));
+
+                try {
+                    String[] roles = cache.getUserRoles(user, userDnAndNamespace[0], userDnAndNamespace[1]);
+                    for (String role : roles) {
+                        principals.add(new RolePrincipal(role));
+                    }
+                } catch (Exception e) {
+                    throw new LoginException("Can't get user " + user + " roles: " + e.getMessage());
+                }
+
+                return true;
+            }
         } finally {
             ManagedSSLSocketFactory.setSocketFactory(null);
             Thread.currentThread().setContextClassLoader(tccl);
         }
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        subject.getPrincipals().removeAll(principals);
+        principals.clear();
+        return true;
     }
 }

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -213,7 +213,6 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
     public void testUsernameFailure() throws Exception {
 
         Properties options = ldapLoginModuleOptions();
-        options.setProperty(GSSAPILdapLoginModule.REALM_PROPERTY, "propertiesTestRealm");
         GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
 
         CallbackHandler cb = new CallbackHandler() {
@@ -238,7 +237,6 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
     public void testPasswordFailure() throws Exception {
 
         Properties options = ldapLoginModuleOptions();
-        options.setProperty(GSSAPILdapLoginModule.REALM_PROPERTY, "propertiesTestRealm");
         GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
 
         CallbackHandler cb = new CallbackHandler() {
@@ -263,7 +261,6 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
     public void testUserNotFound() throws Exception {
 
         Properties options = ldapLoginModuleOptions();
-        options.setProperty(GSSAPILdapLoginModule.REALM_PROPERTY, "propertiesTestRealm");
         GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
 
         CallbackHandler cb = new CallbackHandler() {
@@ -282,6 +279,31 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertFalse(module.login());
+    }
+
+    @Test(expected = LoginException.class)
+    public void testNoRealm() throws Exception {
+
+        Properties options = ldapLoginModuleOptions();
+        options.remove(GSSAPILdapLoginModule.REALM_PROPERTY);
+        GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
+
+        CallbackHandler cb = new CallbackHandler() {
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (Callback cb : callbacks) {
+                    if (cb instanceof NameCallback) {
+                        ((NameCallback) cb).setName("hnelson0");
+                    } else if (cb instanceof PasswordCallback) {
+                        ((PasswordCallback) cb).setPassword("secret".toCharArray());
+                    }
+                }
+            }
+        };
+        Subject subject = new Subject();
+        module.initialize(subject, cb, null, options);
+
+        assertEquals("Precondition", 0, subject.getPrincipals().size());
+        assertTrue(module.login()); // should throw LoginException
     }
 
     protected void setupEnv(Class<? extends Transport> transport, EncryptionType encryptionType,

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -21,7 +21,6 @@ import org.apache.directory.server.core.integ.FrameworkRunner;
 import org.apache.directory.server.core.kerberos.KeyDerivationInterceptor;
 import org.apache.directory.server.kerberos.kdc.AbstractKerberosITest;
 import org.apache.directory.server.kerberos.kdc.KerberosTestUtils;
-import org.apache.directory.server.ldap.LdapServer;
 import org.apache.directory.server.ldap.handlers.sasl.cramMD5.CramMd5MechanismHandler;
 import org.apache.directory.server.ldap.handlers.sasl.digestMD5.DigestMd5MechanismHandler;
 import org.apache.directory.server.ldap.handlers.sasl.gssapi.GssapiMechanismHandler;
@@ -29,7 +28,6 @@ import org.apache.directory.server.ldap.handlers.sasl.ntlm.NtlmMechanismHandler;
 import org.apache.directory.server.ldap.handlers.sasl.plain.PlainMechanismHandler;
 import org.apache.directory.server.protocol.shared.transport.TcpTransport;
 import org.apache.directory.server.protocol.shared.transport.Transport;
-import org.apache.directory.server.protocol.shared.transport.UdpTransport;
 import org.apache.directory.shared.kerberos.codec.types.EncryptionType;
 import org.apache.directory.shared.kerberos.crypto.checksum.ChecksumType;
 import org.apache.felix.utils.properties.Properties;
@@ -210,6 +208,8 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
         boolean foundKrb5User = false;
         boolean foundUser = false;
         boolean foundRole = false;
+        boolean foundTicket = false;
+
         for (Principal pr : subject.getPrincipals()) {
             if (pr instanceof KerberosPrincipal) {
                 assertEquals("hnelson@EXAMPLE.COM", pr.getName());
@@ -222,11 +222,6 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
                 foundRole = true;
             }
         }
-        assertTrue("Principals should contains kerberos user", foundKrb5User);
-        assertTrue("Principals should contains ldap user", foundUser);
-        assertTrue("Principals should contains ldap role", foundRole);
-
-        boolean foundTicket = false;
         for (Object crd : subject.getPrivateCredentials()) {
             if (crd instanceof KerberosTicket) {
                 assertEquals("hnelson@EXAMPLE.COM", ((KerberosTicket) crd).getClient().getName());
@@ -235,8 +230,11 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
                 break;
             }
         }
+
+        assertTrue("Principals should contains kerberos user", foundKrb5User);
+        assertTrue("Principals should contains ldap user", foundUser);
+        assertTrue("Principals should contains ldap role", foundRole);
         assertTrue("PricatePrincipals should contains kerberos ticket", foundTicket);
-        assertTrue(foundTicket);
 
         assertTrue(module.logout());
         assertEquals("Principals should be gone as the user has logged out", 0, subject.getPrincipals().size());

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -1,0 +1,216 @@
+package org.apache.karaf.jaas.modules.ldap;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.ApplyLdifFiles;
+import org.apache.directory.server.core.annotations.CreateDS;
+import org.apache.directory.server.core.annotations.CreatePartition;
+import org.apache.directory.server.core.integ.AbstractLdapTestUnit;
+import org.apache.directory.server.core.integ.FrameworkRunner;
+import org.apache.felix.utils.properties.Properties;
+import org.apache.karaf.jaas.boot.principal.RolePrincipal;
+import org.apache.karaf.jaas.boot.principal.UserPrincipal;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.LoginException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.Principal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(FrameworkRunner.class)
+@CreateLdapServer(transports = {@CreateTransport(protocol = "LDAP")})
+@CreateDS(name = "LdapLoginModuleTest-class",
+        partitions = {@CreatePartition(name = "example", suffix = "dc=example,dc=com")})
+@ApplyLdifFiles(
+        "org/apache/karaf/jaas/modules/ldap/example.com.ldif"
+)
+public class GSSAPILdapLoginModuleTest extends AbstractLdapTestUnit {
+    private static boolean portUpdated;
+
+    @Before
+    public void init() throws Exception {
+        String basedir = System.getProperty("basedir");
+        if (basedir == null) {
+            basedir = new File(".").getCanonicalPath();
+        }
+        File config = new File(basedir + "/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.login.config");
+
+        System.setProperty("java.security.auth.login.config", config.toString());
+
+        updatePort();
+    }
+
+    public void updatePort() throws Exception {
+        if (!portUpdated) {
+            String basedir = System.getProperty("basedir");
+            if (basedir == null) {
+                basedir = new File(".").getCanonicalPath();
+            }
+
+            // Read in ldap.properties and substitute in the correct port
+            File f = new File(basedir + "/src/test/resources/org/apache/karaf/jaas/modules/ldap/ldap.properties");
+
+            FileInputStream inputStream = new FileInputStream(f);
+            String content = IOUtils.toString(inputStream, "UTF-8");
+            inputStream.close();
+            content = content.replaceAll("portno", "" + super.getLdapServer().getPort());
+
+            File f2 = new File(basedir + "/target/test-classes/org/apache/karaf/jaas/modules/ldap/ldap.properties");
+            FileOutputStream outputStream = new FileOutputStream(f2);
+            IOUtils.write(content, outputStream, "UTF-8");
+            outputStream.close();
+            portUpdated = true;
+        }
+
+    }
+
+    @After
+    public void tearDown() {
+        LDAPCache.clear();
+    }
+
+    @Test
+    public void testSuccess() throws Exception {
+
+        Properties options = ldapLoginModuleOptions();
+        options.setProperty(GSSAPILdapLoginModule.REALM_PROPERTY, "propertiesTestRealm");
+        GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
+
+        CallbackHandler cb = new CallbackHandler() {
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (Callback cb : callbacks) {
+                    if (cb instanceof NameCallback) {
+                        ((NameCallback) cb).setName("admin");
+                    } else if (cb instanceof PasswordCallback) {
+                        ((PasswordCallback) cb).setPassword("admin123".toCharArray());
+                    }
+                }
+            }
+        };
+        Subject subject = new Subject();
+        module.initialize(subject, cb, null, options);
+
+        assertEquals("Precondition", 0, subject.getPrincipals().size());
+        assertTrue(module.login());
+        assertTrue(module.commit());
+
+        assertEquals(2, subject.getPrincipals().size());
+
+        boolean foundUser = false;
+        boolean foundRole = false;
+        for (Principal pr : subject.getPrincipals()) {
+            if (pr instanceof UserPrincipal) {
+                assertEquals("admin", pr.getName());
+                foundUser = true;
+            } else if (pr instanceof RolePrincipal) {
+                assertEquals("admin", pr.getName());
+                foundRole = true;
+            }
+        }
+        assertTrue(foundUser);
+        assertTrue(foundRole);
+
+        assertTrue(module.logout());
+        assertEquals("Principals should be gone as the user has logged out", 0, subject.getPrincipals().size());
+    }
+
+    @Test(expected = LoginException.class)
+    public void testUsernameFailure() throws Exception {
+
+        Properties options = ldapLoginModuleOptions();
+        options.setProperty(GSSAPILdapLoginModule.REALM_PROPERTY, "propertiesTestRealm");
+        GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
+
+        CallbackHandler cb = new CallbackHandler() {
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (Callback cb : callbacks) {
+                    if (cb instanceof NameCallback) {
+                        ((NameCallback) cb).setName("admin0");
+                    } else if (cb instanceof PasswordCallback) {
+                        ((PasswordCallback) cb).setPassword("admin123".toCharArray());
+                    }
+                }
+            }
+        };
+        Subject subject = new Subject();
+        module.initialize(subject, cb, null, options);
+
+        assertEquals("Precondition", 0, subject.getPrincipals().size());
+        assertTrue(module.login()); // should throw LoginException
+    }
+
+    @Test(expected = LoginException.class)
+    public void testPasswordFailure() throws Exception {
+
+        Properties options = ldapLoginModuleOptions();
+        options.setProperty(GSSAPILdapLoginModule.REALM_PROPERTY, "propertiesTestRealm");
+        GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
+
+        CallbackHandler cb = new CallbackHandler() {
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (Callback cb : callbacks) {
+                    if (cb instanceof NameCallback) {
+                        ((NameCallback) cb).setName("admin");
+                    } else if (cb instanceof PasswordCallback) {
+                        ((PasswordCallback) cb).setPassword("admin1230".toCharArray());
+                    }
+                }
+            }
+        };
+        Subject subject = new Subject();
+        module.initialize(subject, cb, null, options);
+
+        assertEquals("Precondition", 0, subject.getPrincipals().size());
+        assertTrue(module.login());
+    }
+
+    @Test
+    public void testUserNotFound() throws Exception {
+
+        Properties options = ldapLoginModuleOptions();
+        options.setProperty(GSSAPILdapLoginModule.REALM_PROPERTY, "propertiesTestRealm");
+        GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
+
+        CallbackHandler cb = new CallbackHandler() {
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (Callback cb : callbacks) {
+                    if (cb instanceof NameCallback) {
+                        ((NameCallback) cb).setName("test");
+                    } else if (cb instanceof PasswordCallback) {
+                        ((PasswordCallback) cb).setPassword("test".toCharArray());
+                    }
+                }
+            }
+        };
+        Subject subject = new Subject();
+        module.initialize(subject, cb, null, options);
+
+        assertEquals("Precondition", 0, subject.getPrincipals().size());
+        assertFalse(module.login());
+    }
+
+    protected Properties ldapLoginModuleOptions() throws IOException {
+        String basedir = System.getProperty("basedir");
+        if (basedir == null) {
+            basedir = new File(".").getCanonicalPath();
+        }
+        File file = new File(basedir + "/target/test-classes/org/apache/karaf/jaas/modules/ldap/ldap.properties");
+        return new Properties(file);
+    }
+}

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -162,8 +162,9 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
             String content = IOUtils.toString(inputStream, "UTF-8");
             inputStream.close();
             content = content.replaceAll("portno", "" + super.getLdapServer().getPort());
+            content = content.replaceAll("address", "localhost");
             //content = content.replaceAll("address", "" + super.getLdapServer().getSaslHost());
-            content = content.replaceAll("address", "" + super.getLdapServer().getTransports()[0].getAddress());
+            //content = content.replaceAll("address", "" + super.getLdapServer().getTransports()[0].getAddress());
 
             File f2 = new File(basedir + "/target/test-classes/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties");
             FileOutputStream outputStream = new FileOutputStream(f2);

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -21,6 +21,7 @@ import org.apache.directory.server.core.integ.FrameworkRunner;
 import org.apache.directory.server.core.kerberos.KeyDerivationInterceptor;
 import org.apache.directory.server.kerberos.kdc.AbstractKerberosITest;
 import org.apache.directory.server.kerberos.kdc.KerberosTestUtils;
+import org.apache.directory.server.ldap.LdapServer;
 import org.apache.directory.server.ldap.handlers.sasl.cramMD5.CramMd5MechanismHandler;
 import org.apache.directory.server.ldap.handlers.sasl.digestMD5.DigestMd5MechanismHandler;
 import org.apache.directory.server.ldap.handlers.sasl.gssapi.GssapiMechanismHandler;
@@ -28,6 +29,7 @@ import org.apache.directory.server.ldap.handlers.sasl.ntlm.NtlmMechanismHandler;
 import org.apache.directory.server.ldap.handlers.sasl.plain.PlainMechanismHandler;
 import org.apache.directory.server.protocol.shared.transport.TcpTransport;
 import org.apache.directory.server.protocol.shared.transport.Transport;
+import org.apache.directory.server.protocol.shared.transport.UdpTransport;
 import org.apache.directory.shared.kerberos.codec.types.EncryptionType;
 import org.apache.directory.shared.kerberos.crypto.checksum.ChecksumType;
 import org.apache.felix.utils.properties.Properties;
@@ -114,7 +116,7 @@ import static org.junit.Assert.assertTrue;
 })
 public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
 
-    private static boolean portUpdated;
+    private static boolean loginConfigUpdated;
 
     @Before
     public void setUp() throws Exception {
@@ -140,7 +142,7 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
     }
 
     public void updatePort() throws Exception {
-        if (!portUpdated) {
+        if (!loginConfigUpdated) {
             String basedir = System.getProperty("basedir");
             if (basedir == null) {
                 basedir = new File(".").getCanonicalPath();
@@ -153,12 +155,13 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
             String content = IOUtils.toString(inputStream, "UTF-8");
             inputStream.close();
             content = content.replaceAll("portno", "" + super.getLdapServer().getPort());
+            content = content.replaceAll("address", "" + super.getLdapServer().getSaslHost());
 
             File f2 = new File(basedir + "/target/test-classes/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties");
             FileOutputStream outputStream = new FileOutputStream(f2);
             IOUtils.write(content, outputStream, "UTF-8");
             outputStream.close();
-            portUpdated = true;
+            loginConfigUpdated = true;
         }
 
     }

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -222,20 +222,21 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
                 foundRole = true;
             }
         }
-        assertTrue(foundKrb5User);
-        assertTrue(foundUser);
-        assertTrue(foundRole);
+        assertTrue("Principals should contains kerberos user", foundKrb5User);
+        assertTrue("Principals should contains ldap user", foundUser);
+        assertTrue("Principals should contains ldap role", foundRole);
 
-        boolean foundToken = false;
+        boolean foundTicket = false;
         for (Object crd : subject.getPrivateCredentials()) {
             if (crd instanceof KerberosTicket) {
                 assertEquals("hnelson@EXAMPLE.COM", ((KerberosTicket) crd).getClient().getName());
                 assertEquals("krbtgt/EXAMPLE.COM@EXAMPLE.COM", ((KerberosTicket) crd).getServer().getName());
-                foundToken = true;
+                foundTicket = true;
                 break;
             }
         }
-        assertTrue(foundToken);
+        assertTrue("PricatePrincipals should contains kerberos ticket", foundTicket);
+        assertTrue(foundTicket);
 
         assertTrue(module.logout());
         assertEquals("Principals should be gone as the user has logged out", 0, subject.getPrincipals().size());

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -357,26 +357,11 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
     }
 
     protected Properties ldapLoginModuleOptions() throws IOException {
-        Properties props = new Properties();
-
-        props.setProperty("debug", "true");
-        props.setProperty("connection.url", "ldap://127.0.0.1:" + super.getLdapServer().getPort());
-        props.setProperty("connection.username", "uid=admin,ou=system");
-        props.setProperty("connection.password", "secret");
-        props.setProperty("connection.protocol=", "");
-        props.setProperty("authentication", "simple");
-
-        props.setProperty("user.base.dn", "ou=people,dc=example,dc=com");
-        props.setProperty("user.filter", "(uid=%u)");
-        props.setProperty("user.search.subtree", "true");
-
-        props.setProperty("role.base.dn", "ou=groups,dc=example,dc=com");
-        props.setProperty("role.name.attribute", "cn");
-        props.setProperty("role.filter", "(member=%fqdn)");
-        props.setProperty("role.search.subtree", "true");
-
-        props.setProperty("initialContextFactory", "com.sun.jndi.ldap.LdapCtxFactory");
-
-        return props;
+        String basedir = System.getProperty("basedir");
+        if (basedir == null) {
+            basedir = new File(".").getCanonicalPath();
+        }
+        File file = new File(basedir + "/target/test-classes/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties");
+        return new Properties(file);
     }
 }

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -162,7 +162,8 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
             String content = IOUtils.toString(inputStream, "UTF-8");
             inputStream.close();
             content = content.replaceAll("portno", "" + super.getLdapServer().getPort());
-            content = content.replaceAll("address", "" + super.getLdapServer().getSaslHost());
+            //content = content.replaceAll("address", "" + super.getLdapServer().getSaslHost());
+            content = content.replaceAll("address", "" + super.getLdapServer().getTransports()[0].getAddress());
 
             File f2 = new File(basedir + "/target/test-classes/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties");
             FileOutputStream outputStream = new FileOutputStream(f2);

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -8,7 +8,6 @@ import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.util.Strings;
-import org.apache.directory.ldap.client.api.Krb5LoginConfiguration;
 import org.apache.directory.server.annotations.CreateKdcServer;
 import org.apache.directory.server.annotations.CreateLdapServer;
 import org.apache.directory.server.annotations.CreateTransport;
@@ -32,7 +31,6 @@ import org.apache.directory.server.protocol.shared.transport.Transport;
 import org.apache.directory.shared.kerberos.codec.types.EncryptionType;
 import org.apache.directory.shared.kerberos.crypto.checksum.ChecksumType;
 import org.apache.felix.utils.properties.Properties;
-import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
 import org.junit.After;
 import org.junit.Before;
@@ -45,7 +43,6 @@ import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginException;
 import java.io.File;
 import java.io.FileInputStream;
@@ -108,11 +105,16 @@ import static org.junit.Assert.assertTrue;
         "dn: ou=users,dc=example,dc=com",
         "objectClass: top",
         "objectClass: organizationalUnit",
-        "ou: users"
+        "ou: users",
+
+        "dn: ou=groups,dc=example,dc=com",
+        "objectClass: top",
+        "objectClass: organizationalUnit",
+        "ou: groups"
 })
 public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
-    private static boolean portUpdated;
 
+    private static boolean portUpdated;
 
     @Before
     public void setUp() throws Exception {
@@ -200,18 +202,14 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
             if (pr instanceof UserPrincipal) {
                 assertEquals("hnelson", pr.getName());
                 foundUser = true;
-            } else if (pr instanceof RolePrincipal) {
-                assertEquals("admin", pr.getName());
-                foundRole = true;
             }
         }
         assertTrue(foundUser);
-        assertTrue(foundRole);
 
         assertTrue(module.logout());
         assertEquals("Principals should be gone as the user has logged out", 0, subject.getPrincipals().size());
     }
-/*
+
     @Test(expected = LoginException.class)
     public void testUsernameFailure() throws Exception {
 
@@ -286,7 +284,7 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertFalse(module.login());
     }
-*/
+
     protected void setupEnv(Class<? extends Transport> transport, EncryptionType encryptionType,
                             ChecksumType checksumType)
             throws Exception {
@@ -298,7 +296,7 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
         kdcServer.getConfig().setEncryptionTypes(Collections.singleton(encryptionType));
 
         // create principals
-        createPrincipal("uid=" + USER_UID, "Last", "First Last",
+        createPrincipal("uid=" + USER_UID, "Last", "admin",
                 USER_UID, USER_PASSWORD, USER_UID + "@" + REALM);
 
         createPrincipal("uid=krbtgt", "KDC Service", "KDC Service",

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -173,7 +173,6 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
     public void testSuccess() throws Exception {
 
         Properties options = ldapLoginModuleOptions();
-        options.setProperty(GSSAPILdapLoginModule.REALM_PROPERTY, "krb5TestRealm");
         GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
 
         CallbackHandler cb = new CallbackHandler() {

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -162,7 +162,8 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
             String content = IOUtils.toString(inputStream, "UTF-8");
             inputStream.close();
             content = content.replaceAll("portno", "" + super.getLdapServer().getPort());
-            content = content.replaceAll("address", "localhost");
+            content = content.replaceAll("address", KerberosTestUtils.getHostName());
+            //content = content.replaceAll("address", "localhost");
             //content = content.replaceAll("address", "" + super.getLdapServer().getSaslHost());
             //content = content.replaceAll("address", "" + super.getLdapServer().getTransports()[0].getAddress());
 

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -163,9 +163,6 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
             inputStream.close();
             content = content.replaceAll("portno", "" + super.getLdapServer().getPort());
             content = content.replaceAll("address", KerberosTestUtils.getHostName());
-            //content = content.replaceAll("address", "localhost");
-            //content = content.replaceAll("address", "" + super.getLdapServer().getSaslHost());
-            //content = content.replaceAll("address", "" + super.getLdapServer().getTransports()[0].getAddress());
 
             File f2 = new File(basedir + "/target/test-classes/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties");
             FileOutputStream outputStream = new FileOutputStream(f2);

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties
@@ -18,7 +18,7 @@
 ################################################################################
 
 debug=true
-connection.url=ldap://localhost:portno
+connection.url=ldap://address:portno
 connection.username=hnelson
 connection.password=secret
 connection.protocol=

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties
@@ -1,0 +1,35 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+debug=true
+connection.url=ldap://127.0.0.1:portno
+connection.username=uid=hnelson,ou=users
+connection.password=secret
+authentication=GSSAPI
+
+user.base.dn=ou=users,dc=example,dc=com
+user.filter=(uid=%u)
+user.search.subtree=true
+
+role.base.dn=ou=groups,dc=example,dc=com
+role.name.attribute=cn
+role.filter=(member=%fqdn)
+role.search.subtree=true
+
+initialContextFactory=com.sun.jndi.ldap.LdapCtxFactory

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties
@@ -18,9 +18,10 @@
 ################################################################################
 
 debug=true
-connection.url=ldap://127.0.0.1:portno
+connection.url=ldap://localhost:portno
 connection.username=hnelson
 connection.password=secret
+connection.protocol=
 authentication=GSSAPI
 
 user.base.dn=ou=users,dc=example,dc=com

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties
@@ -23,6 +23,7 @@ connection.username=hnelson
 connection.password=secret
 connection.protocol=
 authentication=GSSAPI
+gssapiRealm=krb5TestRealm
 
 user.base.dn=ou=users,dc=example,dc=com
 user.filter=(uid=%u)

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.ldap.properties
@@ -19,7 +19,7 @@
 
 debug=true
 connection.url=ldap://127.0.0.1:portno
-connection.username=uid=hnelson,ou=users
+connection.username=hnelson
 connection.password=secret
 authentication=GSSAPI
 

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.login.config
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.login.config
@@ -1,0 +1,5 @@
+propertiesTestRealm {
+  org.apache.karaf.jaas.modules.properties.PropertiesLoginModule REQUIRED
+  users="src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.users.properties"
+  debug=true;
+};

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.login.config
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.login.config
@@ -1,5 +1,8 @@
-propertiesTestRealm {
-  org.apache.karaf.jaas.modules.properties.PropertiesLoginModule REQUIRED
-  users="src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.users.properties"
+krb5TestRealm {
+  org.apache.karaf.jaas.modules.krb5.Krb5LoginModule REQUIRED
+  refreshKrb5Config = true
+  password-stacking = storePass
+  doNotPrompt = false
+  useTicketCache = true
   debug=true;
 };

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.users.properties
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.users.properties
@@ -1,2 +1,0 @@
-test=test,test
-admin=admin123,admin

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.users.properties
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/gssapi.users.properties
@@ -1,0 +1,2 @@
+test=test,test
+admin=admin123,admin

--- a/manual/src/main/asciidoc/developer-guide/security-framework.adoc
+++ b/manual/src/main/asciidoc/developer-guide/security-framework.adoc
@@ -561,10 +561,10 @@ Here is a simple example of a krb5 configuration file :
 |
 |===
 
-The GSSAPI module uses the Oracle JVM GSSAPI mechanism to handle authentication to a LDAP server.
+The GSSAPI module uses the GSSAPI mechanism to handle authentication to a LDAP server.
 Typical use is using this and a Kerberos Login Module to connect to an ActiveDirectory Server, or any other LDAP server that needs a Kerberos tickets for authentication.
 
-Here is a simple configuration, that use as Kerberos login module as authentication backend and a LDAP server:
+Here is a simple configuration, that use as Kerberos login module as authentication backend :
 ----
 <jaas:config name="ldap" rank="1">
   <jaas:module className="org.apache.karaf.jaas.modules.ldap.GSSAPILdapLoginModule"flags="required">

--- a/manual/src/main/asciidoc/developer-guide/security-framework.adoc
+++ b/manual/src/main/asciidoc/developer-guide/security-framework.adoc
@@ -516,6 +516,81 @@ performed directly on the LDAP backend.
 
 The Kerberos login module uses the Oracle JVM Krb5 internal login module.
 
+Here is a simple configuration :
+----
+<jaas:config name="krb5" rank="1">
+  <jaas:module className="org.apache.karaf.jaas.modules.krb5.Krb5LoginModule">
+    refreshKrb5Config = true
+    password-stacking = storePass
+    doNotPrompt = false
+    useTicketCache = true
+  </jaas:module>
+</jaas:config>
+----
+
+You must specify a krb5 configuration file through the "java.security.krb5.conf" system property.
+Here is a simple example of a krb5 configuration file :
+----
+[libdefaults]
+ default_realm = EXAMPLE.COM
+ dns_lookup_realm = false
+ dns_lookup_kdc = false
+ ticket_lifetime = 24h
+ renew_lifetime = 365d
+ forwardable = true
+
+[realms]
+
+ EXAMPLE.COM = {
+  kdc = kdc.example.com
+  admin_server = kdc.example.com
+  default_domain = example.com
+ }
+
+[domain_realm]
+ .example.com = EXAMPLE.COM
+ example.com = EXAMPLE.COM
+----
+
+===== GSSAPILdapLoginModule
+
+|===
+|LoginModule |BackendEngineFactory
+
+|org.apache.karaf.jaas.modules.ldap.GSSAPILdapLoginModule
+|
+|===
+
+The GSSAPI module uses the Oracle JVM GSSAPI mechanism to handle authentication to a LDAP server.
+Typical use is using this and a Kerberos Login Module to connect to an ActiveDirectory Server, or any other LDAP server that needs a Kerberos tickets for authentication.
+
+Here is a simple configuration, that use as Kerberos login module as authentication backend and a LDAP server:
+----
+<jaas:config name="ldap" rank="1">
+  <jaas:module className="org.apache.karaf.jaas.modules.ldap.GSSAPILdapLoginModule"flags="required">
+    gssapiRealm=krb5
+    initialContextFactory=com.sun.jndi.ldap.LdapCtxFactory
+    connection.url=ldap://activedirectory_host:389
+    user.base.dn=ou=Users,ou=there,DC=local
+    user.filter=(sAMAccountName=%u)
+    user.search.subtree=true
+    role.base.dn=ou=Groups,ou=there,DC=local
+    role.name.attribute=cn
+    role.filter=(member=%fqdn)
+    role.search.subtree=true
+  </jaas:module>
+</jaas:config>
+<jaas:config name="krb5" rank="1">
+  <jaas:module className="org.apache.karaf.jaas.modules.krb5.Krb5LoginModule">
+    refreshKrb5Config = true
+    password-stacking = storePass
+    doNotPrompt = false
+    useTicketCache = true
+  </jaas:module>
+</jaas:config>
+----
+Note the 'gssapiRealm' property of the LDAP login module that match the name of the Kerberos Configuration.
+
 ===== SyncopeLoginModule
 
 |===

--- a/manual/src/main/asciidoc/user-guide/security.adoc
+++ b/manual/src/main/asciidoc/user-guide/security.adoc
@@ -59,6 +59,8 @@ Apache Karaf provides additional login modules (see the developer guide for deta
 * LDAPLoginModule uses a LDAP server as backend
 * SyncopeLoginModule uses Apache Syncope as backend
 * OsgiConfigLoginModule uses a configuration as backend
+* Krb5LoginModule uses a Kerberos Server as backend
+* GSSAPILdapLoginModule uses a LDAP server as backend but delegate LDAP server authentication to an other backend (typically Krb5LoginModule)
 
 You can manage an existing realm, login module, or create your own realm using the `jaas:realm-manage` command.
 


### PR DESCRIPTION
A GSSAPI login module.
Only tested with Kerberos authentication.
Typically allows to use an Active Directory Server with Kerberos Authentication as LDAP backend.
https://issues.apache.org/jira/browse/KARAF-4487
