### PR TITLE
[KARAF-4997] Generator: merge dependency information

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -557,7 +557,14 @@ public class GenerateDescriptorMojo extends MojoSupport {
             }
             for (Feature includedFeature : includedFeatures.getFeature()) {
                 Dependency dependency = new Dependency(includedFeature.getName(), includedFeature.getVersion());
-                // We musn't de-duplicate here, we may have seen a feature in !add mode
+                // Determine what dependency we're actually going to use
+                Dependency matchingDependency = findMatchingDependency(feature.getFeature(), dependency);
+                if (matchingDependency != null) {
+                    // The feature already has a matching dependency, merge
+                    mergeDependencies(matchingDependency, dependency);
+                    dependency = matchingDependency;
+                }
+                // We mustn't de-duplicate here, we may have seen a feature in !add mode
                 otherFeatures.put(dependency, includedFeature);
                 if (add) {
                     if (!feature.getFeature().contains(dependency)) {
@@ -572,6 +579,28 @@ public class GenerateDescriptorMojo extends MojoSupport {
                             this.dependencyHelper.artifactToMvn(artifact, getVersionOrRange(parent, artifact)));
                 }
             }
+        }
+    }
+
+    private Dependency findMatchingDependency(List<Dependency> dependencies, Dependency reference) {
+        String referenceName = reference.getName();
+        for (Dependency dependency : dependencies) {
+            if (referenceName.equals(dependency.getName())) {
+                return dependency;
+            }
+        }
+        return null;
+    }
+
+    private void mergeDependencies(Dependency target, Dependency source) {
+        if (target.getVersion() == null || Feature.DEFAULT_VERSION.equals(target.getVersion())) {
+            target.setVersion(source.getVersion());
+        }
+        if (source.isDependency()) {
+            target.setDependency(true);
+        }
+        if (source.isPrerequisite()) {
+            target.setPrerequisite(true);
         }
     }
 


### PR DESCRIPTION
In the generator, feature dependencies added from POM entries are
checked against existing dependency information (e.g. from
pre-existing feature.xml stubs). Matching entries are preserved and
the information merged: this allows versions to be determined from the
POM, and dependency/prerequisite flags to be defined in feature.xml.

Signed-off-by: Stephen Kitt <skitt@redhat.com>