### PR TITLE
Remove duplicate copy resource step

### DIFF
--- a/manual/src/main/asciidoc/developer-guide/custom-distribution.adoc
+++ b/manual/src/main/asciidoc/developer-guide/custom-distribution.adoc
@@ -136,20 +136,6 @@ This is the minimal assembly pom changed to use the packaging and annotated
         </resources>
 
         <plugins>
-            <!-- if you want to include resources in the distribution -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
-                <executions>
-                    <execution>
-                        <id>process-resources</id>
-                        <goals>
-                            <goal>resources</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- karaf-maven-plugin will call both assembly and archive goals -->
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
@@ -231,20 +217,6 @@ For instance, to pre-install Spring 4.0.7.RELEASE_1 feature in your custom distr
         </resources>
 
         <plugins>
-            <!-- if you want to include resources in the distribution -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
-                <executions>
-                    <execution>
-                        <id>process-resources</id>
-                        <goals>
-                            <goal>resources</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>


### PR DESCRIPTION
Hello,

In the provided example poms, resources will be copied twice first with `resource` tag and second via the `maven-resources-plugin`. The second copy call had been started after `karaf-assembly` execution. 

```[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building server 4.2-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ server ---
[INFO] Deleting C:\Projekte\App\server\target
[INFO]
[INFO] --- maven-resources-plugin:2.7:resources (default-resources) @ server ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 11 resources
[INFO]
[INFO] --- karaf-maven-plugin:4.0.7:assembly (default-assembly) @ server ---
..........
[INFO]
[INFO] --- maven-resources-plugin:2.7:resources (process-resources) @ server ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 11 resources
[INFO]
[INFO] --- karaf-maven-plugin:4.0.7:archive (default-archive) @ server ---```

After the changing the resources will only copied once.

```[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building server 4.2-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ server ---
[INFO] Deleting C:\Projekte\App\server\target
[INFO]
[INFO] --- maven-resources-plugin:2.7:resources (default-resources) @ server ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 11 resources
[INFO]
[INFO] --- karaf-maven-plugin:4.0.7:assembly (default-assembly) @ server ---
..........
[INFO]
[INFO] --- karaf-maven-plugin:4.0.7:archive (default-archive) @ server ---````

