### PR TITLE
KARAF-5162: use new Map methods

### DIFF
--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/Capabilities.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/Capabilities.java
@@ -160,13 +160,7 @@ public class Capabilities extends BundlesCommand {
         {
             if (matchNamespace(namespace, wire.getCapability().getNamespace()))
             {
-                List<BundleWire> dependents = map.get(wire.getCapability());
-                if (dependents == null)
-                {
-                    dependents = new ArrayList<BundleWire>();
-                    map.put(wire.getCapability(), dependents);
-                }
-                dependents.add(wire);
+                map.computeIfAbsent(wire.getCapability(), k -> new ArrayList<>()).add(wire);
             }
         }
         return map;

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/Requirements.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/Requirements.java
@@ -126,12 +126,7 @@ public class Requirements extends BundlesCommand {
         Map<BundleRequirement, List<BundleWire>> map = new HashMap<BundleRequirement, List<BundleWire>>();
         for (BundleWire wire : wires) {
             if (matchNamespace(namespace, wire.getRequirement().getNamespace())) {
-                List<BundleWire> providers = map.get(wire.getRequirement());
-                if (providers == null) {
-                    providers = new ArrayList<BundleWire>();
-                    map.put(wire.getRequirement(), providers);
-                }
-                providers.add(wire);
+                map.computeIfAbsent(wire.getRequirement(), k -> new ArrayList<>()).add(wire);
             }
         }
         return map;

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/ShowBundleTree.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/ShowBundleTree.java
@@ -136,10 +136,7 @@ public class ShowBundleTree extends BundleCommand {
                     if (wires != null) {
                         for (BundleWire wire : wires) {
                             String name = wire.getCapability().getAttributes().get(BundleRevision.PACKAGE_NAMESPACE).toString();
-                            if (exports.get(name) == null) {
-                                exports.put(name, new HashSet<Bundle>());
-                            }
-                            exports.get(name).add(bundle);
+                            exports.computeIfAbsent(name, k -> new HashSet<>()).add(bundle);
                         }
                     }
                 }

--- a/features/core/src/main/java/org/apache/karaf/features/internal/region/Subsystem.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/region/Subsystem.java
@@ -561,11 +561,7 @@ public class Subsystem extends ResourceImpl {
 
     private void doAddDependency(ResourceImpl resource, boolean mandatory, boolean start, int startLevel) {
         String id = ResolverUtil.getSymbolicName(resource) + "|" + ResolverUtil.getVersion(resource);
-        DependencyInfo info = dependencies.get(id);
-        if (info == null) {
-            info = new DependencyInfo();
-            dependencies.put(id, info);
-        }
+        DependencyInfo info = dependencies.computeIfAbsent(id, k -> new DependencyInfo());
         info.resource = resource;
         info.mandatory |= mandatory;
         info.start |= start;

--- a/features/core/src/main/java/org/apache/karaf/features/internal/region/SubsystemResolveContext.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/region/SubsystemResolveContext.java
@@ -340,11 +340,7 @@ public class SubsystemResolveContext extends ResolveContext {
                 while (!ss.isAcceptDependencies()) {
                     ss = ss.getParent();
                 }
-                Map<Capability, Capability> map = mapping.get(ss);
-                if (map == null) {
-                    map = new HashMap<Capability, Capability>();
-                    mapping.put(ss, map);
-                }
+                Map<Capability, Capability> map = mapping.computeIfAbsent(ss, k -> new HashMap<>());
                 for (Capability cap : entry.getValue()) {
                     Capability wrapped = map.get(cap);
                     if (wrapped == null) {

--- a/features/core/src/main/java/org/apache/karaf/features/internal/region/SubsystemResolver.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/region/SubsystemResolver.java
@@ -310,12 +310,7 @@ public class SubsystemResolver {
     private void addBundleInfos(Subsystem subsystem) {
         if (subsystem != null) {
             String region = getFlatSubsystemsMap().get(subsystem.getName());
-            Map<String, BundleInfo> bis = bundleInfos.get(region);
-            if (bis == null) {
-                bis = new HashMap<>();
-                bundleInfos.put(region, bis);
-            }
-            bis.putAll(subsystem.getBundleInfos());
+            bundleInfos.computeIfAbsent(region, k -> new HashMap<>()).putAll(subsystem.getBundleInfos());
             for (Subsystem child : subsystem.getChildren()) {
                 addBundleInfos(child);
             }

--- a/features/core/src/main/java/org/apache/karaf/features/internal/repository/BaseRepository.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/repository/BaseRepository.java
@@ -57,12 +57,7 @@ public class BaseRepository implements Repository {
     protected void addResource(Resource resource) {
         for (Capability cap : resource.getCapabilities(null)) {
             String ns = cap.getNamespace();
-            CapabilitySet set = capSets.get(ns);
-            if (set == null) {
-                set = new CapabilitySet(Collections.singletonList(ns));
-                capSets.put(ns, set);
-            }
-            set.addCapability(cap);
+            capSets.computeIfAbsent(ns, n -> new CapabilitySet(Collections.singletonList(n))).addCapability(cap);
         }
         resources.add(resource);
     }

--- a/features/core/src/main/java/org/apache/karaf/features/internal/repository/XmlRepository.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/repository/XmlRepository.java
@@ -148,11 +148,7 @@ public class XmlRepository extends BaseRepository {
     private boolean checkAndLoadReferrals(String url, int hopCount) {
         boolean modified = false;
         if (hopCount > 0) {
-            XmlLoader loader = loaders.get(url);
-            if (loader == null) {
-                loader = new XmlLoader(url, expiration);
-                loaders.put(url, loader);
-            }
+            XmlLoader loader = loaders.computeIfAbsent(url, u -> new XmlLoader(u, expiration));
             modified = loader.checkAndLoadCache();
             for (StaxParser.Referral referral : loader.xml.referrals) {
                 modified |= checkAndLoadReferrals(referral.url, Math.min(referral.depth, hopCount - 1));

--- a/features/core/src/main/java/org/apache/karaf/features/internal/resolver/CapabilitySet.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/resolver/CapabilitySet.java
@@ -97,12 +97,7 @@ public class CapabilitySet {
 
     private void indexCapability(
             Map<Object, Set<Capability>> index, Capability cap, Object capValue) {
-        Set<Capability> caps = index.get(capValue);
-        if (caps == null) {
-            caps = new HashSet<>();
-            index.put(capValue, caps);
-        }
-        caps.add(cap);
+        index.computeIfAbsent(capValue, k -> new HashSet<>()).add(cap);
     }
 
     public void removeCapability(Capability cap) {

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/Deployer.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/Deployer.java
@@ -316,11 +316,7 @@ public class Deployer {
         }
         for (Map.Entry<String, Set<String>> entry : newFeatures.entrySet()) {
             for (String feature : entry.getValue()) {
-                Map<String, String> map = stateFeatures.get(entry.getKey());
-                if (map == null) {
-                    map = new HashMap<>();
-                    stateFeatures.put(entry.getKey(), map);
-                }
+                Map<String, String> map = stateFeatures.computeIfAbsent(entry.getKey(), k -> new HashMap<>());
                 map.put(feature, noStart ? FeatureState.Installed.name() : FeatureState.Started.name());
             }
         }
@@ -682,11 +678,7 @@ public class Deployer {
             // Update managed regions
             for (Region computedRegion : computedDigraph.getRegions()) {
                 String name = computedRegion.getName();
-                Map<String, Map<String, Set<String>>> policy = policies.get(name);
-                if (policy == null) {
-                    policy = new HashMap<>();
-                    policies.put(name, policy);
-                }
+                Map<String, Map<String, Set<String>>> policy = policies.computeIfAbsent(name, k -> new HashMap<>());
                 for (RegionDigraph.FilteredRegion fr : computedRegion.getEdges()) {
                     String r2 = fr.getRegion().getName();
                     Map<String, Set<String>> filters = new HashMap<>();

--- a/features/core/src/main/java/org/apache/karaf/features/internal/util/MapUtils.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/util/MapUtils.java
@@ -112,12 +112,7 @@ public final class MapUtils {
 
     public static <S, T> void add(Map<S, Set<T>> from, Map<S, Set<T>> toAdd) {
         for (Map.Entry<S, Set<T>> entry : toAdd.entrySet()) {
-            Set<T> s = from.get(entry.getKey());
-            if (s == null) {
-                s = new HashSet<>();
-                from.put(entry.getKey(), s);
-            }
-            s.addAll(entry.getValue());
+            from.computeIfAbsent(entry.getKey(), k -> new HashSet<>()).addAll(entry.getValue());
         }
     }
 
@@ -201,12 +196,7 @@ public final class MapUtils {
     }
 
     public static <S, T> void addToMapSet(Map<S, Set<T>> map, S key, T value) {
-        Set<T> values = map.get(key);
-        if (values == null) {
-            values = new HashSet<>();
-            map.put(key, values);
-        }
-        values.add(value);
+        map.computeIfAbsent(key, k -> new HashSet<>()).add(value);
     }
 
     public static <S, T> void removeFromMapSet(Map<S, Set<T>> map, S key, T value) {

--- a/features/core/src/test/java/org/apache/karaf/features/TestBase.java
+++ b/features/core/src/test/java/org/apache/karaf/features/TestBase.java
@@ -70,12 +70,7 @@ public class TestBase {
     }
     
     private Map<String, Feature> getOrCreate(final Map<String, Map<String, Feature>> featuresMap, Feature feature) {
-        Map<String, Feature> featureVersion = featuresMap.get(feature.getName());
-        if (featureVersion == null) {
-            featureVersion = new HashMap<String, Feature>();
-            featuresMap.put(feature.getName(), featureVersion);
-        }
-        return featureVersion;
+        return featuresMap.computeIfAbsent(feature.getName(), k -> new HashMap<>());
     }
 
     public Feature feature(String name) {

--- a/itests/src/test/java/org/apache/karaf/itests/PackageTest.java
+++ b/itests/src/test/java/org/apache/karaf/itests/PackageTest.java
@@ -83,7 +83,7 @@ public class PackageTest extends KarafTestSupport {
         for (PackageVersion pVer : packageVersionMap) {
             if (pVer.getBundles().size() > 1) {
                 String packageName = pVer.getPackageName();
-                int expectedNum = expectedDups.containsKey(packageName) ? expectedDups.get(packageName) : 0;
+                int expectedNum = expectedDups.getOrDefault(packageName, 0);
                 Assert.assertEquals("Expecting number of duplicates for package " + packageName, expectedNum, pVer.getBundles().size());
             }
         }

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPOptions.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPOptions.java
@@ -128,10 +128,7 @@ public class LDAPOptions {
                 int index = mapping.lastIndexOf("=");
                 String ldapRole = mapping.substring(0,index).trim();
                 String[] karafRoles = mapping.substring(index+1).split(",");
-                if (roleMapping.get(ldapRole) == null) {
-                    roleMapping.put(ldapRole, new HashSet<String>());
-                }
-                final Set<String> karafRolesSet = roleMapping.get(ldapRole);
+                final Set<String> karafRolesSet = roleMapping.computeIfAbsent(ldapRole, k -> new HashSet<>());
                 for (String karafRole : karafRoles) {
                     karafRolesSet.add(karafRole.trim());
                 }

--- a/package/src/main/java/org/apache/karaf/packages/command/Exports.java
+++ b/package/src/main/java/org/apache/karaf/packages/command/Exports.java
@@ -140,11 +140,8 @@ public class Exports implements Action {
                     String packageName = (String)attr.get(BundleRevision.PACKAGE_NAMESPACE);
                     Version version = (Version)attr.get("version");
                     String key = packageName + ":" + version.toString();
-                    PackageVersion pVer = packageVersionMap.get(key);
-                    if (pVer == null) {
-                        pVer = new PackageVersion(packageName, version);
-                        packageVersionMap.put(key, pVer);
-                    }
+                    PackageVersion pVer =
+                            packageVersionMap.computeIfAbsent(key, k -> new PackageVersion(packageName, version));
                     pVer.addBundle(bundle);
                 }
             }

--- a/package/src/main/java/org/apache/karaf/packages/core/internal/PackageServiceImpl.java
+++ b/package/src/main/java/org/apache/karaf/packages/core/internal/PackageServiceImpl.java
@@ -54,11 +54,8 @@ public class PackageServiceImpl implements PackageService {
                     String packageName = (String)attr.get(BundleRevision.PACKAGE_NAMESPACE);
                     Version version = (Version)attr.get("version");
                     String key = packageName + ":" + version.toString();
-                    PackageVersion pVer = packageVersionMap.get(key);
-                    if (pVer == null) {
-                        pVer = new PackageVersion(packageName, version);
-                        packageVersionMap.put(key, pVer);
-                    }
+                    PackageVersion pVer =
+                            packageVersionMap.computeIfAbsent(key, k -> new PackageVersion(packageName, version));
                     pVer.addBundle(bundle);
                 }
             }

--- a/service/core/src/main/java/org/apache/karaf/service/command/ListServices.java
+++ b/service/core/src/main/java/org/apache/karaf/service/command/ListServices.java
@@ -103,8 +103,7 @@ public class ListServices implements Action {
                     String[] names = (String[])serviceReference.getProperty(Constants.OBJECTCLASS);
                     if (names != null) {
                     	for (String name : names) {
-                    		int curCount = (serviceNames.containsKey(name)) ? serviceNames.get(name) : 0;
-                    		serviceNames.put(name, curCount + 1);
+                            serviceNames.merge(name, 1, (a, b) -> a + b);
                     	}
                     }
                 }

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/RegistryImpl.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/RegistryImpl.java
@@ -74,12 +74,7 @@ public class RegistryImpl implements Registry {
             if (service instanceof Command) {
                 Command cmd = (Command) service;
                 String key = cmd.getScope() + ":" + cmd.getName();
-                List<Command> cmds = commands.get(key);
-                if (cmds == null) {
-                    cmds = new ArrayList<Command>();
-                    commands.put(key, cmds);
-                }
-                cmds.add(cmd);
+                commands.computeIfAbsent(key, k -> new ArrayList<>()).add(cmd);
             }
         }
     }

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/RegistryImpl.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/RegistryImpl.java
@@ -74,12 +74,7 @@ public class RegistryImpl implements Registry {
             if (service instanceof Command) {
                 Command cmd = (Command) service;
                 String key = cmd.getScope() + ":" + cmd.getName();
-                List<Command> cmds = commands.get(key);
-                if (cmds == null) {
-                    cmds = new ArrayList<Command>();
-                    commands.put(key, cmds);
-                }
-                cmds.add(cmd);
+                commands.computeIfAbsent(key, k -> new ArrayList<>()).add(cmd);
             }
         }
     }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
@@ -624,11 +624,8 @@ public class VerifyMojo extends MojoSupport {
                 key = key.substring(prefix.length());
                 String[] parts = key.split("#");
                 if (parts.length == 3) {
-                    Map<VersionRange, Map<String, String>> ranges = result.get(parts[0]);
-                    if (ranges == null) {
-                        ranges = new HashMap<>();
-                        result.put(parts[0], ranges);
-                    }
+                    Map<VersionRange, Map<String, String>> ranges =
+                            result.computeIfAbsent(parts[0], k -> new HashMap<>());
                     String version = parts[1];
                     if (!version.startsWith("[") && !version.startsWith("(")) {
                         Processor processor = new Processor();
@@ -637,12 +634,7 @@ public class VerifyMojo extends MojoSupport {
                         version = macro.process("${range;[==,=+)}");
                     }
                     VersionRange range = new VersionRange(version);
-                    Map<String, String> hdrs = ranges.get(range);
-                    if (hdrs == null) {
-                        hdrs = new HashMap<>();
-                        ranges.put(range, hdrs);
-                    }
-                    hdrs.put(parts[2], val);
+                    ranges.computeIfAbsent(range, k -> new HashMap<>()).put(parts[2], val);
                 }
             }
         }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/GenerateHelpMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/GenerateHelpMojo.java
@@ -138,12 +138,7 @@ public class GenerateHelpMojo extends AbstractMojo {
                     out.close();
                     outStream.close();
 
-                    Set<String> cmds = commands.get(cmd.scope());
-                    if (cmds == null) {
-                        cmds = new TreeSet<String>();
-                        commands.put(cmd.scope(), cmds);
-                    }
-                    cmds.add(cmd.name());
+                    commands.computeIfAbsent(cmd.scope(), k -> new TreeSet<>()).add(cmd.name());
                     getLog().info("Found command: " + cmd.scope() + ":" + cmd.name());
                 } catch (Exception e) {
                     getLog().warn("Unable to write help for " + clazz.getName(), e);

--- a/tooling/utils/src/main/java/org/apache/karaf/tools/utils/KarafPropertiesEditor.java
+++ b/tooling/utils/src/main/java/org/apache/karaf/tools/utils/KarafPropertiesEditor.java
@@ -55,12 +55,7 @@ public class KarafPropertiesEditor {
 
         // organize edits by file.
         for (KarafPropertyEdit edit : edits.getEdits()) {
-            List<KarafPropertyEdit> thisFileEdits = editsByFile.get(edit.getFile());
-            if (thisFileEdits == null) {
-                thisFileEdits = new ArrayList<>();
-                editsByFile.put(edit.getFile(), thisFileEdits);
-            }
-            thisFileEdits.add(edit);
+            editsByFile.computeIfAbsent(edit.getFile(), k -> new ArrayList<>()).add(edit);
         }
 
         for (Map.Entry<String, List<KarafPropertyEdit>> fileOps : editsByFile.entrySet()) {

--- a/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/HttpPlugin.java
+++ b/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/HttpPlugin.java
@@ -266,12 +266,7 @@ public class HttpPlugin extends AbstractWebConsolePlugin {
     public String getStatusLine(List<ServletDetails> servlets, List<WebDetail> web) {
         Map<String, Integer> states = new HashMap<String, Integer>();
         for (ServletDetails servlet : servlets) {
-            Integer count = states.get(servlet.getState());
-            if (count == null) {
-                states.put(servlet.getState(), 1);
-            } else {
-                states.put(servlet.getState(), 1 + count);
-            }
+            states.merge(servlet.getState(), 1, (a, b) -> a + b);
         }
         StringBuilder stateSummary = new StringBuilder();
         boolean first = true;


### PR DESCRIPTION
computeIfAbsent, getOrDefault and merge can be put to good use to
simplify a number of common code sequences.

Signed-off-by: Stephen Kitt <skitt@redhat.com>