### PR TITLE
[KARAF-5107] Add DeploymentListener

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/DeploymentEvent.java
+++ b/features/core/src/main/java/org/apache/karaf/features/DeploymentEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.features;
+
+/**
+ * Enumeration of deployment events. Each deployment is an operation potentially involving multiple features and its
+ * bundles. Deployments cannot overlap.
+ */
+public enum DeploymentEvent {
+    /**
+     * A new deployment operation has started.
+     */
+    DEPLOYMENT_STARTED,
+    /**
+     * Bundle install/uninstall operations within this deployment have completed.
+     */
+    BUNDLES_INSTALLED,
+    /**
+     * Bundle resolution has completed, but the bundles have not yet been started.
+     */
+    BUNDLES_RESOLVED,
+    /**
+     * The deployment has completed.
+     */
+    DEPLOYMENT_FINISHED,
+}

--- a/features/core/src/main/java/org/apache/karaf/features/DeploymentListener.java
+++ b/features/core/src/main/java/org/apache/karaf/features/DeploymentListener.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.features;
+
+import java.util.EventListener;
+
+/**
+ * Interface implemented by components interested in bundle lifecycle operations triggered by {@link FeaturesService}.
+ */
+public interface DeploymentListener extends EventListener {
+    /**
+     * Fired when a deployment event occurs.
+     *
+     * @param event Triggered event
+     */
+    void deploymentEvent(DeploymentEvent event);
+}

--- a/features/core/src/main/java/org/apache/karaf/features/FeaturesService.java
+++ b/features/core/src/main/java/org/apache/karaf/features/FeaturesService.java
@@ -156,6 +156,10 @@ public interface FeaturesService {
 
     void unregisterListener(FeaturesListener listener);
 
+    void registerListener(DeploymentListener listener);
+
+    void unregisterListener(DeploymentListener listener);
+
     FeatureState getState(String featureId);
 
 }

--- a/features/core/src/test/java/org/apache/karaf/features/internal/service/DeployerTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/service/DeployerTest.java
@@ -32,6 +32,7 @@ import java.util.jar.Manifest;
 
 import org.apache.felix.resolver.ResolverImpl;
 import org.apache.felix.utils.version.VersionRange;
+import org.apache.karaf.features.DeploymentEvent;
 import org.apache.karaf.features.Feature;
 import org.apache.karaf.features.FeatureEvent;
 import org.apache.karaf.features.FeaturesService;
@@ -41,7 +42,6 @@ import org.apache.karaf.features.internal.support.TestDownloadManager;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.easymock.IArgumentMatcher;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
@@ -79,6 +79,8 @@ public class DeployerTest {
 
         callback.print(EasyMock.anyString(), EasyMock.anyBoolean());
         EasyMock.expectLastCall().anyTimes();
+        callback.callListeners(DeploymentEvent.DEPLOYMENT_STARTED);
+        EasyMock.expectLastCall();
         callback.replaceDigraph(EasyMock.<Map<String, Map<String, Map<String, Set<String>>>>>anyObject(),
                 EasyMock.<Map<String, Set<Long>>>anyObject());
         EasyMock.expectLastCall();
@@ -86,11 +88,17 @@ public class DeployerTest {
         EasyMock.expectLastCall();
         callback.installFeature(f100);
         EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.BUNDLES_INSTALLED);
+        EasyMock.expectLastCall();
         callback.resolveBundles(EasyMock.<Set<Bundle>>anyObject(),
                                 EasyMock.<Map<Resource, List<Wire>>>anyObject(),
                                 EasyMock.<Map<Resource, Bundle>>anyObject());
         EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.BUNDLES_RESOLVED);
+        EasyMock.expectLastCall();
         callback.callListeners(EasyMock.<FeatureEvent>anyObject());
+        EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.DEPLOYMENT_FINISHED);
         EasyMock.expectLastCall();
 
         Bundle bundleA = createTestBundle(1, Bundle.ACTIVE, dataDir, "a100");
@@ -144,6 +152,8 @@ public class DeployerTest {
 
         callback.print(EasyMock.anyString(), EasyMock.anyBoolean());
         EasyMock.expectLastCall().anyTimes();
+        callback.callListeners(DeploymentEvent.DEPLOYMENT_STARTED);
+        EasyMock.expectLastCall();
 
         callback.stopBundle(EasyMock.eq(bundleA), anyInt());
         EasyMock.expectLastCall().andStubAnswer(new IAnswer<Object>() {
@@ -160,7 +170,7 @@ public class DeployerTest {
                 URL loc = getClass().getResource(dataDir + "/" + "a101" + ".mf");
                 Manifest man = new Manifest(loc.openStream());
                 Hashtable<String, String> headers = new Hashtable<>();
-                for (Map.Entry attr : man.getMainAttributes().entrySet()) {
+                for (Map.Entry<Object, Object> attr : man.getMainAttributes().entrySet()) {
                     headers.put(attr.getKey().toString(), attr.getValue().toString());
                 }
                 bundleA.update(headers);
@@ -177,15 +187,21 @@ public class DeployerTest {
         EasyMock.expectLastCall();
         callback.installFeature(f101);
         EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.BUNDLES_INSTALLED);
+        EasyMock.expectLastCall();
         callback.resolveBundles(EasyMock.eq(Collections.<Bundle>singleton(bundleA)),
                                 EasyMock.<Map<Resource, List<Wire>>>anyObject(),
                                 EasyMock.<Map<Resource, Bundle>>anyObject());
+        EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.BUNDLES_RESOLVED);
         EasyMock.expectLastCall();
         callback.refreshPackages(EasyMock.eq(Collections.<Bundle>singleton(bundleA)));
         EasyMock.expectLastCall();
         callback.callListeners(FeatureEventMatcher.eq(new FeatureEvent(FeatureEvent.EventType.FeatureUninstalled, f100, FeaturesService.ROOT_REGION, false)));
         EasyMock.expectLastCall();
         callback.callListeners(FeatureEventMatcher.eq(new FeatureEvent(FeatureEvent.EventType.FeatureInstalled, f101, FeaturesService.ROOT_REGION, false)));
+        EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.DEPLOYMENT_FINISHED);
         EasyMock.expectLastCall();
 
         EasyMock.replay(callback);
@@ -238,10 +254,14 @@ public class DeployerTest {
 
         callback.print(EasyMock.anyString(), EasyMock.anyBoolean());
         EasyMock.expectLastCall().anyTimes();
+        callback.callListeners(DeploymentEvent.DEPLOYMENT_STARTED);
+        EasyMock.expectLastCall();
         callback.replaceDigraph(EasyMock.<Map<String, Map<String, Map<String, Set<String>>>>>anyObject(),
                 EasyMock.<Map<String, Set<Long>>>anyObject());
         EasyMock.expectLastCall();
         callback.saveState(EasyMock.<State>anyObject());
+        EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.BUNDLES_INSTALLED);
         EasyMock.expectLastCall();
         callback.installFeature(f1);
         EasyMock.expectLastCall();
@@ -249,7 +269,11 @@ public class DeployerTest {
                                 EasyMock.<Map<Resource, List<Wire>>>anyObject(),
                                 EasyMock.<Map<Resource, Bundle>>anyObject());
         EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.BUNDLES_RESOLVED);
+        EasyMock.expectLastCall();
         callback.callListeners(EasyMock.<FeatureEvent>anyObject());
+        EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.DEPLOYMENT_FINISHED);
         EasyMock.expectLastCall();
 
         EasyMock.replay(callback);
@@ -300,6 +324,8 @@ public class DeployerTest {
 
         callback.print(EasyMock.anyString(), EasyMock.anyBoolean());
         EasyMock.expectLastCall().anyTimes();
+        callback.callListeners(DeploymentEvent.DEPLOYMENT_STARTED);
+        EasyMock.expectLastCall();
         callback.installBundle(EasyMock.eq(ROOT_REGION), EasyMock.eq("a100"), EasyMock.<InputStream>anyObject());
         EasyMock.expectLastCall().andReturn(serviceBundle1);
         callback.replaceDigraph(EasyMock.<Map<String, Map<String, Map<String, Set<String>>>>>anyObject(),
@@ -309,11 +335,17 @@ public class DeployerTest {
         EasyMock.expectLastCall();
         callback.installFeature(f1);
         EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.BUNDLES_INSTALLED);
+        EasyMock.expectLastCall();
         callback.resolveBundles(EasyMock.<Set<Bundle>>anyObject(),
                 EasyMock.<Map<Resource, List<Wire>>>anyObject(),
                 EasyMock.<Map<Resource, Bundle>>anyObject());
         EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.BUNDLES_RESOLVED);
+        EasyMock.expectLastCall();
         callback.callListeners(EasyMock.<FeatureEvent>anyObject());
+        EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.DEPLOYMENT_FINISHED);
         EasyMock.expectLastCall();
 
         EasyMock.replay(callback);
@@ -352,6 +384,8 @@ public class DeployerTest {
 
         callback.print(EasyMock.anyString(), EasyMock.anyBoolean());
         EasyMock.expectLastCall().anyTimes();
+        callback.callListeners(DeploymentEvent.DEPLOYMENT_STARTED);
+        EasyMock.expectLastCall();
         callback.installBundle(EasyMock.eq(ROOT_REGION), EasyMock.eq("b100"), EasyMock.<InputStream>anyObject());
         EasyMock.expectLastCall().andReturn(serviceBundle2);
         callback.replaceDigraph(EasyMock.<Map<String, Map<String, Map<String, Set<String>>>>>anyObject(),
@@ -361,11 +395,17 @@ public class DeployerTest {
         EasyMock.expectLastCall();
         callback.installFeature(f2);
         EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.BUNDLES_INSTALLED);
+        EasyMock.expectLastCall();
         callback.resolveBundles(EasyMock.<Set<Bundle>>anyObject(),
                 EasyMock.<Map<Resource, List<Wire>>>anyObject(),
                 EasyMock.<Map<Resource, Bundle>>anyObject());
         EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.BUNDLES_RESOLVED);
+        EasyMock.expectLastCall();
         callback.callListeners(EasyMock.<FeatureEvent>anyObject());
+        EasyMock.expectLastCall();
+        callback.callListeners(DeploymentEvent.DEPLOYMENT_FINISHED);
         EasyMock.expectLastCall();
 
         EasyMock.replay(callback);
@@ -480,7 +520,7 @@ public class DeployerTest {
         URL loc = getClass().getResource(dir + "/" + name + ".mf");
         Manifest man = new Manifest(loc.openStream());
         Hashtable<String, String> headers = new Hashtable<>();
-        for (Map.Entry attr : man.getMainAttributes().entrySet()) {
+        for (Map.Entry<Object, Object> attr : man.getMainAttributes().entrySet()) {
             headers.put(attr.getKey().toString(), attr.getValue().toString());
         }
         return new TestBundle(bundleId, name, state, headers);
@@ -498,6 +538,7 @@ public class DeployerTest {
             return null;
         }
 
+        @Override
         public boolean matches(Object argument) {
             if (!(argument instanceof FeatureEvent)) {
                 return false;
@@ -508,6 +549,7 @@ public class DeployerTest {
                     && arg.isReplay() == expected.isReplay();
         }
 
+        @Override
         public void appendTo(StringBuffer buffer) {
 
         }
@@ -541,6 +583,10 @@ public class DeployerTest {
 
         @Override
         public void callListeners(FeatureEvent featureEvent) {
+        }
+
+        @Override
+        public void callListeners(DeploymentEvent deployEvent) {
         }
 
         @Override

--- a/profile/src/main/java/org/apache/karaf/profile/assembly/AssemblyDeployCallback.java
+++ b/profile/src/main/java/org/apache/karaf/profile/assembly/AssemblyDeployCallback.java
@@ -34,13 +34,12 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 
 import org.apache.felix.utils.properties.Properties;
+import org.apache.karaf.features.DeploymentEvent;
 import org.apache.karaf.features.FeatureEvent;
 import org.apache.karaf.features.FeaturesService;
 import org.apache.karaf.features.internal.model.Library;
-import org.apache.karaf.features.internal.download.DownloadCallback;
 import org.apache.karaf.features.internal.download.DownloadManager;
 import org.apache.karaf.features.internal.download.Downloader;
-import org.apache.karaf.features.internal.download.StreamProvider;
 import org.apache.karaf.features.internal.model.Config;
 import org.apache.karaf.features.internal.model.ConfigFile;
 import org.apache.karaf.features.internal.model.Feature;
@@ -195,6 +194,10 @@ public class AssemblyDeployCallback implements Deployer.DeployCallback {
     }
 
     @Override
+    public void callListeners(DeploymentEvent deployEvent) {
+    }
+
+    @Override
     public void callListeners(FeatureEvent featureEvent) {
     }
 
@@ -230,7 +233,7 @@ public class AssemblyDeployCallback implements Deployer.DeployCallback {
             Hashtable<String, String> headers = new Hashtable<>();
             try (JarFile jar = new JarFile(bundleSystemFile.toFile())) {
                 Attributes attributes = jar.getManifest().getMainAttributes();
-                for (Map.Entry attr : attributes.entrySet()) {
+                for (Map.Entry<Object, Object> attr : attributes.entrySet()) {
                     headers.put(attr.getKey().toString(), attr.getValue().toString());
                 }
             }
@@ -280,7 +283,7 @@ public class AssemblyDeployCallback implements Deployer.DeployCallback {
     @Override
     public void replaceDigraph(Map<String, Map<String, Map<String, Set<String>>>> policies, Map<String, Set<Long>> bundles) throws BundleException, InvalidSyntaxException {
     }
-    
+
     private String substFinalName(String finalname) {
         final String markerVarBeg = "${";
         final String markerVarEnd = "}";

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
@@ -58,6 +58,7 @@ import org.apache.felix.resolver.Logger;
 import org.apache.felix.resolver.ResolverImpl;
 import org.apache.felix.utils.version.VersionRange;
 import org.apache.felix.utils.version.VersionTable;
+import org.apache.karaf.features.DeploymentEvent;
 import org.apache.karaf.features.FeatureEvent;
 import org.apache.karaf.features.FeaturesService;
 import org.apache.karaf.features.internal.download.DownloadCallback;
@@ -82,12 +83,10 @@ import org.apache.karaf.util.config.PropertiesLoader;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.settings.Settings;
 import org.ops4j.pax.url.mvn.MavenResolver;
 import org.ops4j.pax.url.mvn.MavenResolvers;
 import org.osgi.framework.Bundle;
@@ -211,7 +210,7 @@ public class VerifyMojo extends MojoSupport {
         }
     }
 
-    private Object invoke(Object object, String getter) throws MojoExecutionException {
+    private static Object invoke(Object object, String getter) throws MojoExecutionException {
         try {
             return object.getClass().getMethod(getter).invoke(object);
         } catch (Exception e) {
@@ -219,11 +218,11 @@ public class VerifyMojo extends MojoSupport {
         }
     }
 
-    private Object getPolicy(Object object, boolean snapshots) throws MojoExecutionException {
+    private static Object getPolicy(Object object, boolean snapshots) throws MojoExecutionException {
         return invoke(object, "getPolicy", new Class[] { Boolean.TYPE }, new Object[] { snapshots });
     }
 
-    private Object invoke(Object object, String getter, Class[] types, Object[] params) throws MojoExecutionException {
+    private static Object invoke(Object object, String getter, Class<?>[] types, Object[] params) throws MojoExecutionException {
         try {
             return object.getClass().getMethod(getter, types).invoke(object, params);
         } catch (Exception e) {
@@ -474,7 +473,7 @@ public class VerifyMojo extends MojoSupport {
         }
     }
 
-    private Deployer.DeploymentRequest createDeploymentRequest() {
+    private static Deployer.DeploymentRequest createDeploymentRequest() {
         Deployer.DeploymentRequest request = new Deployer.DeploymentRequest();
         request.bundleUpdateRange = FeaturesService.DEFAULT_BUNDLE_UPDATE_RANGE;
         request.featureResolutionRange = FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE;
@@ -486,7 +485,7 @@ public class VerifyMojo extends MojoSupport {
         return request;
     }
 
-    private String toString(Collection<String> collection) {
+    private static String toString(Collection<String> collection) {
         StringBuilder sb = new StringBuilder();
         sb.append("{\n");
         for (String s : collection) {
@@ -551,7 +550,7 @@ public class VerifyMojo extends MojoSupport {
 //        attributes = DeploymentBuilder.overrideAttributes(attributes, metadata);
 
         final Hashtable<String, String> headers = new Hashtable<>();
-        for (Map.Entry attr : attributes.entrySet()) {
+        for (Map.Entry<Object, Object> attr : attributes.entrySet()) {
             headers.put(attr.getKey().toString(), attr.getValue().toString());
         }
 
@@ -788,6 +787,10 @@ public class VerifyMojo extends MojoSupport {
         }
 
         @Override
+        public void callListeners(DeploymentEvent deployEvent) {
+        }
+
+        @Override
         public Bundle installBundle(String region, String uri, InputStream is) throws BundleException {
             try {
                 Hashtable<String, String> headers = new Hashtable<>();
@@ -796,7 +799,7 @@ public class VerifyMojo extends MojoSupport {
                 while ((entry = zis.getNextEntry()) != null) {
                     if (MANIFEST_NAME.equals(entry.getName())) {
                         Attributes attributes = new Manifest(zis).getMainAttributes();
-                        for (Map.Entry attr : attributes.entrySet()) {
+                        for (Map.Entry<Object, Object> attr : attributes.entrySet()) {
                             headers.put(attr.getKey().toString(), attr.getValue().toString());
                         }
                     }


### PR DESCRIPTION
This adds the capability for external components to hook into
the Deployer machinery, so they can perform operations at
opportune moments.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>