### PR TITLE
[KARAF-4989] Changed parsing of jaas ldap login module role.mapping option

### DIFF
--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPOptions.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPOptions.java
@@ -125,9 +125,9 @@ public class LDAPOptions {
             LOGGER.debug("Parse role mapping {}", option);
             String[] mappings = option.split(";");
             for (String mapping : mappings) {
-                String[] map = mapping.split("=", 2);
-                String ldapRole = map[0].trim();
-                String[] karafRoles = map[1].split(",");
+                int index = mapping.lastIndexOf("=");
+                String ldapRole = mapping.substring(0,index).trim();
+                String[] karafRoles = mapping.substring(index+1).split(",");
                 if (roleMapping.get(ldapRole) == null) {
                     roleMapping.put(ldapRole, new HashSet<String>());
                 }

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/example.com.ldif
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/example.com.ldif
@@ -34,6 +34,7 @@ dn: cn=admin,ou=groups,dc=example,dc=com
 objectClass: top
 objectClass: groupOfNames
 cn: admin
+description: cn=admin,ou=groups,dc=example,dc=com
 member: cn=admin,ou=people,dc=example,dc=com
 
 dn: cn=admin,ou=people,dc=example,dc=com
@@ -55,4 +56,3 @@ cn: cheese
 sn: cheese
 uid: cheese
 userPassword: foodie
-

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/example.com_with_escapes.ldif
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/example.com_with_escapes.ldif
@@ -34,6 +34,7 @@ dn: cn=admin,ou=groups,dc=example,dc=com
 objectClass: top
 objectClass: groupOfNames
 cn: admin
+description: cn=admin,ou=groups,dc=example,dc=com
 member: cn=admin\,\=\+\<\>#\;\\,ou=people,dc=example,dc=com
 
 dn: cn=admin\,\=\+\<\>#\;\\,ou=people,dc=example,dc=com


### PR DESCRIPTION
to support fqdn (i.e. strings with more than 1 equal char). The changes are compatible with previous logic.
An example usage is in: jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapLoginModuleTest.java