### PR TITLE
KARAF-4813, RMI should not listen to all hosts

### DIFF
--- a/assemblies/features/base/src/main/resources/resources/etc/org.apache.karaf.management.cfg
+++ b/assemblies/features/base/src/main/resources/resources/etc/org.apache.karaf.management.cfg
@@ -29,7 +29,7 @@ rmiRegistryPort = 1099
 #
 # Host for RMI registry
 #
-rmiRegistryHost = 0.0.0.0
+rmiRegistryHost = 127.0.0.1
 
 #
 # Port number for RMI server connection
@@ -39,7 +39,7 @@ rmiServerPort = 44444
 #
 # Host for RMI server
 #
-rmiServerHost = 0.0.0.0
+rmiServerHost = 127.0.0.1
 
 #
 # Name of the JAAS realm used for authentication


### PR DESCRIPTION
The default RMI configuration will make Karaf listen to all hosts.
Instead. it is usually good practice to, by default, listen to localhost
only to avoid possible security risks.

This patch modified the default configuration file to set RMI to
localhost.