### PR TITLE
KARAF-5168: replace old-style loops

### DIFF
--- a/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/BundlesMBeanImpl.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/BundlesMBeanImpl.java
@@ -76,9 +76,8 @@ public class BundlesMBeanImpl extends StandardMBean implements BundlesMBean {
 
             Bundle[] bundles = bundleContext.getBundles();
 
-            for (int i = 0; i < bundles.length; i++) {
+            for (Bundle bundle : bundles) {
                 try {
-                    Bundle bundle = bundles[i];
                     BundleInfo info = bundleService.getInfo(bundle);
                     String bundleStateString = info.getState().toString();
                     CompositeData data = new CompositeDataSupport(bundleType,

--- a/config/src/main/java/org/apache/karaf/config/core/impl/ConfigMBeanImpl.java
+++ b/config/src/main/java/org/apache/karaf/config/core/impl/ConfigMBeanImpl.java
@@ -16,13 +16,14 @@ package org.apache.karaf.config.core.impl;
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.management.MBeanException;
 import javax.management.NotCompliantMBeanException;
@@ -69,12 +70,9 @@ public class ConfigMBeanImpl extends StandardMBean implements ConfigMBean {
     @Override
     public List<String> getConfigs() throws MBeanException {
         try {
-            Configuration[] configurations = this.configRepo.getConfigAdmin().listConfigurations(null);
-            List<String> pids = new ArrayList<>();
-            for (int i = 0; i < configurations.length; i++) {
-                pids.add(configurations[i].getPid());
-            }
-            return pids;
+            return Arrays.stream(configRepo.getConfigAdmin().listConfigurations(null))
+                    .map(Configuration::getPid)
+                    .collect(Collectors.toList());
         } catch (Exception e) {
             throw new MBeanException(null, e.toString());
         }

--- a/deployer/blueprint/src/main/java/org/apache/karaf/deployer/blueprint/BlueprintTransformer.java
+++ b/deployer/blueprint/src/main/java/org/apache/karaf/deployer/blueprint/BlueprintTransformer.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Enumeration;
@@ -139,10 +138,10 @@ public class BlueprintTransformer {
             line = line.trim();
             if (line.length() > 0) {
                 String parts[] = line.split("\\s*,\\s*");
-                for (int i = 0; i < parts.length; i++) {
-                    int n = parts[i].lastIndexOf('.');
+                for (String part : parts) {
+                    int n = part.lastIndexOf('.');
                     if (n > 0) {
-                        String pkg = parts[i].substring(0, n);
+                        String pkg = part.substring(0, n);
                         if (!pkg.startsWith("java.")) {
                             refers.add(pkg);
                         }

--- a/deployer/spring/src/main/java/org/apache/karaf/deployer/spring/SpringTransformer.java
+++ b/deployer/spring/src/main/java/org/apache/karaf/deployer/spring/SpringTransformer.java
@@ -136,12 +136,12 @@ public class SpringTransformer {
             line = line.trim();
             if (line.length() > 0) {
                 String parts[] = line.split("\\s*,\\s*");
-                for (int i = 0; i < parts.length; i++) {
-                    int n = parts[i].lastIndexOf('.');
+                for (String part : parts) {
+                    int n = part.lastIndexOf('.');
                     if (n > 0) {
-                        String pkg = parts[i].substring(0, n);
+                        String pkg = part.substring(0, n);
                         if (!pkg.startsWith("java.")) {
-                            refers.add(parts[i].substring(0, n));
+                            refers.add(part.substring(0, n));
                         }
                     }
                 }

--- a/features/command/src/main/java/org/apache/karaf/features/command/InfoFeatureCommand.java
+++ b/features/command/src/main/java/org/apache/karaf/features/command/InfoFeatureCommand.java
@@ -240,8 +240,7 @@ public class InfoFeatureCommand extends FeaturesCommandSupport {
                 }
                 prefix += "   ";
                 List<Dependency> dependencies = resolved.getDependencies();
-                for (int i = 0, j = dependencies.size(); i < j; i++) {
-                    Dependency toDisplay = dependencies.get(i);
+                for (Dependency toDisplay : dependencies) {
                     unresolved += displayFeatureTree(admin, toDisplay.getName(), toDisplay.getVersion(), prefix + 1);
                 }
 

--- a/instance/src/main/java/org/apache/karaf/instance/core/internal/InstanceServiceImpl.java
+++ b/instance/src/main/java/org/apache/karaf/instance/core/internal/InstanceServiceImpl.java
@@ -1007,8 +1007,7 @@ public class InstanceServiceImpl implements InstanceService {
             if (files == null) {
                 result = false;
             } else {
-                for (int i = 0; i < files.length; i++) {
-                    File file = files[i];
+                for (File file : files) {
                     if (file.getName().equals(".") || file.getName().equals("..")) {
                         continue;
                     }

--- a/itests/src/test/java/org/apache/karaf/itests/JaasTest.java
+++ b/itests/src/test/java/org/apache/karaf/itests/JaasTest.java
@@ -68,13 +68,12 @@ public class JaasTest extends KarafTestSupport {
         final String userPassRealm = "karaf";
         LoginContext lc = new LoginContext(userPassRealm, new CallbackHandler() {
             public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (int i = 0; i < callbacks.length; i++) {
-                    Callback callback = callbacks[i];
+                for (Callback callback : callbacks) {
                     if (callback instanceof PasswordCallback) {
-                        PasswordCallback passwordCallback = (PasswordCallback)callback;
+                        PasswordCallback passwordCallback = (PasswordCallback) callback;
                         passwordCallback.setPassword(userPassRealm.toCharArray());
                     } else if (callback instanceof NameCallback) {
-                        NameCallback nameCallback = (NameCallback)callback;
+                        NameCallback nameCallback = (NameCallback) callback;
                         nameCallback.setName(userPassRealm);
                     }
                 }

--- a/jaas/command/src/main/java/org/apache/karaf/jaas/command/ListRealmsCommand.java
+++ b/jaas/command/src/main/java/org/apache/karaf/jaas/command/ListRealmsCommand.java
@@ -57,8 +57,8 @@ public class ListRealmsCommand extends JaasCommandSupport {
                 AppConfigurationEntry[] entries = realm.getEntries();
 
                 if (entries != null && entries.length > 0) {
-                    for (int i = 0; i < entries.length; i++) {
-                        String moduleClass = (String) entries[i].getOptions().get(ProxyLoginModule.PROPERTY_MODULE);
+                    for (AppConfigurationEntry entry : entries) {
+                        String moduleClass = (String) entry.getOptions().get(ProxyLoginModule.PROPERTY_MODULE);
                         table.addRow().addContent(index++, realmName, moduleClass);
                     }
                 }

--- a/jaas/command/src/main/java/org/apache/karaf/jaas/command/ManageRealmCommand.java
+++ b/jaas/command/src/main/java/org/apache/karaf/jaas/command/ManageRealmCommand.java
@@ -80,10 +80,10 @@ public class ManageRealmCommand extends JaasCommandSupport {
                         AppConfigurationEntry[] entries = r.getEntries();
 
                         if (entries != null) {
-                            for (int j = 0; j < entries.length; j++) {
+                            for (AppConfigurationEntry entry1 : entries) {
                                 if (i == index) {
                                     realm = r;
-                                    entry = entries[j];
+                                    entry = entry1;
                                     break realms_loop;
                                 }
                                 i++;

--- a/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/ResourceKeystoreInstance.java
+++ b/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/ResourceKeystoreInstance.java
@@ -125,8 +125,7 @@ public class ResourceKeystoreInstance implements KeystoreInstance {
     public void setKeyPasswords(String keyPasswords) {
         if (keyPasswords != null) {
             String[] keys = keyPasswords.split("\\]\\!\\[");
-            for (int i = 0; i < keys.length; i++) {
-                String key = keys[i];
+            for (String key : keys) {
                 int pos = key.indexOf('=');
                 if (pos > 0) {
                     this.keyPasswords.put(key.substring(0, pos), key.substring(pos + 1).toCharArray());

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/properties/NameDigestPasswordCallbackHandler.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/properties/NameDigestPasswordCallbackHandler.java
@@ -60,21 +60,20 @@ public class NameDigestPasswordCallbackHandler implements CallbackHandler {
         this.passwordCallbackName = passwordCallbackName;
     }  
 
-    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {  
-        for (int i = 0; i < callbacks.length; i++) {  
-            Callback callback = callbacks[i];
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        for (Callback callback : callbacks) {
             if (handleCallback(callback)) {
                 continue;
-            } else if (callback instanceof NameCallback) {  
-                ((NameCallback) callback).setName(username);  
-            } else if (callback instanceof PasswordCallback) {  
-                PasswordCallback pwCallback = (PasswordCallback) callback;  
+            } else if (callback instanceof NameCallback) {
+                ((NameCallback) callback).setName(username);
+            } else if (callback instanceof PasswordCallback) {
+                PasswordCallback pwCallback = (PasswordCallback) callback;
                 pwCallback.setPassword(password.toCharArray());
             } else if (!invokePasswordCallback(callback)) {
-                String msg = "Unsupported callback type" + callbacks[i].getClass().getName();
+                String msg = "Unsupported callback type" + callback.getClass().getName();
                 LOG.info(msg);
-                throw new UnsupportedCallbackException(callbacks[i], msg);  
-            }  
+                throw new UnsupportedCallbackException(callback, msg);
+            }
         }  
     }      
     

--- a/jms/pool/src/main/java/org/apache/karaf/jms/pool/internal/PooledSession.java
+++ b/jms/pool/src/main/java/org/apache/karaf/jms/pool/internal/PooledSession.java
@@ -100,13 +100,11 @@ public class PooledSession implements Session, TopicSession, QueueSession, XASes
                 getInternalSession().setMessageListener(null);
 
                 // Close any consumers and browsers that may have been created.
-                for (Iterator<MessageConsumer> iter = consumers.iterator(); iter.hasNext();) {
-                    MessageConsumer consumer = iter.next();
+                for (MessageConsumer consumer : consumers) {
                     consumer.close();
                 }
 
-                for (Iterator<QueueBrowser> iter = browsers.iterator(); iter.hasNext();) {
-                    QueueBrowser browser = iter.next();
+                for (QueueBrowser browser : browsers) {
                     browser.close();
                 }
 

--- a/jndi/src/main/java/org/apache/karaf/jndi/internal/JndiServiceImpl.java
+++ b/jndi/src/main/java/org/apache/karaf/jndi/internal/JndiServiceImpl.java
@@ -170,16 +170,16 @@ public class JndiServiceImpl implements JndiService {
         Context context = new InitialContext();
         String[] splitted = name.split("/");
         if (splitted.length > 0) {
-            for (int i = 0; i < splitted.length; i++) {
+            for (String split : splitted) {
                 try {
-                    Object o = context.lookup(splitted[i]);
+                    Object o = context.lookup(split);
                     if (!(o instanceof Context)) {
-                        throw new NamingException("Name " + splitted[i] + " already exists");
+                        throw new NamingException("Name " + split + " already exists");
                     }
                 } catch (NameNotFoundException e) {
-                    context.createSubcontext(splitted[i]);
+                    context.createSubcontext(split);
                 }
-                context = (Context) context.lookup(splitted[i]);
+                context = (Context) context.lookup(split);
             }
         } else {
             context.createSubcontext(name);

--- a/log/src/main/java/org/apache/karaf/log/core/internal/layout/PatternParser.java
+++ b/log/src/main/java/org/apache/karaf/log/core/internal/layout/PatternParser.java
@@ -548,11 +548,11 @@ public class PatternParser {
             if (properties.size() > 0) {
               Object[] keys = properties.keySet().toArray();
               Arrays.sort(keys);
-              for (int i = 0; i < keys.length; i++) {
+              for (Object key : keys) {
                   buf.append('{');
-                  buf.append(keys[i]);
+                  buf.append(key);
                   buf.append(',');
-                  buf.append(properties.get(keys[i]));
+                  buf.append(properties.get(key));
                   buf.append('}');
               }
             }

--- a/main/src/main/java/org/apache/karaf/main/util/Utils.java
+++ b/main/src/main/java/org/apache/karaf/main/util/Utils.java
@@ -162,8 +162,7 @@ public class Utils {
         }
 
         IOException exception = null;
-        for (int i = 0; i < files.length; i++) {
-            File file = files[i];
+        for (File file : files) {
             try {
                 forceDelete(file);
             } catch (IOException ioe) {

--- a/management/server/src/main/java/org/apache/karaf/management/JaasAuthenticator.java
+++ b/management/server/src/main/java/org/apache/karaf/management/JaasAuthenticator.java
@@ -58,13 +58,13 @@ public class JaasAuthenticator implements JMXAuthenticator {
             Subject subject = new Subject();
             LoginContext loginContext = new LoginContext(realm, subject, new CallbackHandler() {
                 public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                    for (int i = 0; i < callbacks.length; i++) {
-                        if (callbacks[i] instanceof NameCallback) {
-                            ((NameCallback) callbacks[i]).setName(params[0]);
-                        } else if (callbacks[i] instanceof PasswordCallback) {
-                            ((PasswordCallback) callbacks[i]).setPassword((params[1].toCharArray()));
+                    for (Callback callback : callbacks) {
+                        if (callback instanceof NameCallback) {
+                            ((NameCallback) callback).setName(params[0]);
+                        } else if (callback instanceof PasswordCallback) {
+                            ((PasswordCallback) callback).setPassword((params[1].toCharArray()));
                         } else {
-                            throw new UnsupportedCallbackException(callbacks[i]);
+                            throw new UnsupportedCallbackException(callback);
                         }
                     }
                 }

--- a/obr/src/main/java/org/apache/karaf/obr/command/FindCommand.java
+++ b/obr/src/main/java/org/apache/karaf/obr/command/FindCommand.java
@@ -26,7 +26,6 @@ import org.apache.karaf.shell.api.action.lifecycle.Service;
 
 import java.io.PrintStream;
 import java.lang.reflect.Array;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -68,19 +67,14 @@ public class FindCommand extends ObrCommandSupport {
         printUnderline(out, name    .length());
 
         Map map = resource.getProperties();
-        for (Iterator iter = map.entrySet().iterator(); iter.hasNext(); )
-        {
-            Map.Entry entry = (Map.Entry) iter.next();
-            if (entry.getValue().getClass().isArray())
-            {
+        for (Object o : map.entrySet()) {
+            Map.Entry entry = (Map.Entry) o;
+            if (entry.getValue().getClass().isArray()) {
                 out.println(entry.getKey() + ":");
-                for (int j = 0; j < Array.getLength(entry.getValue()); j++)
-                {
+                for (int j = 0; j < Array.getLength(entry.getValue()); j++) {
                     out.println("   " + Array.get(entry.getValue(), j));
                 }
-            }
-            else
-            {
+            } else {
                 out.println(entry.getKey() + ": " + entry.getValue());
             }
         }
@@ -89,29 +83,23 @@ public class FindCommand extends ObrCommandSupport {
         if ((reqs != null) && (reqs.length > 0))
         {
             boolean hdr = false;
-            for (int i = 0; i < reqs.length; i++)
-            {
-                if (!reqs[i].isOptional())
-                {
-                    if (!hdr)
-                    {
+            for (Requirement req : reqs) {
+                if (!req.isOptional()) {
+                    if (!hdr) {
                         hdr = true;
                         out.println("Requirements:");
                     }
-                    out.println("   " + reqs[i].getName() + ":" + reqs[i].getFilter());
+                    out.println("   " + req.getName() + ":" + req.getFilter());
                 }
             }
             hdr = false;
-            for (int i = 0; i < reqs.length; i++)
-            {
-                if (reqs[i].isOptional())
-                {
-                    if (!hdr)
-                    {
+            for (Requirement req : reqs) {
+                if (req.isOptional()) {
+                    if (!hdr) {
                         hdr = true;
                         out.println("Optional Requirements:");
                     }
-                    out.println("   " + reqs[i].getName() + ":" + reqs[i].getFilter());
+                    out.println("   " + req.getName() + ":" + req.getFilter());
                 }
             }
         }
@@ -120,9 +108,8 @@ public class FindCommand extends ObrCommandSupport {
         if ((caps != null) && (caps.length > 0))
         {
             out.println("Capabilities:");
-            for (int i = 0; i < caps.length; i++)
-            {
-                out.println("   " + caps[i].getName() + ":" + caps[i].getPropertiesAsMap());
+            for (Capability cap : caps) {
+                out.println("   " + cap.getName() + ":" + cap.getPropertiesAsMap());
             }
         }
     }

--- a/obr/src/main/java/org/apache/karaf/obr/command/InfoCommand.java
+++ b/obr/src/main/java/org/apache/karaf/obr/command/InfoCommand.java
@@ -18,7 +18,6 @@ package org.apache.karaf.obr.command;
 
 import java.io.PrintStream;
 import java.lang.reflect.Array;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -70,19 +69,14 @@ public class InfoCommand extends ObrCommandSupport {
         printUnderline(out, resourceId.length());
 
         Map map = resource.getProperties();
-        for (Iterator iter = map.entrySet().iterator(); iter.hasNext(); )
-        {
-            Map.Entry entry = (Map.Entry) iter.next();
-            if (entry.getValue().getClass().isArray())
-            {
+        for (Object o : map.entrySet()) {
+            Map.Entry entry = (Map.Entry) o;
+            if (entry.getValue().getClass().isArray()) {
                 out.println(entry.getKey() + ":");
-                for (int j = 0; j < Array.getLength(entry.getValue()); j++)
-                {
+                for (int j = 0; j < Array.getLength(entry.getValue()); j++) {
                     out.println("   " + Array.get(entry.getValue(), j));
                 }
-            }
-            else
-            {
+            } else {
                 out.println(entry.getKey() + ": " + entry.getValue());
             }
         }
@@ -91,9 +85,8 @@ public class InfoCommand extends ObrCommandSupport {
         if ((reqs != null) && (reqs.length > 0))
         {
             out.println("Requires:");
-            for (int i = 0; i < reqs.length; i++)
-            {
-                out.println("   " + reqs[i].getName() + ":" + reqs[i].getFilter());
+            for (Requirement req : reqs) {
+                out.println("   " + req.getName() + ":" + req.getFilter());
             }
         }
 
@@ -101,9 +94,8 @@ public class InfoCommand extends ObrCommandSupport {
         if ((caps != null) && (caps.length > 0))
         {
             out.println("Capabilities:");
-            for (int i = 0; i < caps.length; i++)
-            {
-                out.println("   " + caps[i].getName() + ":" + caps[i].getPropertiesAsMap());
+            for (Capability cap : caps) {
+                out.println("   " + cap.getName() + ":" + cap.getPropertiesAsMap());
             }
         }
     }

--- a/obr/src/main/java/org/apache/karaf/obr/command/ObrCommandSupport.java
+++ b/obr/src/main/java/org/apache/karaf/obr/command/ObrCommandSupport.java
@@ -147,9 +147,9 @@ public abstract class ObrCommandSupport implements Action {
                 if ((resources != null) && (resources.length > 0)) {
                     System.out.println("\nRequired resource(s):");
                     printUnderline(System.out, 21);
-                    for (int resIdx = 0; resIdx < resources.length; resIdx++) {
-                        System.out.println("   " + getResourceId(resources[resIdx])
-                                + " (" + resources[resIdx].getVersion() + ")");
+                    for (Resource resource : resources) {
+                        System.out.println("   " + getResourceId(resource)
+                                + " (" + resource.getVersion() + ")");
                     }
                 }
                 if (deployOptional) {
@@ -157,8 +157,8 @@ public abstract class ObrCommandSupport implements Action {
                     if ((resources != null) && (resources.length > 0)) {
                         System.out.println("\nOptional resource(s):");
                         printUnderline(System.out, 21);
-                        for (int resIdx = 0; resIdx < resources.length; resIdx++) {
-                            System.out.println("   " + getResourceId(resources[resIdx]) + " (" + resources[resIdx].getVersion() + ")");
+                        for (Resource resource : resources) {
+                            System.out.println("   " + getResourceId(resource) + " (" + resource.getVersion() + ")");
                         }
                     }
                 }
@@ -175,9 +175,9 @@ public abstract class ObrCommandSupport implements Action {
                 if ((reqs != null) && (reqs.length > 0)) {
                     System.out.println("Unsatisfied requirement(s):");
                     printUnderline(System.out, 27);
-                    for (int reqIdx = 0; reqIdx < reqs.length; reqIdx++) {
-                        System.out.println("   " + reqs[reqIdx].getRequirement().getFilter());
-                        System.out.println("      " + getResourceId(reqs[reqIdx].getResource()));
+                    for (Reason req : reqs) {
+                        System.out.println("   " + req.getRequirement().getFilter());
+                        System.out.println("      " + getResourceId(req.getResource()));
                     }
                 } else {
                     System.out.println("Could not resolve targets.");

--- a/obr/src/main/java/org/apache/karaf/obr/command/RefreshUrlCommand.java
+++ b/obr/src/main/java/org/apache/karaf/obr/command/RefreshUrlCommand.java
@@ -53,9 +53,9 @@ public class RefreshUrlCommand extends ObrCommandSupport {
 		} else {
 			Repository[] repos = admin.listRepositories();
 			if ((repos != null) && (repos.length > 0)) {
-				for (int i = 0; i < repos.length; i++) {
-					admin.addRepository(repos[i].getURI());
-				}
+                for (Repository repo : repos) {
+                    admin.addRepository(repo.getURI());
+                }
 			}
 		}
     }

--- a/obr/src/main/java/org/apache/karaf/obr/command/ResolveCommand.java
+++ b/obr/src/main/java/org/apache/karaf/obr/command/ResolveCommand.java
@@ -75,10 +75,10 @@ public class ResolveCommand extends ObrCommandSupport {
             if ((resources != null) && (resources.length > 0)) {
                 System.out.println("Required resource(s):");
                 printUnderline(System.out, 21);
-                for (int resIdx = 0; resIdx < resources.length; resIdx++) {
-                    System.out.println("   " + resources[resIdx].getPresentationName() + " (" + resources[resIdx].getVersion() + ")");
+                for (Resource resource : resources) {
+                    System.out.println("   " + resource.getPresentationName() + " (" + resource.getVersion() + ")");
                     if (why) {
-                        Reason[] req = resolver.getReason(resources[resIdx]);
+                        Reason[] req = resolver.getReason(resource);
                         for (int reqIdx = 0; req != null && reqIdx < req.length; reqIdx++) {
                             if (!req[reqIdx].getRequirement().isOptional()) {
                                 Resource r = req[reqIdx].getResource();
@@ -97,11 +97,11 @@ public class ResolveCommand extends ObrCommandSupport {
                 System.out.println();
                 System.out.println("Optional resource(s):");
                 printUnderline(System.out, 21);
-                for (int resIdx = 0; resIdx < resources.length; resIdx++) {
-                    System.out.println("   " + resources[resIdx].getPresentationName()
-                        + " (" + resources[resIdx].getVersion() + ")");
+                for (Resource resource : resources) {
+                    System.out.println("   " + resource.getPresentationName()
+                            + " (" + resource.getVersion() + ")");
                     if (why) {
-                        Reason[] req = resolver.getReason(resources[resIdx]);
+                        Reason[] req = resolver.getReason(resource);
                         for (int reqIdx = 0; req != null && reqIdx < req.length; reqIdx++) {
                             if (!req[reqIdx].getRequirement().isOptional()) {
                                 Resource r = req[reqIdx].getResource();
@@ -132,9 +132,9 @@ public class ResolveCommand extends ObrCommandSupport {
             if ((reqs != null) && (reqs.length > 0)) {
                 System.out.println("Unsatisfied requirement(s):");
                 printUnderline(System.out, 27);
-                for (int reqIdx = 0; reqIdx < reqs.length; reqIdx++) {
-                    System.out.println("   " + reqs[reqIdx].getRequirement().getName() + ":" + reqs[reqIdx].getRequirement().getFilter());
-                    System.out.println("      " +reqs[reqIdx].getResource().getPresentationName());
+                for (Reason req : reqs) {
+                    System.out.println("   " + req.getRequirement().getName() + ":" + req.getRequirement().getFilter());
+                    System.out.println("      " + req.getResource().getPresentationName());
                 }
             } else {
                 System.out.println("Could not resolve targets.");

--- a/obr/src/main/java/org/apache/karaf/obr/core/internal/ObrMBeanImpl.java
+++ b/obr/src/main/java/org/apache/karaf/obr/core/internal/ObrMBeanImpl.java
@@ -16,8 +16,9 @@
  */
 package org.apache.karaf.obr.core.internal;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.management.MBeanException;
 import javax.management.NotCompliantMBeanException;
@@ -58,12 +59,9 @@ public class ObrMBeanImpl extends StandardMBean implements ObrMBean {
     }
 
     public List<String> getUrls() {
-        Repository[] repositories = repositoryAdmin.listRepositories();
-        List<String> urls = new ArrayList<String>();
-        for (int i = 0; i < repositories.length; i++) {
-            urls.add(repositories[i].getURI());
-        }
-        return urls;
+        return Arrays.stream(repositoryAdmin.listRepositories())
+                .map(Repository::getURI)
+                .collect(Collectors.toList());
     }
 
     public TabularData getBundles() throws MBeanException {
@@ -77,11 +75,11 @@ public class ObrMBeanImpl extends StandardMBean implements ObrMBean {
             TabularData table = new TabularDataSupport(tableType);
 
             Resource[] resources = repositoryAdmin.discoverResources("(|(presentationname=*)(symbolicname=*))");
-            for (int i = 0; i < resources.length; i++) {
+            for (Resource resource : resources) {
                 try {
                     CompositeData data = new CompositeDataSupport(bundleType,
                             new String[]{"presentationname", "symbolicname", "version"},
-                            new Object[]{resources[i].getPresentationName(), resources[i].getSymbolicName(), resources[i].getVersion().toString()});
+                            new Object[]{resource.getPresentationName(), resource.getSymbolicName(), resource.getVersion().toString()});
                     table.put(data);
                 } catch (Exception e) {
                     e.printStackTrace();

--- a/services/eventadmin/src/main/java/org/apache/felix/eventadmin/impl/Configuration.java
+++ b/services/eventadmin/src/main/java/org/apache/felix/eventadmin/impl/Configuration.java
@@ -420,9 +420,8 @@ public class Configuration
         {
             if ( m_adapters != null )
             {
-                for(int i=0;i<m_adapters.length;i++)
-                {
-                    m_adapters[i].destroy(m_bundleContext);
+                for (AbstractAdapter adapter : m_adapters) {
+                    adapter.destroy(m_bundleContext);
                 }
                 m_adapters = null;
             }

--- a/services/eventadmin/src/main/java/org/apache/felix/eventadmin/impl/handler/EventAdminImpl.java
+++ b/services/eventadmin/src/main/java/org/apache/felix/eventadmin/impl/handler/EventAdminImpl.java
@@ -149,9 +149,9 @@ public class EventAdminImpl implements EventAdmin
         if (needTimeStamp || needSubject) {
             String[] names = event.getPropertyNames();
             HashMap<String, Object> map = new HashMap<String, Object>(names.length + 1);
-            for (int i = 0; i < names.length; i++) {
-                if (!EventConstants.EVENT_TOPIC.equals(names[i])) {
-                    map.put(names[i], event.getProperty(names[i]));
+            for (String name : names) {
+                if (!EventConstants.EVENT_TOPIC.equals(name)) {
+                    map.put(name, event.getProperty(name));
                 }
             }
             if (needTimeStamp) {

--- a/shell/commands/src/main/java/org/apache/karaf/shell/commands/impl/ThreadsAction.java
+++ b/shell/commands/src/main/java/org/apache/karaf/shell/commands/impl/ThreadsAction.java
@@ -240,8 +240,7 @@ public class ThreadsAction implements Action {
         public boolean isInteresting() {
             int nb = 0;
             StackTraceElement[] stacktrace = info.getStackTrace();
-            for (int i = 0; i < stacktrace.length; i++) {
-                StackTraceElement ste = stacktrace[i];
+            for (StackTraceElement ste : stacktrace) {
                 boolean interestingLine = true;
                 for (String pkg : packages) {
                     if (ste.getClassName().startsWith(pkg)) {

--- a/shell/console/src/main/java/org/apache/karaf/shell/commands/basic/DefaultActionPreparator.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/commands/basic/DefaultActionPreparator.java
@@ -64,8 +64,7 @@ public class DefaultActionPreparator implements ActionPreparator {
                 + "Error executing command " + command2.scope() + ":" 
                 + INTENSITY_BOLD + command2.name() + INTENSITY_NORMAL
                 + COLOR_DEFAULT + ": " : "";
-        for (Iterator<Object> it = params.iterator(); it.hasNext(); ) {
-            Object param = it.next();
+        for (Object param : params) {
             if (HelpOption.HELP.name().equals(param)) {
                 int termWidth = getWidth(session);
                 boolean globalScope = NameScoping.isGlobalScope(session, actionMetaData.getCommand().scope());

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/action/command/DefaultActionPreparator.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/action/command/DefaultActionPreparator.java
@@ -90,8 +90,7 @@ public class DefaultActionPreparator {
         assertIndexesAreCorrect(action.getClass(), orderedArguments);
 
         String commandErrorSt = COLOR_RED + "Error executing command " + command.scope() + ":" + INTENSITY_BOLD + command.name() + INTENSITY_NORMAL + COLOR_DEFAULT + ": ";
-        for (Iterator<Object> it = params.iterator(); it.hasNext(); ) {
-            Object param = it.next();
+        for (Object param : params) {
             if (HelpOption.HELP.name().equals(param)) {
                 int termWidth = session.getTerminal() != null ? session.getTerminal().getWidth() : 80;
                 boolean globalScope = NameScoping.isGlobalScope(session, command.scope());

--- a/shell/core/src/main/java/org/apache/karaf/shell/support/completers/UriCompleter.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/support/completers/UriCompleter.java
@@ -110,9 +110,9 @@ public class UriCompleter implements Completer {
                 String group = "";
                 String[] dirs = parts.length > 0 ? parts[0].split("\\.") : new String[] { "" };
                 if (parts.length > 0 && parts[0].endsWith(".")) {
-                    for (int i = 0; i < dirs.length; i++) {
-                        known += dirs[i] + "/";
-                        group += dirs[i] + ".";
+                    for (String dir : dirs) {
+                        known += dir + "/";
+                        group += dir + ".";
                     }
                 } else {
                     for (int i = 0; i < dirs.length - 1; i++) {

--- a/system/src/main/java/org/apache/karaf/system/commands/SystemProperty.java
+++ b/system/src/main/java/org/apache/karaf/system/commands/SystemProperty.java
@@ -19,12 +19,12 @@ package org.apache.karaf.system.commands;
 import java.io.File;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Vector;
 
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.Argument;
@@ -133,14 +133,12 @@ public class SystemProperty implements Action {
 
     private void printOrderedProperties(Properties props, PrintStream out) {
         Set<Object> keys = props.keySet();
-        Vector<String> order = new Vector<String>(keys.size());
-        for (Iterator<Object> i = keys.iterator(); i.hasNext(); ) {
-            Object str = (Object) i.next();
+        List<String> order = new ArrayList<>(keys.size());
+        for (Object str : keys) {
             order.add((String) str);
         }
         Collections.sort(order);
-        for (Iterator<String> i = order.iterator(); i.hasNext(); ) {
-            String key = (String) i.next();
+        for (String key : order) {
             out.println(key + "=" + props.getProperty(key));
         }
     }

--- a/system/src/main/java/org/apache/karaf/system/management/internal/SystemMBeanImpl.java
+++ b/system/src/main/java/org/apache/karaf/system/management/internal/SystemMBeanImpl.java
@@ -211,28 +211,24 @@ public class SystemMBeanImpl extends StandardMBean implements SystemMBean {
 
     private void printOrderedProperties(Properties props, PrintStream out) {
         Set<Object> keys = props.keySet();
-        Vector<String> order = new Vector<String>(keys.size());
-        for (Iterator<Object> i = keys.iterator(); i.hasNext(); ) {
-            Object str = (Object) i.next();
+        List<String> order = new ArrayList<>(keys.size());
+        for (Object str : keys) {
             order.add((String) str);
         }
         Collections.sort(order);
-        for (Iterator<String> i = order.iterator(); i.hasNext(); ) {
-            String key = (String) i.next();
+        for (String key : order) {
             out.println(key + "=" + props.getProperty(key));
         }
     }
 
     private void printOrderedProperties(Properties props, Map<String, String> result) {
         Set<Object> keys = props.keySet();
-        Vector<String> order = new Vector<String>(keys.size());
-        for (Iterator<Object> i = keys.iterator(); i.hasNext(); ) {
-            Object str = (Object) i.next();
+        List<String> order = new ArrayList<>(keys.size());
+        for (Object str : keys) {
             order.add((String) str);
         }
         Collections.sort(order);
-        for (Iterator<String> i = order.iterator(); i.hasNext(); ) {
-            String key = (String) i.next();
+        for (String key : order) {
             result.put(key, props.getProperty(key));
         }
     }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MojoSupport.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MojoSupport.java
@@ -25,7 +25,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -144,10 +143,7 @@ public abstract class MojoSupport extends AbstractMojo {
         if (dependencyManagement != null
                 && dependencyManagement.getDependencies() != null) {
             map = new HashMap();
-            for (Iterator i = dependencyManagement.getDependencies().iterator(); i
-                    .hasNext();) {
-                Dependency d = (Dependency) i.next();
-
+            for (Dependency d : dependencyManagement.getDependencies()) {
                 try {
                     VersionRange versionRange = VersionRange
                             .createFromVersionSpec(d.getVersion());

--- a/util/src/main/java/org/apache/karaf/util/collections/CopyOnWriteArrayIdentityList.java
+++ b/util/src/main/java/org/apache/karaf/util/collections/CopyOnWriteArrayIdentityList.java
@@ -189,8 +189,7 @@ public class CopyOnWriteArrayIdentityList<E> implements List<E>, RandomAccess, C
             int size = old.length;
             E[] toAdd = newElementArray(c.size());
             int i = 0;
-            for (Iterator it = c.iterator(); it.hasNext();) {
-                E o = (E) it.next();
+            for (E o : c) {
                 if (indexOf(o) < 0) {
                     toAdd[i++] = o;
                 }
@@ -296,9 +295,7 @@ public class CopyOnWriteArrayIdentityList<E> implements List<E>, RandomAccess, C
 
     public int hashCode() {
         int hashCode = 1;
-        Iterator it = listIterator();
-        while (it.hasNext()) {
-            Object obj = it.next();
+        for (Object obj : this) {
             hashCode = 31 * hashCode + (obj == null ? 0 : obj.hashCode());
         }
         return hashCode;
@@ -441,9 +438,8 @@ public class CopyOnWriteArrayIdentityList<E> implements List<E>, RandomAccess, C
     public String toString() {
         StringBuilder sb = new StringBuilder("[");
 
-        Iterator it = listIterator();
-        while (it.hasNext()) {
-            sb.append(String.valueOf(it.next()));
+        for (Object o : this) {
+            sb.append(String.valueOf(o));
             sb.append(", ");
         }
         if (sb.length() > 1) {
@@ -632,9 +628,7 @@ public class CopyOnWriteArrayIdentityList<E> implements List<E>, RandomAccess, C
         if (size == 0) {
             return false;
         }
-        Iterator it = c.iterator();
-        while (it.hasNext()) {
-            Object next = it.next();
+        for (Object next : c) {
             if (indexOf(next, data, start, size) < 0) {
                 return false;
             }
@@ -1141,8 +1135,8 @@ public class CopyOnWriteArrayIdentityList<E> implements List<E>, RandomAccess, C
         int size = back.length;
         oos.defaultWriteObject();
         oos.writeInt(size);
-        for (int i = 0; i < size; i++) {
-            oos.writeObject(back[i]);
+        for (E aBack : back) {
+            oos.writeObject(aBack);
         }
     }
 

--- a/util/src/main/java/org/apache/karaf/util/jaas/JaasHelper.java
+++ b/util/src/main/java/org/apache/karaf/util/jaas/JaasHelper.java
@@ -153,8 +153,8 @@ public class JaasHelper {
             ProtectionDomain[] optimized = new ProtectionDomain[domains.length];
             ProtectionDomain pd;
             int num = 0;
-            for (int i = 0; i < domains.length; i++) {
-                if ((pd = domains[i]) != null) {
+            for (ProtectionDomain domain : domains) {
+                if ((pd = domain) != null) {
                     boolean found = false;
                     for (int j = 0; j < num && !found; j++) {
                         found = (optimized[j] == pd);

--- a/webconsole/console/src/main/java/org/apache/felix/webconsole/internal/servlet/JaasSecurityProvider.java
+++ b/webconsole/console/src/main/java/org/apache/felix/webconsole/internal/servlet/JaasSecurityProvider.java
@@ -104,13 +104,13 @@ public class JaasSecurityProvider implements WebConsoleSecurityProvider2, Manage
             Subject subject = new Subject();
             LoginContext loginContext = new LoginContext(realm, subject, new CallbackHandler() {
                 public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                    for (int i = 0; i < callbacks.length; i++) {
-                        if (callbacks[i] instanceof NameCallback) {
-                            ((NameCallback) callbacks[i]).setName(username);
-                        } else if (callbacks[i] instanceof PasswordCallback) {
-                            ((PasswordCallback) callbacks[i]).setPassword(password.toCharArray());
+                    for (Callback callback : callbacks) {
+                        if (callback instanceof NameCallback) {
+                            ((NameCallback) callback).setName(username);
+                        } else if (callback instanceof PasswordCallback) {
+                            ((PasswordCallback) callback).setPassword(password.toCharArray());
                         } else {
-                            throw new UnsupportedCallbackException(callbacks[i]);
+                            throw new UnsupportedCallbackException(callback);
                         }
                     }
                 }


### PR DESCRIPTION
This patch replaces a number of old-style explicit loops over arrays
or iterators with foreach loops or streams.

Signed-off-by: Stephen Kitt <skitt@redhat.com>