### PR TITLE
KARAF-4917 Support dynamicaliy registered configurations in RBAC

### DIFF
--- a/management/server/src/main/java/org/apache/karaf/management/KarafMBeanServerGuard.java
+++ b/management/server/src/main/java/org/apache/karaf/management/KarafMBeanServerGuard.java
@@ -367,7 +367,8 @@ public class KarafMBeanServerGuard implements InvocationHandler {
         String[] pidStrArray = pid.split(Pattern.quote("."));
         Set<String[]> rets = new TreeSet<String[]>(WILDCARD_PID_COMPARATOR);
         for (String id : allPids) {
-            String[] idStrArray = id.split(Pattern.quote("."));
+            String idWithoutRandomSuffix = id.replaceFirst("\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", "");
+            String[] idStrArray = idWithoutRandomSuffix.split(Pattern.quote("."));
             if (idStrArray.length == pidStrArray.length) {
                 boolean match = true;
                 for (int i = 0; i < idStrArray.length; i++) {
@@ -380,7 +381,7 @@ public class KarafMBeanServerGuard implements InvocationHandler {
                     }
                 }
                 if (match) {
-                    rets.add(idStrArray);
+                    rets.add(id.split(Pattern.quote(".")));
                 }
             }
         }


### PR DESCRIPTION
When adding configuration at runtime through
`ConfigurationAdmin#createFactoryConfiguration` Apache Felix appends
random UUID to the Configuration PID [1][2].

In order for those to be considered by `getRequiredRoles` that random 
UUID needs to be removed in comparison performed by `getGeneralPid`.

[1] https://github.com/apache/felix/blob/trunk/configadmin/src/main/java/org/apache/felix/cm/impl/ConfigurationManager.java#L397-L400
[2] https://github.com/apache/felix/blob/trunk/configadmin/src/main/java/org/apache/felix/cm/impl/ConfigurationManager.java#L1093-L1137