### PR TITLE
KARAF-4806: specify /bin/bash for scripts with bashisms

### DIFF
--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/client
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/client
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/instance
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/instance
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with

--- a/assemblies/features/framework/src/main/filtered-resources/resources/bin/shell
+++ b/assemblies/features/framework/src/main/filtered-resources/resources/bin/shell
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
The client, instance and shell scripts use ulimit and type, but these
are bashisms. In some environments (e.g. Solaris, Debian) /bin/sh
isn't bash.

Signed-off-by: Stephen Kitt skitt@redhat.com
(cherry picked from commit 9e72b9357d20de866abce7391cdc41ba616f3a75)
