### PR TITLE
KARAF-4853, Option to prevent execution as root

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/setenv
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/setenv
@@ -48,4 +48,4 @@
 # export KARAF_OPTS # Additional available Karaf options
 # export KARAF_DEBUG # Enable debug mode
 # export KARAF_REDIRECT # Enable/set the std/err redirection when using bin/start
-
+# export KARAF_NOROOT # Prevent execution as root if set to true

--- a/assemblies/features/base/src/main/resources/resources/bin/karaf
+++ b/assemblies/features/base/src/main/resources/resources/bin/karaf
@@ -70,6 +70,14 @@ die() {
     exit 1
 }
 
+forceNoRoot() {
+    # If configured, prevent execution as root
+	 if [ "${KARAF_NOROOT}" ] && [ "$(id -u)" -eq 0 ]; then
+        echo "Do not run as root!"
+        exit 2
+    fi
+}
+
 detectOS() {
     # OS specific support (must be 'true' or 'false').
     cygwin=false;
@@ -360,6 +368,9 @@ checkRootInstance() {
 }
 
 init() {
+    # Prevent root execution if configured
+	 forceNoRoot
+
     # Determine if there is special OS handling we must perform
     detectOS
 


### PR DESCRIPTION
Usually, it is not a good idea to run Karaf as root. In some cases, it
might even be harmful. This patch introduces the option `KARAF_NOROOT`
which, if set, will prevent Karaf from being executed as root.