### PR TITLE
[KARAF-4805] configfiles are not copied to system directory

### DIFF
--- a/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
+++ b/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
@@ -753,6 +753,10 @@ public class Builder {
                     installArtifact(downloader, bundle.getLocation().trim());
                 }
             }
+            // Install config files
+            for (ConfigFile configFile : feature.getConfigfile()) {
+                installArtifact(downloader, configFile.getLocation().trim());
+            }
             for (Conditional cond : feature.getConditional()) {
                 for (Bundle bundle : cond.getBundle()) {
                     if (!ignoreDependencyFlag || !bundle.isDependency()) {


### PR DESCRIPTION
Added the missing copy of the config files and tested it. 
