### PR TITLE
Fix Contribute link in README

### DIFF
--- a/README
+++ b/README
@@ -69,7 +69,7 @@ with JIRA here:
 We welcome contributions, and encourage you to get involved in the 
 Karaf community. If you'd like to learn more about how you can
 contribute, please see:
-    http://karaf.apache.org/index/community/contributing.html
+    http://karaf.apache.org/community.html#contribute
 
 Many thanks for using Apache Karaf.
 


### PR DESCRIPTION
In README, the URL to contribute is incorrect: http://karaf.apache.org/index/community/contributing.html returns a 404.