### PR TITLE
Update AssemblyMojo.java

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
@@ -409,7 +409,7 @@ public class AssemblyMojo extends MojoSupport {
                 case Boot:      bootKars.add(uri); break;
                 case Installed: installedKars.add(uri); break;
                 }
-            } else if ("features".equals(artifact.getClassifier())) {
+            } else if ("features".equals(artifact.getClassifier()) || "karaf".equals(artifact.getClassifier())) {
                 String uri = artifactToMvn(artifact);
                 switch (stage) {
                 case Startup:   startupRepositories.add(uri); break;


### PR DESCRIPTION
HIbernate 5.x Features in the JBoss Maven repository https://repository.jboss.org/nexus/content/repositories/releases/ has a classifier of "karaf" and not "features".

This PR should fix that particular issue in the short term.

In case it is not obvious, I am niclas@apache.org, and an ASF Member with ICLA on file with the secretary.