### PR TITLE
KARAF-4809, SSH should not listen to all hosts

### DIFF
--- a/assemblies/features/base/src/main/resources/resources/etc/org.apache.karaf.shell.cfg
+++ b/assemblies/features/base/src/main/resources/resources/etc/org.apache.karaf.shell.cfg
@@ -25,7 +25,7 @@
 # Via sshPort and sshHost you define the address you can login into Karaf.
 #
 sshPort = 8101
-sshHost = 0.0.0.0
+sshHost = 127.0.0.1
 
 #
 # The sshIdleTimeout defines the inactivity timeout to logout the SSH session.


### PR DESCRIPTION
The default SSH server configuration will make Karaf listen to all
hosts. It is usually good practice to instead listen to localhost only
by default to avoid possible security risks (e.g. accidentally exposing
an unconfigured SSH server).
