### PR TITLE
Expose Dependency.hasVersion()

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/Dependency.java
+++ b/features/core/src/main/java/org/apache/karaf/features/Dependency.java
@@ -23,6 +23,8 @@ public interface Dependency {
 
     String getVersion();
 
+    boolean hasVersion();
+
     boolean isPrerequisite();
 
     boolean isDependency();

--- a/features/core/src/main/java/org/apache/karaf/features/internal/model/Dependency.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/model/Dependency.java
@@ -69,6 +69,7 @@ public class Dependency implements org.apache.karaf.features.Dependency {
      * @return possible object is
      * {@link String }
      */
+    @Override
     public String getName() {
         return name;
     }
@@ -89,6 +90,7 @@ public class Dependency implements org.apache.karaf.features.Dependency {
      * @return possible object is
      * {@link String }
      */
+    @Override
     public String getVersion() {
         if (version == null) {
             return Feature.DEFAULT_VERSION;
@@ -105,6 +107,15 @@ public class Dependency implements org.apache.karaf.features.Dependency {
      */
     public void setVersion(String value) {
         this.version = value;
+    }
+
+    /**
+     * Since version has a default value ("0.0.0"), returns
+     * whether or not the version has been set.
+     */
+    @Override
+    public boolean hasVersion() {
+        return version != null;
     }
 
     @Override


### PR DESCRIPTION
Since Dependency.getVersion() behaves the same as Feature.getVersion()
by returning "0.0.0" when no version is set, users attempting to examine
dependencies need to resort to touching the internal model to understand
that the version is not actually set.

Expose Dependency.hasVersion() to help potential users to understand
that the version has not been set.

Signed-off-by: Robert Varga <nite@hq.sk>