### PR TITLE
KARAF-4814, Special character in stop script

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/stop
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/stop
@@ -145,7 +145,7 @@ run() {
         KARAF_BASE=`cygpath --path --windows "$KARAF_BASE"`
         KARAF_DATA=`cygpath --path --windows "$KARAF_DATA"`
         KARAF_ETC=`cygpath --path --windows "$KARAF_ETC"`
-        if [ ! -z "$CLASSPATH" ]; then
+        if [ ! -z "$CLASSPATH" ]; then
             CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
         fi
     fi


### PR DESCRIPTION
The stop script contains an `&nbsp;` for what should be a regular space.