### PR TITLE
[KARAF-4260] Rename Service Wrapper pid file to not clash with Karaf JVM pid file

### DIFF
--- a/wrapper/src/main/resources/org/apache/karaf/wrapper/internal/unix/karaf-service
+++ b/wrapper/src/main/resources/org/apache/karaf/wrapper/internal/unix/karaf-service
@@ -134,7 +134,7 @@ fi
 
 # Process ID
 ANCHORFILE="$PIDDIR/$APP_NAME.anchor"
-PIDFILE="$PIDDIR/$APP_NAME.pid"
+PIDFILE="$PIDDIR/$APP_NAME.wrapper.pid"
 LOCKDIR="/var/lock/subsys"
 LOCKFILE="$LOCKDIR/$APP_NAME"
 pid=""

--- a/wrapper/src/main/resources/org/apache/karaf/wrapper/internal/unix/karaf.service
+++ b/wrapper/src/main/resources/org/apache/karaf/wrapper/internal/unix/karaf.service
@@ -23,7 +23,7 @@ Description=${displayName}
 
 [Service]
 Type=forking
-PIDFile=${karaf.base}/${name}.pid
+PIDFile=${karaf.base}/${name}.wrapper.pid
 ExecStart=${karaf.base}/bin/${name}-service start
 ExecReload=${karaf.base}/bin/${name}-service restart
 ExecStop=${karaf.base}/bin/${name}-service stop


### PR DESCRIPTION
When service name is 'karaf' PID file created by Service Wrapper clashes with PID file created from Karaf JVM. As result service is started, PID file overridden by Karaf Java code and service can't be controlled by OS "service" command.

Example output:

```
[root@smosesb02 java]# service karaf stop
Stopping karaf...
Removed stale pid file: /opt/apache-karaf-4.0.9-SNAPSHOT/karaf.pid
karaf was not running.

[root@smosesb02 java]# ps -ef | grep java
root      5184 17242  0 12:24 pts/0    00:00:00 grep java
karaf    27269 27267 24 12:19 ?        00:01:06 /usr/java/jdk1.8.0_92/bin/java -Dkaraf.home=/opt/apache-karaf-4.0.9-SNAPSHOT -Dkaraf.base=/opt/apache-karaf-4.0.9-SNAPSHOT -Dkaraf.data=/opt/apache-karaf-4.0.9-SNAPSHOT/data -Dkaraf.etc=/opt/apache-karaf-4.0.9-SNAPSHOT/etc -Dcom.sun.management.jmxremote -Dkaraf.startLocalConsole=false -Dkaraf.startRemoteShell=true -Djava.endorsed.dirs=/usr/java/jdk1.8.0_92/jre/lib/endorsed:/usr/java/jdk1.8.0_92/lib/endorsed:/opt/apache-karaf-4.0.9-SNAPSHOT/lib/endorsed -Djava.ext.dirs=/usr/java/jdk1.8.0_92/jre/lib/ext:/usr/java/jdk1.8.0_92/lib/ext:/opt/apache-karaf-4.0.9-SNAPSHOT/lib/ext -Djava.io.tmpdir=/opt/apache-karaf-4.0.9-SNAPSHOT/data/tmp -XX:MaxPermSize=128m -Djava.io.tmpdir=/opt/apache-karaf-4.0.9-SNAPSHOT/data/tmp -XX:-HeapDumpOnOutOfMemoryError -Xms512m -Xmx512m -Djava.library.path=/opt/apache-karaf-4.0.9-SNAPSHOT/lib/wrapper/ -classpath /opt/apache-karaf-4.0.9-SNAPSHOT/lib/boot/org.apache.karaf.diagnostic.boot-4.0.8.CITC_8.jar:/opt/apache-karaf-4.0.9-SNAPSHOT/lib/boot/org.apache.karaf.jaas.boot-4.0.8.CITC_8.jar:/opt/apache-karaf-4.0.9-SNAPSHOT/lib/boot/org.osgi.core-6.0.0.jar:/opt/apache-karaf-4.0.9-SNAPSHOT/lib/boot/org.apache.karaf.main-4.0.8.CITC_8.jar:/opt/apache-karaf-4.0.9-SNAPSHOT/lib/wrapper/karaf-wrapper-main.jar:/opt/apache-karaf-4.0.9-SNAPSHOT/lib/wrapper/karaf-wrapper.jar -Dwrapper.key=755NX7xqehWEZrWs -Dwrapper.port=32001 -Dwrapper.jvm.port.min=31000 -Dwrapper.jvm.port.max=31999 -Dwrapper.pid=27267 -Dwrapper.version=3.2.3 -Dwrapper.native_library=wrapper -Dwrapper.service=TRUE -Dwrapper.cpu.timeout=30 -Dwrapper.jvmid=1 org.apache.karaf.wrapper.internal.service.Main

```