### PR TITLE
[KARAF-4968] LDAPLoginModule does not correctly implement login method

### DIFF
--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPLoginModule.java
@@ -138,7 +138,7 @@ public class LDAPLoginModule extends AbstractKarafLoginModule {
             context.close();
         } catch (Exception e) {
             logger.warn("User " + user + " authentication failed.", e);
-            return false;
+            throw new LoginException("Authentication failed: " + e.getMessage());
         } finally {
             if (context != null) {
                 try {

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapLoginModuleTest.java
@@ -246,7 +246,12 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
         module.initialize(subject, cb, null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
-        assertFalse(module.login());
+        try {
+            module.login();
+            fail("Should have thrown LoginException");
+        } catch (LoginException e) {
+            assertTrue(e.getMessage().startsWith("Authentication failed"));
+        }
     }
 
     @Test


### PR DESCRIPTION
Correcting the behavior of the LDAPLoginModule's login method in case of failed authentication.
More details provided in the JIRA issue: https://issues.apache.org/jira/browse/KARAF-4968