### PR TITLE
KARAF-5055: use karaf shutdown timeout when notifying the service wra…

### DIFF
--- a/main/src/main/java/org/apache/karaf/main/Main.java
+++ b/main/src/main/java/org/apache/karaf/main/Main.java
@@ -638,11 +638,13 @@ public class Main {
             return true;
         }
         try {
-            int step = 5000;
-
-            // Notify the callback asap
+            int timeout = config.shutdownTimeout;
+            if (config.shutdownTimeout <= 0) {
+                timeout = Integer.MAX_VALUE;
+            }
+            
             if (shutdownCallback != null) {
-                shutdownCallback.waitingForShutdown(step);
+                shutdownCallback.waitingForShutdown(timeout);
             }
 
             exiting = true;
@@ -659,15 +661,9 @@ public class Main {
                 }.start();
             }
 
-            int timeout = config.shutdownTimeout;
-            if (config.shutdownTimeout <= 0) {
-                timeout = Integer.MAX_VALUE;
-            }
+            int step = 5000;      
             while (timeout > 0) {
                 timeout -= step;
-                if (shutdownCallback != null) {
-                    shutdownCallback.waitingForShutdown(step * 2);
-                }
                 FrameworkEvent event = framework.waitForStop(step);
                 if (event.getType() != FrameworkEvent.WAIT_TIMEDOUT) {
                     if (activatorManager != null) {


### PR DESCRIPTION
…pper

https://issues.apache.org/jira/browse/KARAF-5055

Instead of notifying the service wrapper every 5 seconds that we are awaiting shutdown for 5*2 seconds or so, I propose to notify once the service wrapper that we are shutting down using the Karaf shutdown timeout.

I've tested both when the timeout is reached(ungraceful shutdown) and when it's not (graceful shutdown). Both cases yield expected behavior.

Thanks!