### PR TITLE
Remove the VM option "-server"

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/inc
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/inc
@@ -274,7 +274,7 @@ setupDefaults() {
                 DEFAULT_JAVA_OPTS="${DEFAULT_JAVA_OPTS} -XX:MaxPermSize=${JAVA_MAX_PERM_MEM}"
             fi
         fi
-        DEFAULT_JAVA_OPTS="-server ${DEFAULT_JAVA_OPTS} -Dcom.sun.management.jmxremote"
+        DEFAULT_JAVA_OPTS="${DEFAULT_JAVA_OPTS} -Dcom.sun.management.jmxremote"
     elif [ "${JVM_VENDOR}" = "IBM" ]; then
         if ${os400}; then
             DEFAULT_JAVA_OPTS="${DEFAULT_JAVA_OPTS}"

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat
@@ -96,7 +96,6 @@ if "%KARAF_ETC%" == "" (
 )
 
 set LOCAL_CLASSPATH=%CLASSPATH%
-set JAVA_MODE=-server
 
 set CLASSPATH=%LOCAL_CLASSPATH%;%KARAF_BASE%\conf
 set DEFAULT_JAVA_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
@@ -235,10 +234,9 @@ if not exist "%JAVA_HOME%\bin\server\jvm.dll" (
         echo WARNING: Running Karaf on a Java HotSpot Client VM because server-mode is not available.
         echo Install Java Developer Kit to fix this.
         echo For more details see http://java.sun.com/products/hotspot/whitepaper.html#client
-        set JAVA_MODE=-client
     )
 )
-set DEFAULT_JAVA_OPTS=%JAVA_MODE% -Xms%JAVA_MIN_MEM% -Xmx%JAVA_MAX_MEM% -Dcom.sun.management.jmxremote  -XX:+UnlockDiagnosticVMOptions -XX:+UnsyncloadClass
+set DEFAULT_JAVA_OPTS=-Xms%JAVA_MIN_MEM% -Xmx%JAVA_MAX_MEM% -Dcom.sun.management.jmxremote  -XX:+UnlockDiagnosticVMOptions -XX:+UnsyncloadClass
 
 rem Check some easily accessible MIN/MAX params for JVM mem usage
 if not "%JAVA_PERM_MEM%" == "" (


### PR DESCRIPTION
Hi,

If not explicitly defined, the vm option `-server` has been 
automatically set since Java 5.  The bar for it picking `-server` over 
`-client` is pretty low by modern standards; 2 CPU and 2GB RAM.

[http://docs.oracle.com/javase/8/docs/technotes/guides/vm/server-class.html](http://docs.oracle.com/javase/8/docs/technotes/guides/vm/server-class.html)

The Oracle ARMv7 HFP does not support `-server`.  So when running on a 
Raspberry Pi, one must either set JAVA_OPTS or regex replace the 
relevant lines in launch scripts.

IMO it would be better to remove this _redundant_ flag, as I'd guess 
there are few systems that would actually require this to be explicitly 
set.

cheers,
Caspar