### PR TITLE
KARAF-4809, SSH should not listen to all hosts

### DIFF
--- a/assemblies/features/base/src/main/resources/resources/etc/org.apache.karaf.shell.cfg
+++ b/assemblies/features/base/src/main/resources/resources/etc/org.apache.karaf.shell.cfg
@@ -23,9 +23,10 @@
 
 #
 # Via sshPort and sshHost you define the address you can login into Karaf.
-#
-sshPort = 8101
-sshHost = 127.0.0.1
+# Default(sshPort): 8101
+# Default(sshHost): 127.0.0.1
+#sshPort = 8101
+#sshHost = 127.0.0.1
 
 #
 # The sshIdleTimeout defines the inactivity timeout to logout the SSH session.

--- a/assemblies/features/base/src/main/resources/resources/etc/org.apache.karaf.shell.cfg
+++ b/assemblies/features/base/src/main/resources/resources/etc/org.apache.karaf.shell.cfg
@@ -25,7 +25,7 @@
 # Via sshPort and sshHost you define the address you can login into Karaf.
 #
 sshPort = 8101
-sshHost = 0.0.0.0
+sshHost = 127.0.0.1
 
 #
 # The sshIdleTimeout defines the inactivity timeout to logout the SSH session.

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/Activator.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/Activator.java
@@ -140,8 +140,8 @@ public class Activator extends BaseActivator implements ManagedService {
     }
 
     protected SshServer createSshServer(SessionFactory sessionFactory) {
-        int sshPort           = getInt("sshPort", 8181);
-        String sshHost        = getString("sshHost", "0.0.0.0");
+        int sshPort           = getInt("sshPort", 8101);
+        String sshHost        = getString("sshHost", "127.0.0.1");
         long sshIdleTimeout   = getLong("sshIdleTimeout", 1800000);
         String sshRealm       = getString("sshRealm", "karaf");
         String hostKey        = getString("hostKey", System.getProperty("karaf.etc") + "/host.key");


### PR DESCRIPTION
The default SSH server configuration will make Karaf listen to all
hosts. It is usually good practice to instead listen to localhost only
by default to avoid possible security risks (e.g. accidentally exposing
an unconfigured SSH server).

This is a rebased version of pull request #259 since @cschneider told me in IRC that pull requests are expected to be created against master and then cherry-picked to release branches. Hence, please feel free to reject the other pull request.
