### PR TITLE
KARAF-5169: remove redundant type specifiers

### DIFF
--- a/bundle/blueprintstate/src/main/java/org/apache/karaf/bundle/state/blueprint/internal/BlueprintStateService.java
+++ b/bundle/blueprintstate/src/main/java/org/apache/karaf/bundle/state/blueprint/internal/BlueprintStateService.java
@@ -44,7 +44,7 @@ public class BlueprintStateService implements org.osgi.service.blueprint.contain
     private final Map<Long, BlueprintEvent> states;
 
     public BlueprintStateService() {
-        states = new ConcurrentHashMap<Long, BlueprintEvent>();
+        states = new ConcurrentHashMap<>();
     }
 
     @Override

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/BundlesCommand.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/BundlesCommand.java
@@ -56,7 +56,7 @@ public abstract class BundlesCommand implements Action {
         if (bundles.isEmpty()) {
             throw new IllegalArgumentException("No matching bundles");
         }
-        List<Exception> exceptions = new ArrayList<Exception>();
+        List<Exception> exceptions = new ArrayList<>();
         for (Bundle bundle : bundles) {
             try {
                 executeOnBundle(bundle);

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/Capabilities.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/Capabilities.java
@@ -155,7 +155,7 @@ public class Capabilities extends BundlesCommand {
     {
         // Aggregate matching capabilities.
         Map<BundleCapability, List<BundleWire>> map =
-            new HashMap<BundleCapability, List<BundleWire>>();
+                new HashMap<>();
         for (BundleWire wire : wires)
         {
             if (matchNamespace(namespace, wire.getCapability().getNamespace()))

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/Headers.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/Headers.java
@@ -86,17 +86,17 @@ public class Headers extends BundlesCommand {
 
     protected String generateFormattedOutput(Bundle bundle) {
         StringBuilder output = new StringBuilder();
-        Map<String, Object> otherAttribs = new TreeMap<String, Object>();
-        Map<String, Object> karafAttribs = new TreeMap<String, Object>();
-        Map<String, Object> bundleAttribs = new TreeMap<String, Object>();
-        Map<String, Object> serviceAttribs = new TreeMap<String, Object>();
-        Map<String, Object> packagesAttribs = new TreeMap<String, Object>();
+        Map<String, Object> otherAttribs = new TreeMap<>();
+        Map<String, Object> karafAttribs = new TreeMap<>();
+        Map<String, Object> bundleAttribs = new TreeMap<>();
+        Map<String, Object> serviceAttribs = new TreeMap<>();
+        Map<String, Object> packagesAttribs = new TreeMap<>();
         Dictionary<String, String> dict = bundle.getHeaders();
         Enumeration<String> keys = dict.keys();
 
         // do an initial loop and separate the attributes in different groups
         while (keys.hasMoreElements()) {
-            String k = (String) keys.nextElement();
+            String k = keys.nextElement();
             Object v = dict.get(k);
             if (k.startsWith(KARAF_PREFIX)) {
                 // starts with Karaf-xxx
@@ -170,7 +170,7 @@ public class Headers extends BundlesCommand {
             output.append('\n');
         }
 
-        Map<String, ClauseFormatter> formatters = new HashMap<String, ClauseFormatter>();
+        Map<String, ClauseFormatter> formatters = new HashMap<>();
         formatters.put(REQUIRE_BUNDLE_ATTRIB, new ClauseFormatter() {
             public void pre(Clause clause, StringBuilder output) {
                 boolean isSatisfied = checkBundle(clause.getName(), clause.getAttribute("bundle-version"));

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/Requirements.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/Requirements.java
@@ -123,7 +123,7 @@ public class Requirements extends BundlesCommand {
     private static Map<BundleRequirement, List<BundleWire>> aggregateRequirements(
             Pattern namespace, List<BundleWire> wires) {
         // Aggregate matching capabilities.
-        Map<BundleRequirement, List<BundleWire>> map = new HashMap<BundleRequirement, List<BundleWire>>();
+        Map<BundleRequirement, List<BundleWire>> map = new HashMap<>();
         for (BundleWire wire : wires) {
             if (matchNamespace(namespace, wire.getRequirement().getNamespace())) {
                 map.computeIfAbsent(wire.getRequirement(), k -> new ArrayList<>()).add(wire);

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/Restart.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/Restart.java
@@ -38,7 +38,7 @@ public class Restart extends BundlesCommand {
             System.err.println("No bundles specified.");
             return null;
         }
-        List<Exception> exceptions = new ArrayList<Exception>();
+        List<Exception> exceptions = new ArrayList<>();
         for (Bundle bundle : bundles) {
             try {
                 bundle.stop(Bundle.STOP_TRANSIENT);

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/Services.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/Services.java
@@ -41,9 +41,9 @@ public class Services extends BundlesCommand {
     @Option(name = "-p", aliases = {}, description = "Shows the properties of the services", required = false, multiValued = false)
     boolean showProperties = false;
 
-    Set<String> hidden = new HashSet<String>(Arrays.asList(new String[] {
-        "org.apache.felix.service.command.Function",
-        "org.apache.karaf.shell.console.Completer"
+    Set<String> hidden = new HashSet<>(Arrays.asList(new String[] {
+            "org.apache.felix.service.command.Function",
+            "org.apache.karaf.shell.console.Completer"
     }));
 
     @Override

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/ShowBundleTree.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/ShowBundleTree.java
@@ -64,7 +64,7 @@ public class ShowBundleTree extends BundleCommand {
         long start = System.currentTimeMillis();
         // let's do the real work here
         printHeader(bundle);
-        tree = new Tree<Bundle>(bundle);
+        tree = new Tree<>(bundle);
         createTree(bundle);
         printTree(tree);
         printDuplicatePackages(tree);
@@ -126,7 +126,7 @@ public class ShowBundleTree extends BundleCommand {
      */
     private void printDuplicatePackages(Tree<Bundle> tree) {
         Set<Bundle> bundles = tree.flatten();
-        Map<String, Set<Bundle>> exports = new HashMap<String, Set<Bundle>>();
+        Map<String, Set<Bundle>> exports = new HashMap<>();
 
         for (Bundle bundle : bundles) {
             for (BundleRevision revision : bundle.adapt(BundleRevisions.class).getRevisions()) {
@@ -230,7 +230,7 @@ public class ShowBundleTree extends BundleCommand {
     */
     private void createNode(Node<Bundle> node) {
         Bundle bundle = node.getValue();
-        Collection<Bundle> exporters = new HashSet<Bundle>();
+        Collection<Bundle> exporters = new HashSet<>();
         exporters.addAll(bundleService.getWiredBundles(bundle).values());
 
         for (Bundle exporter : exporters) {

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/bundletree/Node.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/bundletree/Node.java
@@ -29,7 +29,7 @@ public class Node<T> {
     
     private final T value;
     private Node<T> parent;
-    private List<Node<T>> children = new LinkedList<Node<T>>();
+    private List<Node<T>> children = new LinkedList<>();
 
     /**
      * Create a new node. Only meant for wrapper use,
@@ -79,7 +79,7 @@ public class Node<T> {
      * @return the child node.
      */
     public Node<T> addChild(T value) {
-        Node<T> node = new Node<T>(value, this);
+        Node<T> node = new Node<>(value, this);
         children.add(node);
         return node;
     }
@@ -90,7 +90,7 @@ public class Node<T> {
      * @return the set of values.
      */
     public Set<T> flatten() {
-        Set<T> result = new HashSet<T>();
+        Set<T> result = new HashSet<>();
         result.add(getValue());
         for (Node<T> child : getChildren()) {
             result.addAll(child.flatten());

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/BundleInfoImpl.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/BundleInfoImpl.java
@@ -47,7 +47,7 @@ public class BundleInfoImpl implements BundleInfo {
     private static Map<Integer, BundleState> bundleStateMap;
     
     static {
-        bundleStateMap = new HashMap<Integer, BundleState>();
+        bundleStateMap = new HashMap<>();
         bundleStateMap.put(Bundle.ACTIVE, BundleState.Active);
         bundleStateMap.put(Bundle.INSTALLED, BundleState.Installed);
         bundleStateMap.put(Bundle.RESOLVED, BundleState.Resolved);
@@ -58,11 +58,11 @@ public class BundleInfoImpl implements BundleInfo {
     public BundleInfoImpl(Bundle bundle, BundleState extState) {
         BundleStartLevel bsl = bundle.adapt(BundleStartLevel.class);
         this.startLevel = bsl.getStartLevel();
-        this.name = (String)bundle.getHeaders().get(Constants.BUNDLE_NAME);
+        this.name = bundle.getHeaders().get(Constants.BUNDLE_NAME);
         this.symbolicName = bundle.getSymbolicName();
-        String locationFromHeader = (String)bundle.getHeaders().get(Constants.BUNDLE_UPDATELOCATION);
+        String locationFromHeader = bundle.getHeaders().get(Constants.BUNDLE_UPDATELOCATION);
         this.updateLocation = locationFromHeader != null ? locationFromHeader : bundle.getLocation();
-        this.version = (String)bundle.getHeaders().get(Constants.BUNDLE_VERSION);
+        this.version = bundle.getHeaders().get(Constants.BUNDLE_VERSION);
         this.revisions = populateRevisions(bundle);
         this.bundleId = bundle.getBundleId();
         this.state = (extState != BundleState.Unknown) ? extState : getBundleState(bundle);
@@ -71,8 +71,8 @@ public class BundleInfoImpl implements BundleInfo {
 
     private void populateFragementInfos(Bundle bundle) {
         this.isFragment = bundle.getHeaders().get(Constants.FRAGMENT_HOST) != null;
-        this.fragments = new ArrayList<Bundle>();
-        this.fragmentHosts = new ArrayList<Bundle>();
+        this.fragments = new ArrayList<>();
+        this.fragmentHosts = new ArrayList<>();
         BundleRevisions revisions = bundle.adapt(BundleRevisions.class);
         if (revisions == null) {
             return;

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/BundleWatcherImpl.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/BundleWatcherImpl.java
@@ -54,7 +54,7 @@ public class BundleWatcherImpl implements Runnable, BundleListener, BundleWatche
 
     private AtomicBoolean running = new AtomicBoolean(false);
     private long interval = 1000L;
-    private List<String> watchURLs = new CopyOnWriteArrayList<String>();
+    private List<String> watchURLs = new CopyOnWriteArrayList<>();
     private AtomicInteger counter = new AtomicInteger(0);
 
     public BundleWatcherImpl(BundleContext bundleContext, MavenConfigService mavenConfigService, BundleService bundleService) {
@@ -76,7 +76,7 @@ public class BundleWatcherImpl implements Runnable, BundleListener, BundleWatche
     public void run() {
         logger.debug("Bundle watcher thread started");
         int oldCounter = -1;
-        Set<Bundle> watchedBundles = new HashSet<Bundle>();
+        Set<Bundle> watchedBundles = new HashSet<>();
         while (running.get() && watchURLs.size() > 0) {
             if (oldCounter != counter.get()) {
                 oldCounter = counter.get();
@@ -95,7 +95,7 @@ public class BundleWatcherImpl implements Runnable, BundleListener, BundleWatche
                 // Get the wiring before any in case of a refresh of a dependency
                 FrameworkWiring wiring = bundleContext.getBundle(0).adapt(FrameworkWiring.class);
                 File localRepository = this.localRepoDetector.getLocalRepository();
-                List<Bundle> updated = new ArrayList<Bundle>();
+                List<Bundle> updated = new ArrayList<>();
                 for (Bundle bundle : watchedBundles) {
                     try {
                         updateBundleIfNecessary(localRepository, updated, bundle);

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/osgi/Activator.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/osgi/Activator.java
@@ -50,7 +50,7 @@ public class Activator extends BaseActivator {
 
         final BundleServiceImpl bundleService = new BundleServiceImpl(bundleContext);
         register(BundleService.class, bundleService);
-        bundleStateServicesTracker = new ServiceTracker<BundleStateService, BundleStateService>(
+        bundleStateServicesTracker = new ServiceTracker<>(
                 bundleContext, BundleStateService.class, new ServiceTrackerCustomizer<BundleStateService, BundleStateService>() {
             @Override
             public BundleStateService addingService(ServiceReference<BundleStateService> reference) {

--- a/bundle/core/src/test/java/org/apache/karaf/bundle/command/TestBundleFactory.java
+++ b/bundle/core/src/test/java/org/apache/karaf/bundle/command/TestBundleFactory.java
@@ -36,11 +36,11 @@ public class TestBundleFactory {
         if (keyProp.length % 2 != 0) {
             throw new IllegalArgumentException("");
         }
-        Hashtable<String, Object> keyPropMap = new Hashtable<String, Object>();
+        Hashtable<String, Object> keyPropMap = new Hashtable<>();
         int c = 0;
         while (c < keyProp.length) {
             String key = (String)keyProp[c++];
-            Object value = (Object)keyProp[c++];
+            Object value = keyProp[c++];
             keyPropMap.put(key, value);
             expect(serviceRef.getProperty(key)).andReturn(value).anyTimes();
         }
@@ -51,7 +51,7 @@ public class TestBundleFactory {
     Bundle createBundle(long id, String name) {
         Bundle bundle = createMock(Bundle.class);
         expect(bundle.getBundleId()).andReturn(id).anyTimes();
-        Dictionary<String, String> headers = new Hashtable<String, String>();
+        Dictionary<String, String> headers = new Hashtable<>();
         headers.put(Constants.BUNDLE_NAME, name);
         expect(bundle.getHeaders()).andReturn(headers).anyTimes();
         return bundle;

--- a/bundle/core/src/test/java/org/apache/karaf/bundle/command/bundletree/TreeTest.java
+++ b/bundle/core/src/test/java/org/apache/karaf/bundle/command/bundletree/TreeTest.java
@@ -40,7 +40,7 @@ public class TreeTest {
 
     @Test
     public void writeTreeWithOneChild() throws IOException {
-        Tree<String> tree = new Tree<String>("root");
+        Tree<String> tree = new Tree<>("root");
         tree.addChild("child");
 
         BufferedReader reader = read(tree);
@@ -51,7 +51,7 @@ public class TreeTest {
 
     @Test
     public void writeTreeWithOneChildAndNodeConverter() throws IOException {
-        Tree<String> tree = new Tree<String>("root");
+        Tree<String> tree = new Tree<>("root");
         tree.addChild("child");
 
         StringWriter writer = new StringWriter();
@@ -69,7 +69,7 @@ public class TreeTest {
 
     @Test
     public void writeTreeWithChildAndGrandChild() throws IOException {
-        Tree<String> tree = new Tree<String>("root");
+        Tree<String> tree = new Tree<>("root");
         Node<String> node = tree.addChild("child");
         node.addChild("grandchild");
 
@@ -82,7 +82,7 @@ public class TreeTest {
 
     @Test
     public void writeTreeWithTwoChildrenAndOneGrandchild() throws IOException {
-        Tree<String> tree = new Tree<String>("root");
+        Tree<String> tree = new Tree<>("root");
         Node<String> child = tree.addChild("child1");
         child.addChild("grandchild");
         tree.addChild("child2");
@@ -97,7 +97,7 @@ public class TreeTest {
 
     @Test
     public void flattenTree() throws IOException {
-        Tree<String> tree = new Tree<String>("root");
+        Tree<String> tree = new Tree<>("root");
         Node<String> child1 = tree.addChild("child1");
         child1.addChild("grandchild");
         Node<String> child2 = tree.addChild("child2");
@@ -114,7 +114,7 @@ public class TreeTest {
 
     @Test
     public void hasAncestor() throws IOException {
-        Tree<String> tree = new Tree<String>("root");
+        Tree<String> tree = new Tree<>("root");
         Node<String> child1 = tree.addChild("child1");
         child1.addChild("grandchild");
         Node<String> child2 = tree.addChild("child2");

--- a/bundle/core/src/test/java/org/apache/karaf/bundle/core/internal/MavenConfigServiceTest.java
+++ b/bundle/core/src/test/java/org/apache/karaf/bundle/core/internal/MavenConfigServiceTest.java
@@ -26,27 +26,27 @@ public class MavenConfigServiceTest {
 
     @Test
     public void testLocalRepoEmpty() throws Exception {
-        Hashtable<String, Object> config = new Hashtable<String, Object>();
+        Hashtable<String, Object> config = new Hashtable<>();
         assertEquals(null, MavenConfigService.getLocalRepoFromConfig(config));
     }
 
     @Test
     public void testLocalRepoExplicit() throws Exception {
-        Hashtable<String, Object> config = new Hashtable<String, Object>();
+        Hashtable<String, Object> config = new Hashtable<>();
         config.put("org.ops4j.pax.url.mvn.localRepository", "foo/bar");
         assertEquals("foo/bar", MavenConfigService.getLocalRepoFromConfig(config));
     }
 
     @Test
     public void testLocalRepoFromSettings() throws Exception {
-        Hashtable<String, Object> config = new Hashtable<String, Object>();
+        Hashtable<String, Object> config = new Hashtable<>();
         config.put("org.ops4j.pax.url.mvn.settings", getClass().getResource("/settings.xml").getPath());
         assertEquals("foo/bar", MavenConfigService.getLocalRepoFromConfig(config));
     }
 
     @Test
     public void testLocalRepoFromSettingsNs() throws Exception {
-        Hashtable<String, Object> config = new Hashtable<String, Object>();
+        Hashtable<String, Object> config = new Hashtable<>();
         config.put("org.ops4j.pax.url.mvn.settings", getClass().getResource("/settings2.xml").getPath());
         assertEquals("foo/bar", MavenConfigService.getLocalRepoFromConfig(config));
     }

--- a/bundle/springstate/src/main/java/org/apache/karaf/bundle/state/spring/internal/SpringStateService.java
+++ b/bundle/springstate/src/main/java/org/apache/karaf/bundle/state/spring/internal/SpringStateService.java
@@ -46,7 +46,7 @@ public class SpringStateService
     private final Map<Long, OsgiBundleApplicationContextEvent> states;
 
     public SpringStateService() {
-        this.states = new ConcurrentHashMap<Long, OsgiBundleApplicationContextEvent>();
+        this.states = new ConcurrentHashMap<>();
     }
 
     public String getName() {

--- a/client/src/main/java/org/slf4j/impl/SimpleLoggerFactory.java
+++ b/client/src/main/java/org/slf4j/impl/SimpleLoggerFactory.java
@@ -33,7 +33,7 @@ public class SimpleLoggerFactory implements ILoggerFactory {
   Map<String, Logger> loggerMap;
 
   public SimpleLoggerFactory() {
-    loggerMap = new HashMap<String, Logger>();
+    loggerMap = new HashMap<>();
   }
 
   /**
@@ -43,7 +43,7 @@ public class SimpleLoggerFactory implements ILoggerFactory {
     Logger slogger = null;
     // protect against concurrent access of the loggerMap
     synchronized (this) {
-      slogger = (Logger) loggerMap.get(name);
+      slogger = loggerMap.get(name);
       if (slogger == null) {
         slogger = new SimpleLogger(name);
         loggerMap.put(name, slogger);

--- a/config/src/main/java/org/apache/karaf/config/command/ListCommand.java
+++ b/config/src/main/java/org/apache/karaf/config/command/ListCommand.java
@@ -37,7 +37,7 @@ public class ListCommand extends ConfigCommandSupport {
     protected Object doExecute() throws Exception {
         Configuration[] configs = configRepository.getConfigAdmin().listConfigurations(query);
         if (configs != null) {
-            Map<String, Configuration> sortedConfigs = new TreeMap<String, Configuration>();
+            Map<String, Configuration> sortedConfigs = new TreeMap<>();
             for (Configuration config : configs) {
                 sortedConfigs.put(config.getPid(), config);
             }
@@ -52,7 +52,7 @@ public class ListCommand extends ConfigCommandSupport {
                 if (config.getProperties() != null) {
                     System.out.println("Properties:");
                     Dictionary props = config.getProperties();
-                    Map<String, Object> sortedProps = new TreeMap<String, Object>();
+                    Map<String, Object> sortedProps = new TreeMap<>();
                     for (Enumeration e = props.keys(); e.hasMoreElements();) {
                         Object key = e.nextElement();
                         sortedProps.put(key.toString(), props.get(key));

--- a/config/src/main/java/org/apache/karaf/config/command/MetaCommand.java
+++ b/config/src/main/java/org/apache/karaf/config/command/MetaCommand.java
@@ -138,7 +138,7 @@ public class MetaCommand extends ConfigCommandSupport {
                 return;
             }
             Configuration config = configRepository.getConfigAdmin().getConfiguration(pid);
-            Dictionary<String, Object> props = new Hashtable<String, Object>();
+            Dictionary<String, Object> props = new Hashtable<>();
             for (AttributeDefinition attr : attrs) {
                 String valueStr = getDefaultValueStr(attr.getDefaultValue());
                 if (valueStr != null) {

--- a/config/src/main/java/org/apache/karaf/config/command/completers/ConfigurationCompleter.java
+++ b/config/src/main/java/org/apache/karaf/config/command/completers/ConfigurationCompleter.java
@@ -75,7 +75,7 @@ public class ConfigurationCompleter implements Completer, ConfigurationListener 
             return;
         }
 
-        Collection<String> pids = new ArrayList<String>();
+        Collection<String> pids = new ArrayList<>();
         for (Configuration config : configs) {
             pids.add(config.getPid());
         }

--- a/config/src/main/java/org/apache/karaf/config/command/completers/ConfigurationPropertyCompleter.java
+++ b/config/src/main/java/org/apache/karaf/config/command/completers/ConfigurationPropertyCompleter.java
@@ -97,7 +97,7 @@ public class ConfigurationPropertyCompleter implements Completer {
      */
     @SuppressWarnings("rawtypes")
     private Set<String> getPropertyNames(String pid) {
-        Set<String> propertyNames = new HashSet<String>();
+        Set<String> propertyNames = new HashSet<>();
         if (pid != null) {
             Configuration configuration = null;
             try {

--- a/config/src/main/java/org/apache/karaf/config/command/completers/MetaCompleter.java
+++ b/config/src/main/java/org/apache/karaf/config/command/completers/MetaCompleter.java
@@ -64,7 +64,7 @@ public class MetaCompleter implements Completer, BundleListener {
 
             @Override
             public List<String> callWith(MetaTypeService metatypeService) {
-                List<String> pids = new ArrayList<String>();
+                List<String> pids = new ArrayList<>();
                 Bundle[] bundles = context.getBundles();
                 for (Bundle bundle : bundles) {
                     

--- a/config/src/test/java/org/apache/karaf/config/command/EditCommandTest.java
+++ b/config/src/test/java/org/apache/karaf/config/command/EditCommandTest.java
@@ -57,7 +57,7 @@ public class EditCommandTest extends TestCase {
         replay(admin);
         
         // the ConfigAdmin service returns a Dictionary for an existing PID
-        Dictionary<String, Object> props = new Hashtable<String, Object>();
+        Dictionary<String, Object> props = new Hashtable<>();
         expect(config.getProperties()).andReturn(props);
         replay(config);
         

--- a/config/src/test/java/org/apache/karaf/config/command/MockCommandSession.java
+++ b/config/src/test/java/org/apache/karaf/config/command/MockCommandSession.java
@@ -34,7 +34,7 @@ import org.apache.karaf.shell.api.console.Terminal;
  */
 class MockCommandSession implements Session {
 
-    private Map<String, Object> properties = new HashMap<String, Object>();
+    private Map<String, Object> properties = new HashMap<>();
 
     public void close() {
         // not implemented

--- a/config/src/test/java/org/apache/karaf/config/command/UpdateCommandTest.java
+++ b/config/src/test/java/org/apache/karaf/config/command/UpdateCommandTest.java
@@ -37,7 +37,7 @@ public class UpdateCommandTest extends TestCase {
     private static final String PID = "myPid";
 
     public void testupdateRegularConfig() throws Exception {
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 
         UpdateCommand command = new UpdateCommand();
         ConfigRepository configRepo = EasyMock.createMock(ConfigRepository.class);
@@ -54,7 +54,7 @@ public class UpdateCommandTest extends TestCase {
     }
 
     public void testupdateOnNewFactoryPid() throws Exception {
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 
         UpdateCommand command = new UpdateCommand();
         ConfigRepository configRepo = EasyMock.createMock(ConfigRepository.class);

--- a/deployer/blueprint/src/main/java/org/apache/karaf/deployer/blueprint/osgi/Activator.java
+++ b/deployer/blueprint/src/main/java/org/apache/karaf/deployer/blueprint/osgi/Activator.java
@@ -32,7 +32,7 @@ public class Activator extends BaseActivator {
 
     @Override
     protected void doStart() throws Exception {
-        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        Hashtable<String, Object> props = new Hashtable<>();
         props.put("url.handler.protocol", "blueprint");
         register(URLStreamHandlerService.class, new BlueprintURLHandler(), props);
         register(new Class[] { ArtifactUrlTransformer.class, ArtifactListener.class },

--- a/deployer/features/src/main/java/org/apache/karaf/deployer/features/FeatureDeploymentListener.java
+++ b/deployer/features/src/main/java/org/apache/karaf/deployer/features/FeatureDeploymentListener.java
@@ -199,7 +199,7 @@ public class FeatureDeploymentListener implements ArtifactUrlTransformer, Bundle
             Bundle bundle = bundleEvent.getBundle();
             if (bundleEvent.getType() == BundleEvent.RESOLVED) {
                 try {
-                    List<URL> urls = new ArrayList<URL>();
+                    List<URL> urls = new ArrayList<>();
                     Enumeration featuresUrlEnumeration = bundle.findEntries("/META-INF/" + FEATURE_PATH + "/", "*.xml", false);
                     while (featuresUrlEnumeration != null && featuresUrlEnumeration.hasMoreElements()) {
                         URL url = (URL) featuresUrlEnumeration.nextElement();
@@ -208,8 +208,8 @@ public class FeatureDeploymentListener implements ArtifactUrlTransformer, Bundle
                             URI needRemovedRepo = null;
                             for (Repository repo : featuresService.listRepositories()) {
                                 if (repo.getURI().equals(url.toURI())) {
-                                    Set<Feature> features = new HashSet<Feature>(Arrays.asList(repo.getFeatures()));
-                                    Set<String> autoInstallFeatures = new HashSet<String>();
+                                    Set<Feature> features = new HashSet<>(Arrays.asList(repo.getFeatures()));
+                                    Set<String> autoInstallFeatures = new HashSet<>();
                                     for(Feature feature:features) {
                                         if(feature.getInstall() != null && feature.getInstall().equals(Feature.DEFAULT_INSTALL_MODE)){
                                             if (!featuresService.isInstalled(feature)) {

--- a/deployer/features/src/main/java/org/apache/karaf/deployer/features/osgi/Activator.java
+++ b/deployer/features/src/main/java/org/apache/karaf/deployer/features/osgi/Activator.java
@@ -41,7 +41,7 @@ public class Activator extends BaseActivator {
             return;
         }
 
-        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        Hashtable<String, Object> props = new Hashtable<>();
         props.put("url.handler.protocol", "feature");
         FeatureURLHandler handler = new FeatureURLHandler();
         register(URLStreamHandlerService.class, handler, props);

--- a/deployer/spring/src/main/java/org/apache/karaf/deployer/spring/SpringTransformer.java
+++ b/deployer/spring/src/main/java/org/apache/karaf/deployer/spring/SpringTransformer.java
@@ -120,7 +120,7 @@ public class SpringTransformer {
 
     public static Set<String> analyze(Source source) throws Exception {
 
-        Set<String> refers = new TreeSet<String>();
+        Set<String> refers = new TreeSet<>();
 
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         Result r = new StreamResult(bout);

--- a/deployer/spring/src/main/java/org/apache/karaf/deployer/spring/osgi/Activator.java
+++ b/deployer/spring/src/main/java/org/apache/karaf/deployer/spring/osgi/Activator.java
@@ -32,7 +32,7 @@ public class Activator extends BaseActivator {
 
     @Override
     protected void doStart() throws Exception {
-        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        Hashtable<String, Object> props = new Hashtable<>();
         props.put("url.handler.protocol", "spring");
         register(URLStreamHandlerService.class, new SpringURLHandler(), props);
         register(new Class[] { ArtifactUrlTransformer.class, ArtifactListener.class },

--- a/deployer/wrap/src/main/java/org/apache/karaf/deployer/wrap/osgi/Activator.java
+++ b/deployer/wrap/src/main/java/org/apache/karaf/deployer/wrap/osgi/Activator.java
@@ -33,7 +33,7 @@ public class Activator extends BaseActivator {
 
     @Override
     protected void doStart() throws Exception {
-        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        Hashtable<String, Object> props = new Hashtable<>();
         props.put("service.ranking", -1);
         register(ArtifactUrlTransformer.class, new WrapDeploymentListener(), props);
     }

--- a/diagnostic/boot/src/main/java/org/apache/karaf/diagnostic/core/Dump.java
+++ b/diagnostic/boot/src/main/java/org/apache/karaf/diagnostic/core/Dump.java
@@ -45,7 +45,7 @@ public final class Dump {
     }
 
     public static void dump(BundleContext bundleContext, DumpDestination destination, boolean noThreadDump, boolean noHeapDump) {
-        List<DumpProvider> providers = new ArrayList<DumpProvider>();
+        List<DumpProvider> providers = new ArrayList<>();
         providers.add(new EnvironmentDumpProvider(bundleContext));
         providers.add(new MemoryDumpProvider());
         if (!noThreadDump) providers.add(new ThreadDumpProvider());

--- a/diagnostic/boot/src/main/java/org/apache/karaf/diagnostic/core/providers/BundleDumpProvider.java
+++ b/diagnostic/boot/src/main/java/org/apache/karaf/diagnostic/core/providers/BundleDumpProvider.java
@@ -33,7 +33,7 @@ public class BundleDumpProvider extends TextDumpProvider {
     /**
      * Static map with state mask to string representation.
      */
-    private static Map<Integer, String> stateMap = new HashMap<Integer, String>();
+    private static Map<Integer, String> stateMap = new HashMap<>();
 
     /**
      * Map bundle states to string representation.

--- a/diagnostic/core/src/main/java/org/apache/karaf/diagnostic/internal/Activator.java
+++ b/diagnostic/core/src/main/java/org/apache/karaf/diagnostic/internal/Activator.java
@@ -42,10 +42,10 @@ public class Activator implements BundleActivator {
 
     @Override
     public void start(final BundleContext context) throws Exception {
-        registrations = new ArrayList<ServiceRegistration<DumpProvider>>();
+        registrations = new ArrayList<>();
         registrations.add(context.registerService(DumpProvider.class, new LogDumpProvider(context), null));
 
-        featuresServiceTracker = new SingleServiceTracker<FeaturesService>(context, FeaturesService.class, (oldFs, newFs) -> {
+        featuresServiceTracker = new SingleServiceTracker<>(context, FeaturesService.class, (oldFs, newFs) -> {
             if (featuresProviderRegistration != null) {
                 featuresProviderRegistration.unregister();
                 featuresProviderRegistration = null;
@@ -62,7 +62,7 @@ public class Activator implements BundleActivator {
         final DiagnosticDumpMBeanImpl diagnostic = new DiagnosticDumpMBeanImpl();
         diagnostic.setBundleContext(context);
 
-        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        Hashtable<String, Object> props = new Hashtable<>();
         props.put("jmx.objectname", "org.apache.karaf:type=diagnostic,name=" + System.getProperty("karaf.name"));
         mbeanRegistration = context.registerService(
                 getInterfaceNames(diagnostic),
@@ -81,7 +81,7 @@ public class Activator implements BundleActivator {
     }
 
     private String[] getInterfaceNames(Object object) {
-        List<String> names = new ArrayList<String>();
+        List<String> names = new ArrayList<>();
         for (Class cl = object.getClass(); cl != Object.class; cl = cl.getSuperclass()) {
             addSuperInterfaces(names, cl);
         }

--- a/features/command/src/main/java/org/apache/karaf/features/command/InfoFeatureCommand.java
+++ b/features/command/src/main/java/org/apache/karaf/features/command/InfoFeatureCommand.java
@@ -219,7 +219,7 @@ public class InfoFeatureCommand extends FeaturesCommandSupport {
 
             if (resolved != null) {
                 if (bundle) {
-                    List<String> bundleLocation = new LinkedList<String>();
+                    List<String> bundleLocation = new LinkedList<>();
                     List<BundleInfo> bundles = resolved.getBundles();
                     for (BundleInfo bundleInfo : bundles) {
                         bundleLocation.add(bundleInfo.getLocation());

--- a/features/command/src/main/java/org/apache/karaf/features/command/InstallFeatureCommand.java
+++ b/features/command/src/main/java/org/apache/karaf/features/command/InstallFeatureCommand.java
@@ -75,6 +75,6 @@ public class InstallFeatureCommand extends FeaturesCommandSupport {
         addOption(FeaturesService.Option.DisplayFeaturesWiring, featuresWiring);
         addOption(FeaturesService.Option.DisplayAllWiring, allWiring);
         admin.setResolutionOutputFile(outputFile);
-        admin.installFeatures(new HashSet<String>(features), region, options);
+        admin.installFeatures(new HashSet<>(features), region, options);
     }
 }

--- a/features/command/src/main/java/org/apache/karaf/features/command/RegionInfoCommand.java
+++ b/features/command/src/main/java/org/apache/karaf/features/command/RegionInfoCommand.java
@@ -84,7 +84,7 @@ public class RegionInfoCommand implements Action {
         BundleContext bundleContext = this.bundleContext.getBundle(0).getBundleContext();
         System.out.println(region.getName());
         if (verbose || bundles) {
-            for (Long id : new TreeSet<Long>(region.getBundleIds())) {
+            for (Long id : new TreeSet<>(region.getBundleIds())) {
                 Bundle b = bundleContext.getBundle(id);
                 System.out.println(String.format("  %3d  %s%s", id, getStateString(b), b));
             }

--- a/features/command/src/main/java/org/apache/karaf/features/command/RepoListCommand.java
+++ b/features/command/src/main/java/org/apache/karaf/features/command/RepoListCommand.java
@@ -59,7 +59,7 @@ public class RepoListCommand extends FeaturesCommandSupport {
     private void reloadAllRepos(FeaturesService featuresService) throws Exception {
         System.out.println("Reloading all repositories from their urls");
         System.out.println();
-        List<Exception> exceptions = new ArrayList<Exception>();
+        List<Exception> exceptions = new ArrayList<>();
         for (Repository repo : featuresService.listRepositories()) {
             try {
                 featuresService.addRepository(repo.getURI());

--- a/features/command/src/main/java/org/apache/karaf/features/command/RepoRefreshCommand.java
+++ b/features/command/src/main/java/org/apache/karaf/features/command/RepoRefreshCommand.java
@@ -43,7 +43,7 @@ public class RepoRefreshCommand extends FeaturesCommandSupport {
 
     @Override
     protected void doExecute(FeaturesService featuresService) throws Exception {
-        List<URI> uris = new ArrayList<URI>();
+        List<URI> uris = new ArrayList<>();
     	if (nameOrUrl != null) {
     		String effectiveVersion = (version == null) ? "LATEST" : version;
         	URI uri = featuresService.getRepositoryUriFor(nameOrUrl, effectiveVersion);

--- a/features/command/src/main/java/org/apache/karaf/features/command/UninstallFeatureCommand.java
+++ b/features/command/src/main/java/org/apache/karaf/features/command/UninstallFeatureCommand.java
@@ -51,6 +51,6 @@ public class UninstallFeatureCommand extends FeaturesCommandSupport {
         addOption(FeaturesService.Option.Simulate, simulate);
         addOption(FeaturesService.Option.Verbose, verbose);
         addOption(FeaturesService.Option.NoAutoRefreshBundles, noRefresh);
-        admin.uninstallFeatures(new HashSet<String>(features), region, options);
+        admin.uninstallFeatures(new HashSet<>(features), region, options);
     }
 }

--- a/features/core/src/main/java/org/apache/karaf/features/internal/model/Content.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/model/Content.java
@@ -59,7 +59,7 @@ public class Content {
      */
     public List<Config> getConfig() {
         if (config == null) {
-            config = new ArrayList<Config>();
+            config = new ArrayList<>();
         }
         return this.config;
     }
@@ -140,19 +140,19 @@ public class Content {
     }
 
     public List<org.apache.karaf.features.Dependency> getDependencies() {
-        return Collections.<org.apache.karaf.features.Dependency>unmodifiableList(getFeature());
+        return Collections.unmodifiableList(getFeature());
     }
 
     public List<BundleInfo> getBundles() {
-        return Collections.<BundleInfo>unmodifiableList(getBundle());
+        return Collections.unmodifiableList(getBundle());
     }
 
     public List<ConfigInfo> getConfigurations() {
-    	return Collections.<ConfigInfo>unmodifiableList(getConfig());
+    	return Collections.unmodifiableList(getConfig());
     }
 
     public List<ConfigFileInfo> getConfigurationFiles() {
-        return Collections.<ConfigFileInfo>unmodifiableList(getConfigfile());
+        return Collections.unmodifiableList(getConfigfile());
     }
 
 }

--- a/features/core/src/main/java/org/apache/karaf/features/internal/model/Feature.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/model/Feature.java
@@ -458,7 +458,7 @@ public class Feature extends Content implements org.apache.karaf.features.Featur
     public List<String> getResourceRepositories() {
         return resourceRepositories != null
                 ? resourceRepositories
-                : Collections.<String>emptyList();
+                : Collections.emptyList();
     }
 
     public void setResourceRepositories(List<String> resourceRepositories) {

--- a/features/core/src/main/java/org/apache/karaf/features/internal/region/AbstractRegionDigraphVisitor.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/region/AbstractRegionDigraphVisitor.java
@@ -34,9 +34,9 @@ import org.eclipse.equinox.region.RegionFilter;
 public abstract class AbstractRegionDigraphVisitor<C> implements RegionDigraphVisitor {
 
     private final Collection<C> allCandidates;
-    private final Deque<Set<C>> allowedDeque = new ArrayDeque<Set<C>>();
-    private final Deque<Collection<C>> filteredDeque = new ArrayDeque<Collection<C>>();
-    private Set<C> allowed = new HashSet<C>();
+    private final Deque<Set<C>> allowedDeque = new ArrayDeque<>();
+    private final Deque<Collection<C>> filteredDeque = new ArrayDeque<>();
+    private Set<C> allowed = new HashSet<>();
 
     public AbstractRegionDigraphVisitor(Collection<C> candidates) {
         this.allCandidates = candidates;
@@ -69,7 +69,7 @@ public abstract class AbstractRegionDigraphVisitor<C> implements RegionDigraphVi
     public boolean preEdgeTraverse(RegionFilter regionFilter) {
         // Find the candidates filtered by the previous edge
         Collection<C> filtered = filteredDeque.isEmpty() ? allCandidates : filteredDeque.peek();
-        Collection<C> candidates = new ArrayList<C>(filtered);
+        Collection<C> candidates = new ArrayList<>(filtered);
         // remove any candidates contained in the current region
         candidates.removeAll(allowed);
         // apply the filter across remaining candidates
@@ -87,7 +87,7 @@ public abstract class AbstractRegionDigraphVisitor<C> implements RegionDigraphVi
         filteredDeque.push(candidates);
         // push the allowed
         allowedDeque.push(allowed);
-        allowed = new HashSet<C>();
+        allowed = new HashSet<>();
         return true;
     }
 

--- a/features/core/src/main/java/org/apache/karaf/features/internal/region/OfflineResolver.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/region/OfflineResolver.java
@@ -81,12 +81,12 @@ public class OfflineResolver {
 
             @Override
             public Collection<Resource> getMandatoryResources() {
-                List<Resource> resources = new ArrayList<Resource>();
+                List<Resource> resources = new ArrayList<>();
                 Requirement req = new RequirementImpl(
                         null,
                         IDENTITY_NAMESPACE,
-                        Collections.<String, String>emptyMap(),
-                        Collections.<String, Object>emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
                         SimpleFilter.parse("(" + IDENTITY_NAMESPACE + "=root)"));
                 Collection<Capability> identities = repository.findProviders(Collections.singleton(req)).get(req);
                 for (Capability identity : identities) {

--- a/features/core/src/main/java/org/apache/karaf/features/internal/region/Subsystem.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/region/Subsystem.java
@@ -540,7 +540,7 @@ public class Subsystem extends ResourceImpl {
             while ((entry = zis.getNextEntry()) != null) {
                 if (MANIFEST_NAME.equals(entry.getName())) {
                     Attributes attributes = new Manifest(zis).getMainAttributes();
-                    Map<java.lang.String, java.lang.String> headers = new HashMap<java.lang.String, java.lang.String>();
+                    Map<java.lang.String, java.lang.String> headers = new HashMap<>();
                     for (Map.Entry attr : attributes.entrySet()) {
                         headers.put(attr.getKey().toString(), attr.getValue().toString());
                     }

--- a/features/core/src/main/java/org/apache/karaf/features/internal/region/SubsystemResolveContext.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/region/SubsystemResolveContext.java
@@ -67,7 +67,7 @@ public class SubsystemResolveContext extends ResolveContext {
     private final Set<Resource> mandatory = new HashSet<>();
     private final CandidateComparator candidateComparator = new CandidateComparator(mandatory);
 
-    private final Map<Resource, Subsystem> resToSub = new HashMap<Resource, Subsystem>();
+    private final Map<Resource, Subsystem> resToSub = new HashMap<>();
     private final Repository repository;
     private final Repository globalRepository;
     private final Downloader downloader;
@@ -176,7 +176,7 @@ public class SubsystemResolveContext extends ResolveContext {
 
     @Override
     public Collection<Resource> getMandatoryResources() {
-        return Collections.<Resource>singleton(root);
+        return Collections.singleton(root);
     }
 
     @Override
@@ -311,7 +311,7 @@ public class SubsystemResolveContext extends ResolveContext {
             List<Capability> identities = resource.getCapabilities(IDENTITY_NAMESPACE);
             if (identities != null && !identities.isEmpty()) {
                 Capability identity = identities.iterator().next();
-                Map<String, Object> attrs = new HashMap<String, Object>();
+                Map<String, Object> attrs = new HashMap<>();
                 attrs.put(BUNDLE_SYMBOLICNAME_ATTRIBUTE, identity.getAttributes().get(IDENTITY_NAMESPACE));
                 attrs.put(BUNDLE_VERSION_ATTRIBUTE, identity.getAttributes().get(CAPABILITY_VERSION_ATTRIBUTE));
                 return filter.isAllowed(VISIBLE_BUNDLE_NAMESPACE, attrs);
@@ -324,7 +324,7 @@ public class SubsystemResolveContext extends ResolveContext {
     class SubsystemRepository implements Repository {
 
         private final Repository repository;
-        private final Map<Subsystem, Map<Capability, Capability>> mapping = new HashMap<Subsystem, Map<Capability, Capability>>();
+        private final Map<Subsystem, Map<Capability, Capability>> mapping = new HashMap<>();
 
         public SubsystemRepository(Repository repository) {
             this.repository = repository;
@@ -333,9 +333,9 @@ public class SubsystemResolveContext extends ResolveContext {
         @Override
         public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
             Map<Requirement, Collection<Capability>> base = repository.findProviders(requirements);
-            Map<Requirement, Collection<Capability>> result = new HashMap<Requirement, Collection<Capability>>();
+            Map<Requirement, Collection<Capability>> result = new HashMap<>();
             for (Map.Entry<Requirement, Collection<Capability>> entry : base.entrySet()) {
-                List<Capability> caps = new ArrayList<Capability>();
+                List<Capability> caps = new ArrayList<>();
                 Subsystem ss = getSubsystem(entry.getKey().getResource());
                 while (!ss.isAcceptDependencies()) {
                     ss = ss.getParent();

--- a/features/core/src/main/java/org/apache/karaf/features/internal/region/SubsystemResolver.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/region/SubsystemResolver.java
@@ -168,7 +168,7 @@ public class SubsystemResolver {
         if (root != null) {
             return root.collectPrerequisites();
         }
-        return new HashSet<String>();
+        return new HashSet<>();
     }
 
     public Map<Resource, List<Wire>> resolve(
@@ -272,8 +272,8 @@ public class SubsystemResolver {
         Requirement req = new RequirementImpl(
                 null,
                 IDENTITY_NAMESPACE,
-                Collections.<String, String>emptyMap(),
-                Collections.<String, Object>emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
                 new SimpleFilter(null, null, SimpleFilter.MATCH_ALL));
         Collection<Capability> identities = repository.findProviders(Collections.singleton(req)).get(req);
         List<Object> resources = new ArrayList<>();

--- a/features/core/src/main/java/org/apache/karaf/features/internal/repository/AggregateRepository.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/repository/AggregateRepository.java
@@ -37,9 +37,9 @@ public class AggregateRepository implements Repository {
 
     @Override
     public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
-        Map<Requirement, Collection<Capability>> result = new HashMap<Requirement, Collection<Capability>>();
+        Map<Requirement, Collection<Capability>> result = new HashMap<>();
         for (Requirement requirement : requirements) {
-            List<Capability> caps = new ArrayList<Capability>();
+            List<Capability> caps = new ArrayList<>();
             for (Repository repository : repositories) {
                 Map<Requirement, Collection<Capability>> resMap =
                         repository.findProviders(Collections.singleton(requirement));

--- a/features/core/src/main/java/org/apache/karaf/features/internal/repository/BaseRepository.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/repository/BaseRepository.java
@@ -43,8 +43,8 @@ public class BaseRepository implements Repository {
     protected final Map<String, CapabilitySet> capSets;
 
     public BaseRepository() {
-        this.resources = new ArrayList<Resource>();
-        this.capSets = new HashMap<String, CapabilitySet>();
+        this.resources = new ArrayList<>();
+        this.capSets = new HashMap<>();
     }
 
     public BaseRepository(Collection<Resource> resources) {
@@ -68,7 +68,7 @@ public class BaseRepository implements Repository {
 
     @Override
     public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
-        Map<Requirement, Collection<Capability>> result = new HashMap<Requirement, Collection<Capability>>();
+        Map<Requirement, Collection<Capability>> result = new HashMap<>();
         for (Requirement requirement : requirements) {
             CapabilitySet set = capSets.get(requirement.getNamespace());
             if (set != null) {
@@ -83,7 +83,7 @@ public class BaseRepository implements Repository {
                 }
                 result.put(requirement, set.match(sf, true));
             } else {
-                result.put(requirement, Collections.<Capability>emptyList());
+                result.put(requirement, Collections.emptyList());
             }
         }
         return result;

--- a/features/core/src/main/java/org/apache/karaf/features/internal/repository/XmlRepository.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/repository/XmlRepository.java
@@ -48,7 +48,7 @@ public class XmlRepository extends BaseRepository {
     protected final String url;
     protected final long expiration;
     protected final boolean ignoreFailures;
-    protected final Map<String, XmlLoader> loaders = new HashMap<String, XmlLoader>();
+    protected final Map<String, XmlLoader> loaders = new HashMap<>();
     protected final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     public XmlRepository(String url, long expiration, boolean ignoreFailures) {
@@ -102,7 +102,7 @@ public class XmlRepository extends BaseRepository {
     private boolean hasResource(String type, String name, Version version) {
         CapabilitySet set = capSets.get(IDENTITY_NAMESPACE);
         if (set != null) {
-            Map<String, Object> attrs = new HashMap<String, Object>();
+            Map<String, Object> attrs = new HashMap<>();
             attrs.put(CAPABILITY_TYPE_ATTRIBUTE, type);
             attrs.put(IDENTITY_NAMESPACE, name);
             attrs.put(CAPABILITY_VERSION_ATTRIBUTE, version);

--- a/features/core/src/main/java/org/apache/karaf/features/internal/resolver/CapabilitySet.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/resolver/CapabilitySet.java
@@ -46,7 +46,7 @@ public class CapabilitySet {
         indices = new TreeMap<>();
         for (int i = 0; (indexProps != null) && (i < indexProps.size()); i++) {
             indices.put(
-                    indexProps.get(i), new HashMap<Object, Set<Capability>>());
+                    indexProps.get(i), new HashMap<>());
         }
     }
 

--- a/features/core/src/main/java/org/apache/karaf/features/internal/resolver/ResolverUtil.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/resolver/ResolverUtil.java
@@ -92,7 +92,7 @@ public class ResolverUtil
 
     public static List<Requirement> getDynamicRequirements(List<Requirement> reqs)
     {
-        List<Requirement> result = new ArrayList<Requirement>();
+        List<Requirement> result = new ArrayList<>();
         if (reqs != null)
         {
             for (Requirement req : reqs)

--- a/features/core/src/main/java/org/apache/karaf/features/internal/resolver/ResourceBuilder.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/resolver/ResourceBuilder.java
@@ -122,7 +122,7 @@ public final class ResourceBuilder {
         if (uri != null) {
             Map<String, Object> attrs = new HashMap<>();
             attrs.put(ContentNamespace.CAPABILITY_URL_ATTRIBUTE, uri);
-            resource.addCapability(new CapabilityImpl(resource, ContentNamespace.CONTENT_NAMESPACE, Collections.<String, String>emptyMap(), attrs));
+            resource.addCapability(new CapabilityImpl(resource, ContentNamespace.CONTENT_NAMESPACE, Collections.emptyMap(), attrs));
         }
 
         // Add a bundle and host capability to all
@@ -190,7 +190,7 @@ public final class ResourceBuilder {
         // Parse Bundle-RequiredExecutionEnvironment.
         //
         List<Requirement> breeReqs =
-                parseBreeHeader((String) headerMap.get(Constants.BUNDLE_REQUIREDEXECUTIONENVIRONMENT), resource);
+                parseBreeHeader(headerMap.get(Constants.BUNDLE_REQUIREDEXECUTIONENVIRONMENT), resource);
 
         //
         // Parse Export-Package.
@@ -377,7 +377,7 @@ public final class ResourceBuilder {
                             resource,
                             ServiceNamespace.SERVICE_NAMESPACE,
                             dirs,
-                            Collections.<String, Object>emptyMap(),
+                            Collections.emptyMap(),
                             SimpleFilter.parse(filter)));
                 }
             }
@@ -422,7 +422,7 @@ public final class ResourceBuilder {
                                 resource,
                                 BundleRevision.PACKAGE_NAMESPACE,
                                 newDirs,
-                                Collections.<String, Object>emptyMap(),
+                                Collections.emptyMap(),
                                 sf)
                 );
             }
@@ -850,7 +850,7 @@ public final class ResourceBuilder {
     }
 
     private static List<Requirement> parseBreeHeader(String header, Resource resource) {
-        List<String> filters = new ArrayList<String>();
+        List<String> filters = new ArrayList<>();
         for (String entry : parseDelimitedString(header, ",")) {
             List<String> names = parseDelimitedString(entry, "/");
             List<String> left = parseDelimitedString(names.get(0), "-");
@@ -930,11 +930,11 @@ public final class ResourceBuilder {
             }
 
             SimpleFilter sf = SimpleFilter.parse(reqFilter);
-            return Collections.<Requirement>singletonList(new RequirementImpl(
+            return Collections.singletonList(new RequirementImpl(
                     resource,
                     ExecutionEnvironmentNamespace.EXECUTION_ENVIRONMENT_NAMESPACE,
                     Collections.singletonMap(ExecutionEnvironmentNamespace.REQUIREMENT_FILTER_DIRECTIVE, reqFilter),
-                    Collections.<String, Object>emptyMap(),
+                    Collections.emptyMap(),
                     sf));
         }
     }

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/Deployer.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/Deployer.java
@@ -595,8 +595,8 @@ public class Deployer {
             toRefresh.put(serviceBundle, "FeaturesService bundle is being updated");
             computeBundlesToRefresh(toRefresh,
                     dstate.bundles.values(),
-                    Collections.<Resource, Bundle>emptyMap(),
-                    Collections.<Resource, List<Wire>>emptyMap());
+                    Collections.emptyMap(),
+                    Collections.emptyMap());
             installSupport.stopBundle(serviceBundle, STOP_TRANSIENT);
             try (
                     InputStream is = getBundleInputStream(resource, providers)
@@ -964,7 +964,7 @@ public class Deployer {
         // Compute the new list of fragments
         Map<Bundle, Set<Resource>> newFragments = new HashMap<>();
         for (Bundle bundle : bundles) {
-            newFragments.put(bundle, new HashSet<Resource>());
+            newFragments.put(bundle, new HashSet<>());
         }
         if (resolution != null) {
             for (Resource res : resolution.keySet()) {

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/EventAdminListener.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/EventAdminListener.java
@@ -39,7 +39,7 @@ public class EventAdminListener implements FeaturesListener {
     private final ServiceTracker<EventAdmin, EventAdmin> tracker;
 
     public EventAdminListener(BundleContext context) {
-        tracker = new ServiceTracker<EventAdmin, EventAdmin>(context, EventAdmin.class.getName(), null);
+        tracker = new ServiceTracker<>(context, EventAdmin.class.getName(), null);
         tracker.open();
     }
 
@@ -49,7 +49,7 @@ public class EventAdminListener implements FeaturesListener {
             if (eventAdmin == null) {
                 return;
             }
-            Dictionary<String, Object> props = new Hashtable<String, Object>();
+            Dictionary<String, Object> props = new Hashtable<>();
             props.put(EventConstants.TYPE, event.getType());
             props.put(EventConstants.EVENT, event);
             props.put(EventConstants.TIMESTAMP, System.currentTimeMillis());
@@ -78,7 +78,7 @@ public class EventAdminListener implements FeaturesListener {
             if (eventAdmin == null) {
                 return;
             }
-            Dictionary<String, Object> props = new Hashtable<String, Object>();
+            Dictionary<String, Object> props = new Hashtable<>();
             props.put(EventConstants.TYPE, event.getType());
             props.put(EventConstants.EVENT, event);
             props.put(EventConstants.TIMESTAMP, System.currentTimeMillis());

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
@@ -185,7 +185,7 @@ public class FeatureConfigInstaller {
         // Substitute all variables, but keep unknown ones.
         final String dummyKey = "";
         try {
-            finalname = InterpolationHelper.substVars(finalname, dummyKey, null, null, (SubstitutionCallback) null,
+            finalname = InterpolationHelper.substVars(finalname, dummyKey, null, null, null,
                     true, true, false);
         } catch (final IllegalArgumentException ex) {
             LOGGER.info("Substitution failed. Skip substitution of variables of configuration final name ({}).",

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/Overrides.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/Overrides.java
@@ -79,7 +79,7 @@ public final class Overrides {
                 // Ignore invalid overrides
                 continue;
             }
-            for (String uri : new ArrayList<String>(resources.keySet())) {
+            for (String uri : new ArrayList<>(resources.keySet())) {
                 Resource res = resources.get(uri);
                 if (shouldOverride(res, over, overrideRange)) {
                     resources.put(uri, over);
@@ -110,7 +110,7 @@ public final class Overrides {
     }
 
     public static Set<String> loadOverrides(String overridesUrl) {
-        Set<String> overrides = new HashSet<String>();
+        Set<String> overrides = new HashSet<>();
         try {
             if (overridesUrl != null) {
                 try (

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/RequirementSort.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/RequirementSort.java
@@ -42,20 +42,20 @@ public final class RequirementSort<T extends Resource> {
      * @return sorted collection of resources.
      */
     public static <T extends Resource> Collection<T> sort(Collection<T> resources) {
-        Set<String> namespaces = new HashSet<String>();
+        Set<String> namespaces = new HashSet<>();
         for (Resource r : resources) {
             for (Capability cap : r.getCapabilities(null)) {
                 namespaces.add(cap.getNamespace());
             }
         }
-        CapabilitySet capSet = new CapabilitySet(new ArrayList<String>(namespaces));
+        CapabilitySet capSet = new CapabilitySet(new ArrayList<>(namespaces));
         for (Resource r : resources) {
             for (Capability cap : r.getCapabilities(null)) {
                 capSet.addCapability(cap);
             }
         }
-        Set<T> sorted = new LinkedHashSet<T>();
-        Set<T> visited = new LinkedHashSet<T>();
+        Set<T> sorted = new LinkedHashSet<>();
+        Set<T> visited = new LinkedHashSet<>();
         for (T r : resources) {
             visit(r, visited, sorted, capSet);
         }
@@ -74,7 +74,7 @@ public final class RequirementSort<T extends Resource> {
 
     @SuppressWarnings("unchecked")
     private static <T extends Resource> Set<T> collectDependencies(T resource, CapabilitySet capSet) {
-        Set<T> result = new LinkedHashSet<T>();
+        Set<T> result = new LinkedHashSet<>();
         for (Requirement requirement : resource.getRequirements(null)) {
             String filter = requirement.getDirectives().get(Constants.FILTER_DIRECTIVE);
             SimpleFilter sf = (filter != null)

--- a/features/core/src/main/java/org/apache/karaf/features/management/codec/JmxFeature.java
+++ b/features/core/src/main/java/org/apache/karaf/features/management/codec/JmxFeature.java
@@ -166,7 +166,7 @@ public class JmxFeature {
 				FEATURE_CONFIG_ELEMENT_TABLE);
 		for (Object key : props.keySet()) {
 			String[] itemNames = FeaturesServiceMBean.FEATURE_CONFIG_ELEMENT;
-			Object[] itemValues = { (String) key,
+			Object[] itemValues = {key,
 					props.getProperty((String) key) };
 			CompositeData element = new CompositeDataSupport(
 					FEATURE_CONFIG_ELEMENT, itemNames, itemValues);

--- a/features/core/src/test/java/org/apache/karaf/features/FeaturesServiceTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/FeaturesServiceTest.java
@@ -375,12 +375,12 @@ public class FeaturesServiceTest extends TestBase {
         FeaturesServiceImpl svc = new FeaturesServiceImpl(new Storage(), null, null, resolver, installSupport, null, cfg);
         svc.addRepository(uri);
         try {
-            List<String> features = new ArrayList<String>();
+            List<String> features = new ArrayList<>();
             for (Feature feature : svc.listFeatures()) {
                 features.add(feature.getId());
             }
             Collections.reverse(features);
-            svc.installFeatures(new CopyOnWriteArraySet<String>(features),
+            svc.installFeatures(new CopyOnWriteArraySet<>(features),
                                 EnumSet.noneOf(FeaturesService.Option.class));
             fail("Call should have thrown an exception");
         } catch (MultiException e) {

--- a/features/core/src/test/java/org/apache/karaf/features/TestBase.java
+++ b/features/core/src/test/java/org/apache/karaf/features/TestBase.java
@@ -37,7 +37,7 @@ public class TestBase {
         Bundle bundle = EasyMock.createNiceMock(Bundle.class);
         
         // Be aware that this means all bundles are treated as different
-        expect(bundle.compareTo(EasyMock.<Bundle>anyObject())).andReturn(1).anyTimes();
+        expect(bundle.compareTo(EasyMock.anyObject())).andReturn(1).anyTimes();
 
         expect(bundle.getBundleId()).andReturn(id).anyTimes();
         expect(bundle.getSymbolicName()).andReturn(symbolicName).anyTimes();
@@ -50,7 +50,7 @@ public class TestBase {
     }
     
     public Dictionary<String, String> headers(String ... keyAndHeader) {
-        Hashtable<String, String> headersTable = new Hashtable<String, String>();
+        Hashtable<String, String> headersTable = new Hashtable<>();
         int c=0;
         while (c < keyAndHeader.length) {
             String key = keyAndHeader[c++];
@@ -61,7 +61,7 @@ public class TestBase {
     }
     
     public Map<String, Map<String, Feature>> features(Feature ... features) {
-        final Map<String, Map<String, Feature>> featuresMap = new HashMap<String, Map<String,Feature>>();
+        final Map<String, Map<String, Feature>> featuresMap = new HashMap<>();
         for (Feature feature : features) {
             Map<String, Feature> featureVersion = getOrCreate(featuresMap, feature);
             featureVersion.put(feature.getVersion(), feature);
@@ -82,19 +82,19 @@ public class TestBase {
     }
     
     public Set<Bundle> setOf(Bundle ... elements) {
-        return new HashSet<Bundle>(Arrays.asList(elements));
+        return new HashSet<>(Arrays.asList(elements));
     }
     
     public Set<Long> setOf(Long ... elements) {
-        return new HashSet<Long>(Arrays.asList(elements));
+        return new HashSet<>(Arrays.asList(elements));
     }
     
     public Set<String> setOf(String ... elements) {
-        return new HashSet<String>(asList(elements));
+        return new HashSet<>(asList(elements));
     }
     
     public Set<Feature> setOf(Feature ... elements) {
-        return new HashSet<Feature>(Arrays.asList(elements));
+        return new HashSet<>(Arrays.asList(elements));
     }
 
 }

--- a/features/core/src/test/java/org/apache/karaf/features/internal/region/FeaturesDependenciesTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/region/FeaturesDependenciesTest.java
@@ -131,12 +131,12 @@ public class FeaturesDependenciesTest {
     private void doTestFeatureDependency(String[] features, String[] bundles) throws Exception {
         RepositoryImpl repo = new RepositoryImpl(getClass().getResource("data8/features.xml").toURI());
 
-        Map<String, Set<String>> requirements = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> requirements = new HashMap<>();
         for (String feature : features) {
             addToMapSet(requirements, "root", feature);
         }
 
-        Map<String, Set<String>> expected = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> expected = new HashMap<>();
         for (String bundle : bundles) {
             addToMapSet(expected, "root", bundle);
         }
@@ -144,8 +144,8 @@ public class FeaturesDependenciesTest {
         SubsystemResolver resolver = new SubsystemResolver(this.resolver, new TestDownloadManager(getClass(), "data8"));
         resolver.prepare(Arrays.asList(repo.getFeatures()),
                 requirements,
-                Collections.<String, Set<BundleRevision>>emptyMap());
-        resolver.resolve(Collections.<String>emptySet(),
+                Collections.emptyMap());
+        resolver.resolve(Collections.emptySet(),
                 FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE,
                 null, null, null);
 
@@ -173,7 +173,7 @@ public class FeaturesDependenciesTest {
     }
 
     private Map<String, Set<String>> getBundleNamesPerRegions(SubsystemResolver resolver) {
-        Map<String, Set<String>> mapping = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> mapping = new HashMap<>();
         Map<String, Set<Resource>> bundles = resolver.getBundlesPerRegions();
         for (Map.Entry<String,Set<Resource>> entry : bundles.entrySet()) {
             for (Resource r : entry.getValue()) {
@@ -187,7 +187,7 @@ public class FeaturesDependenciesTest {
     private void dumpWiring(SubsystemResolver resolver) {
         System.out.println("Wiring");
         Map<Resource, List<Wire>> wiring = resolver.getWiring();
-        List<Resource> resources = new ArrayList<Resource>(wiring.keySet());
+        List<Resource> resources = new ArrayList<>(wiring.keySet());
         Collections.sort(resources, new Comparator<Resource>() {
             @Override
             public int compare(Resource o1, Resource o2) {

--- a/features/core/src/test/java/org/apache/karaf/features/internal/region/SubsystemTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/region/SubsystemTest.java
@@ -52,11 +52,11 @@ public class SubsystemTest {
     public void test1() throws Exception {
         RepositoryImpl repo = new RepositoryImpl(getClass().getResource("data1/features.xml").toURI());
 
-        Map<String, Set<String>> features = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> features = new HashMap<>();
         addToMapSet(features, "root", "f1");
         addToMapSet(features, "root/apps1", "f2");
 
-        Map<String, Set<String>> expected = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> expected = new HashMap<>();
         addToMapSet(expected, "root", "a/1.0.0");
         addToMapSet(expected, "root", "c/1.0.0");
         addToMapSet(expected, "root/apps1", "b/1.0.0");
@@ -64,8 +64,8 @@ public class SubsystemTest {
         SubsystemResolver resolver = new SubsystemResolver(this.resolver, new TestDownloadManager(getClass(), "data1"));
         resolver.prepare(Arrays.asList(repo.getFeatures()),
                          features,
-                         Collections.<String, Set<BundleRevision>>emptyMap());
-        resolver.resolve(Collections.<String>emptySet(),
+                         Collections.emptyMap());
+        resolver.resolve(Collections.emptySet(),
                          FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE,
                          null, null, null);
 
@@ -77,12 +77,12 @@ public class SubsystemTest {
 
         RepositoryImpl repo = new RepositoryImpl(getClass().getResource("data2/features.xml").toURI());
 
-        Map<String, Set<String>> features = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> features = new HashMap<>();
         addToMapSet(features, "root/apps1", "f1");
         addToMapSet(features, "root/apps1", "f3");
         addToMapSet(features, "root/apps2", "f1");
 
-        Map<String, Set<String>> expected = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> expected = new HashMap<>();
         addToMapSet(expected, "root/apps1", "c/1.0.0");
         addToMapSet(expected, "root/apps1", "b/1.0.0");
         addToMapSet(expected, "root/apps1", "e/1.0.0");
@@ -95,8 +95,8 @@ public class SubsystemTest {
         SubsystemResolver resolver = new SubsystemResolver(this.resolver, new TestDownloadManager(getClass(), "data2"));
         resolver.prepare(Arrays.asList(repo.getFeatures()),
                          features,
-                         Collections.<String, Set<BundleRevision>>emptyMap());
-        resolver.resolve(Collections.<String>emptySet(),
+                         Collections.emptyMap());
+        resolver.resolve(Collections.emptySet(),
                          FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE,
                          null, null, null);
 
@@ -107,16 +107,16 @@ public class SubsystemTest {
     public void testOverrides() throws Exception {
         RepositoryImpl repo = new RepositoryImpl(getClass().getResource("data3/features.xml").toURI());
 
-        Map<String, Set<String>> features = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> features = new HashMap<>();
         addToMapSet(features, "root/apps1", "f1");
 
-        Map<String, Set<String>> expected = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> expected = new HashMap<>();
         addToMapSet(expected, "root/apps1", "a/1.0.1");
 
         SubsystemResolver resolver = new SubsystemResolver(this.resolver, new TestDownloadManager(getClass(), "data3"));
         resolver.prepare(Arrays.asList(repo.getFeatures()),
                          features,
-                         Collections.<String, Set<BundleRevision>>emptyMap());
+                         Collections.emptyMap());
         resolver.resolve(Collections.singleton("b"),
                          FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE,
                          null, null, null);
@@ -128,16 +128,16 @@ public class SubsystemTest {
     public void testConditionalUnsatisfiedWithOptional() throws Exception {
         RepositoryImpl repo = new RepositoryImpl(getClass().getResource("data4/features.xml").toURI());
 
-        Map<String, Set<String>> features = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> features = new HashMap<>();
         addToMapSet(features, "root/apps1", "f1");
-        Map<String, Set<String>> expected = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> expected = new HashMap<>();
         addToMapSet(expected, "root/apps1", "a/1.0.0");
 
         SubsystemResolver resolver = new SubsystemResolver(this.resolver, new TestDownloadManager(getClass(), "data4"));
         resolver.prepare(Arrays.asList(repo.getFeatures()),
                          features,
-                         Collections.<String, Set<BundleRevision>>emptyMap());
-        resolver.resolve(Collections.<String>emptySet(),
+                         Collections.emptyMap());
+        resolver.resolve(Collections.emptySet(),
                          FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE,
                          null, null, null);
 
@@ -148,18 +148,18 @@ public class SubsystemTest {
     public void testConditionalSatisfiedWithOptional() throws Exception {
         RepositoryImpl repo = new RepositoryImpl(getClass().getResource("data4/features.xml").toURI());
 
-        Map<String, Set<String>> features = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> features = new HashMap<>();
         addToMapSet(features, "root/apps1", "f1");
         addToMapSet(features, "root/apps1", "f2");
-        Map<String, Set<String>> expected = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> expected = new HashMap<>();
         addToMapSet(expected, "root/apps1", "a/1.0.0");
         addToMapSet(expected, "root/apps1", "b/1.0.0");
 
         SubsystemResolver resolver = new SubsystemResolver(this.resolver, new TestDownloadManager(getClass(), "data4"));
         resolver.prepare(Arrays.asList(repo.getFeatures()),
                          features,
-                         Collections.<String, Set<BundleRevision>>emptyMap());
-        resolver.resolve(Collections.<String>emptySet(),
+                         Collections.emptyMap());
+        resolver.resolve(Collections.emptySet(),
                          FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE,
                          null, null, null);
 
@@ -170,18 +170,18 @@ public class SubsystemTest {
     public void testBundle() throws Exception {
         RepositoryImpl repo = new RepositoryImpl(getClass().getResource("data1/features.xml").toURI());
 
-        Map<String, Set<String>> features = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> features = new HashMap<>();
         addToMapSet(features, "root/apps1", "bundle:a");
         addToMapSet(features, "root/apps1", "bundle:c;dependency=true");
-        Map<String, Set<String>> expected = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> expected = new HashMap<>();
         addToMapSet(expected, "root/apps1", "a/1.0.0");
         addToMapSet(expected, "root/apps1", "c/1.0.0");
 
         SubsystemResolver resolver = new SubsystemResolver(this.resolver, new TestDownloadManager(getClass(), "data1"));
         resolver.prepare(Arrays.asList(repo.getFeatures()),
                 features,
-                Collections.<String, Set<BundleRevision>>emptyMap());
-        resolver.resolve(Collections.<String>emptySet(),
+                Collections.emptyMap());
+        resolver.resolve(Collections.emptySet(),
                 FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE,
                 null, null, null);
 
@@ -192,17 +192,17 @@ public class SubsystemTest {
     public void testFeatureOptional() throws Exception {
         RepositoryImpl repo = new RepositoryImpl(getClass().getResource("data5/features.xml").toURI());
 
-        Map<String, Set<String>> features = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> features = new HashMap<>();
         addToMapSet(features, "root", "f1");
-        Map<String, Set<String>> expected = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> expected = new HashMap<>();
         addToMapSet(expected, "root", "a/1.0.0");
         addToMapSet(expected, "root", "b/1.0.0");
 
         SubsystemResolver resolver = new SubsystemResolver(this.resolver, new TestDownloadManager(getClass(), "data5"));
         resolver.prepare(Arrays.asList(repo.getFeatures()),
                 features,
-                Collections.<String, Set<BundleRevision>>emptyMap());
-        resolver.resolve(Collections.<String>emptySet(),
+                Collections.emptyMap());
+        resolver.resolve(Collections.emptySet(),
                 FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE,
                 null, null, null);
 
@@ -213,18 +213,18 @@ public class SubsystemTest {
     public void testFeatureOptionalAlreadyProvided() throws Exception {
         RepositoryImpl repo = new RepositoryImpl(getClass().getResource("data5/features.xml").toURI());
 
-        Map<String, Set<String>> features = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> features = new HashMap<>();
         addToMapSet(features, "root", "f1");
         addToMapSet(features, "root", "f3");
-        Map<String, Set<String>> expected = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> expected = new HashMap<>();
         addToMapSet(expected, "root", "a/1.0.0");
         addToMapSet(expected, "root", "c/1.0.0");
 
         SubsystemResolver resolver = new SubsystemResolver(this.resolver, new TestDownloadManager(getClass(), "data5"));
         resolver.prepare(Arrays.asList(repo.getFeatures()),
                 features,
-                Collections.<String, Set<BundleRevision>>emptyMap());
-        resolver.resolve(Collections.<String>emptySet(),
+                Collections.emptyMap());
+        resolver.resolve(Collections.emptySet(),
                 FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE,
                 null, null, null);
 
@@ -235,18 +235,18 @@ public class SubsystemTest {
     public void testFeatureOptionalAlreadyProvided2() throws Exception {
         RepositoryImpl repo = new RepositoryImpl(getClass().getResource("data6/features.xml").toURI());
 
-        Map<String, Set<String>> features = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> features = new HashMap<>();
         addToMapSet(features, "root", "pax-http");
         addToMapSet(features, "root", "pax-http-tomcat");
-        Map<String, Set<String>> expected = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> expected = new HashMap<>();
         addToMapSet(expected, "root", "a/1.0.0");
         addToMapSet(expected, "root", "c/1.0.0");
 
         SubsystemResolver resolver = new SubsystemResolver(this.resolver, new TestDownloadManager(getClass(), "data6"));
         resolver.prepare(Arrays.asList(repo.getFeatures()),
                 features,
-                Collections.<String, Set<BundleRevision>>emptyMap());
-        resolver.resolve(Collections.<String>emptySet(),
+                Collections.emptyMap());
+        resolver.resolve(Collections.emptySet(),
                 FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE,
                 null, null, null);
 
@@ -257,11 +257,11 @@ public class SubsystemTest {
     public void testResourceRepositories() throws Exception {
         RepositoryImpl repo = new RepositoryImpl(getClass().getResource("data7/features.xml").toURI());
 
-        Map<String, Set<String>> features = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> features = new HashMap<>();
         addToMapSet(features, "root", "f1");
         addToMapSet(features, "root/apps1", "f2");
 
-        Map<String, Set<String>> expected = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> expected = new HashMap<>();
         addToMapSet(expected, "root", "a/1.0.0");
         addToMapSet(expected, "root", "c/1.0.0");
         addToMapSet(expected, "root/apps1", "b/1.0.0");
@@ -269,8 +269,8 @@ public class SubsystemTest {
         SubsystemResolver resolver = new SubsystemResolver(this.resolver, new TestDownloadManager(getClass(), "data7"));
         resolver.prepare(Arrays.asList(repo.getFeatures()),
                 features,
-                Collections.<String, Set<BundleRevision>>emptyMap());
-        resolver.resolve(Collections.<String>emptySet(),
+                Collections.emptyMap());
+        resolver.resolve(Collections.emptySet(),
                 FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE,
                 null, null, null);
 
@@ -298,7 +298,7 @@ public class SubsystemTest {
     }
 
     private Map<String, Set<String>> getBundleNamesPerRegions(SubsystemResolver resolver) {
-        Map<String, Set<String>> mapping = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> mapping = new HashMap<>();
         Map<String, Set<Resource>> bundles = resolver.getBundlesPerRegions();
         for (Map.Entry<String,Set<Resource>> entry : bundles.entrySet()) {
             for (Resource r : entry.getValue()) {
@@ -312,7 +312,7 @@ public class SubsystemTest {
     private void dumpWiring(SubsystemResolver resolver) {
         System.out.println("Wiring");
         Map<Resource, List<Wire>> wiring = resolver.getWiring();
-        List<Resource> resources = new ArrayList<Resource>(wiring.keySet());
+        List<Resource> resources = new ArrayList<>(wiring.keySet());
         Collections.sort(resources, new Comparator<Resource>() {
             @Override
             public int compare(Resource o1, Resource o2) {

--- a/features/core/src/test/java/org/apache/karaf/features/internal/service/BootFeaturesInstallerTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/service/BootFeaturesInstallerTest.java
@@ -65,7 +65,7 @@ public class BootFeaturesInstallerTest extends TestBase {
         bootFeatures.installBootFeatures();
         verify(impl);
 
-        List<String> features = new ArrayList<String>(featuresCapture.getValue());
+        List<String> features = new ArrayList<>(featuresCapture.getValue());
         Assert.assertEquals("config", features.get(0));
         Assert.assertEquals("standard", features.get(1));
         Assert.assertEquals("region", features.get(2));

--- a/features/core/src/test/java/org/apache/karaf/features/internal/service/DeployerTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/service/DeployerTest.java
@@ -84,10 +84,10 @@ public class DeployerTest {
         EasyMock.expectLastCall().anyTimes();
         callback.callListeners(DeploymentEvent.DEPLOYMENT_STARTED);
         EasyMock.expectLastCall();
-        installSupport.replaceDigraph(EasyMock.<Map<String, Map<String, Map<String, Set<String>>>>>anyObject(),
-                EasyMock.<Map<String, Set<Long>>>anyObject());
+        installSupport.replaceDigraph(EasyMock.anyObject(),
+                EasyMock.anyObject());
         EasyMock.expectLastCall();
-        callback.saveState(EasyMock.<State>anyObject());
+        callback.saveState(EasyMock.anyObject());
         EasyMock.expectLastCall();
         installSupport.installConfigs(f100);
         EasyMock.expectLastCall();
@@ -95,9 +95,9 @@ public class DeployerTest {
         EasyMock.expectLastCall();
         callback.callListeners(DeploymentEvent.BUNDLES_INSTALLED);
         EasyMock.expectLastCall();
-        installSupport.resolveBundles(EasyMock.<Set<Bundle>>anyObject(),
-                                EasyMock.<Map<Resource, List<Wire>>>anyObject(),
-                                EasyMock.<Map<Resource, Bundle>>anyObject());
+        installSupport.resolveBundles(EasyMock.anyObject(),
+                                EasyMock.anyObject(),
+                                EasyMock.anyObject());
         EasyMock.expectLastCall();
         callback.callListeners(DeploymentEvent.BUNDLES_RESOLVED);
         EasyMock.expectLastCall();
@@ -107,7 +107,7 @@ public class DeployerTest {
         EasyMock.expectLastCall();
 
         Bundle bundleA = createTestBundle(1, Bundle.ACTIVE, dataDir, "a100");
-        EasyMock.expect(installSupport.installBundle(EasyMock.eq(ROOT_REGION), EasyMock.eq("a100"), EasyMock.<InputStream>anyObject()))
+        EasyMock.expect(installSupport.installBundle(EasyMock.eq(ROOT_REGION), EasyMock.eq("a100"), EasyMock.anyObject()))
                 .andReturn(bundleA);
 
         c.replay();
@@ -120,7 +120,7 @@ public class DeployerTest {
         dstate.features.put(f100.getId(), f100);
         dstate.features.put(f101.getId(), f101);
         dstate.filtersPerRegion = new HashMap<>();
-        dstate.filtersPerRegion.put(ROOT_REGION, new HashMap<String, Map<String, Set<String>>>());
+        dstate.filtersPerRegion.put(ROOT_REGION, new HashMap<>());
 
         Deployer.DeploymentRequest request = new Deployer.DeploymentRequest();
         request.bundleUpdateRange = DEFAULT_BUNDLE_UPDATE_RANGE;
@@ -170,7 +170,7 @@ public class DeployerTest {
                 return null;
             }
         });
-        installSupport.updateBundle(EasyMock.eq(bundleA), EasyMock.<String>anyObject(), EasyMock.<InputStream>anyObject());
+        installSupport.updateBundle(EasyMock.eq(bundleA), EasyMock.anyObject(), EasyMock.anyObject());
         EasyMock.expectLastCall().andStubAnswer(new IAnswer<Object>() {
             @Override
             public Object answer() throws Throwable {
@@ -187,10 +187,10 @@ public class DeployerTest {
         installSupport.startBundle(EasyMock.eq(bundleA));
         EasyMock.expectLastCall();
 
-        installSupport.replaceDigraph(EasyMock.<Map<String, Map<String, Map<String, Set<String>>>>>anyObject(),
-                EasyMock.<Map<String, Set<Long>>>anyObject());
+        installSupport.replaceDigraph(EasyMock.anyObject(),
+                EasyMock.anyObject());
         EasyMock.expectLastCall();
-        callback.saveState(EasyMock.<State>anyObject());
+        callback.saveState(EasyMock.anyObject());
         EasyMock.expectLastCall();
         installSupport.installConfigs(f101);
         EasyMock.expectLastCall();
@@ -198,13 +198,13 @@ public class DeployerTest {
         EasyMock.expectLastCall();
         callback.callListeners(DeploymentEvent.BUNDLES_INSTALLED);
         EasyMock.expectLastCall();
-        installSupport.resolveBundles(EasyMock.eq(Collections.<Bundle>singleton(bundleA)),
-                                EasyMock.<Map<Resource, List<Wire>>>anyObject(),
-                                EasyMock.<Map<Resource, Bundle>>anyObject());
+        installSupport.resolveBundles(EasyMock.eq(Collections.singleton(bundleA)),
+                                EasyMock.anyObject(),
+                                EasyMock.anyObject());
         EasyMock.expectLastCall();
         callback.callListeners(DeploymentEvent.BUNDLES_RESOLVED);
         EasyMock.expectLastCall();
-        installSupport.refreshPackages(EasyMock.eq(Collections.<Bundle>singleton(bundleA)));
+        installSupport.refreshPackages(EasyMock.eq(Collections.singleton(bundleA)));
         EasyMock.expectLastCall();
         callback.callListeners(FeatureEventMatcher.eq(new FeatureEvent(FeatureEvent.EventType.FeatureUninstalled, f100, FeaturesService.ROOT_REGION, false)));
         EasyMock.expectLastCall();
@@ -227,7 +227,7 @@ public class DeployerTest {
         dstate.features.put(f100.getId(), f100);
         dstate.features.put(f101.getId(), f101);
         dstate.filtersPerRegion = new HashMap<>();
-        dstate.filtersPerRegion.put(ROOT_REGION, new HashMap<String, Map<String, Set<String>>>());
+        dstate.filtersPerRegion.put(ROOT_REGION, new HashMap<>());
 
         Deployer.DeploymentRequest request = new Deployer.DeploymentRequest();
         request.bundleUpdateRange = DEFAULT_BUNDLE_UPDATE_RANGE;
@@ -266,10 +266,10 @@ public class DeployerTest {
         EasyMock.expectLastCall().anyTimes();
         callback.callListeners(DeploymentEvent.DEPLOYMENT_STARTED);
         EasyMock.expectLastCall();
-        installSupport.replaceDigraph(EasyMock.<Map<String, Map<String, Map<String, Set<String>>>>>anyObject(),
-                EasyMock.<Map<String, Set<Long>>>anyObject());
+        installSupport.replaceDigraph(EasyMock.anyObject(),
+                EasyMock.anyObject());
         EasyMock.expectLastCall();
-        callback.saveState(EasyMock.<State>anyObject());
+        callback.saveState(EasyMock.anyObject());
         EasyMock.expectLastCall();
         callback.callListeners(DeploymentEvent.BUNDLES_INSTALLED);
         EasyMock.expectLastCall();
@@ -277,9 +277,9 @@ public class DeployerTest {
         EasyMock.expectLastCall();
         installSupport.installLibraries(f1);
         EasyMock.expectLastCall();
-        installSupport.resolveBundles(EasyMock.<Set<Bundle>>anyObject(),
-                                EasyMock.<Map<Resource, List<Wire>>>anyObject(),
-                                EasyMock.<Map<Resource, Bundle>>anyObject());
+        installSupport.resolveBundles(EasyMock.anyObject(),
+                                EasyMock.anyObject(),
+                                EasyMock.anyObject());
         EasyMock.expectLastCall();
         callback.callListeners(DeploymentEvent.BUNDLES_RESOLVED);
         EasyMock.expectLastCall();
@@ -298,7 +298,7 @@ public class DeployerTest {
         addToMapSet(dstate.bundlesPerRegion, ROOT_REGION, serviceBundle.getBundleId());
         dstate.features = Collections.singletonMap(f1.getId(), f1);
         dstate.filtersPerRegion = new HashMap<>();
-        dstate.filtersPerRegion.put(ROOT_REGION, new HashMap<String, Map<String, Set<String>>>());
+        dstate.filtersPerRegion.put(ROOT_REGION, new HashMap<>());
 
         Deployer.DeploymentRequest request = new Deployer.DeploymentRequest();
         request.bundleUpdateRange = DEFAULT_BUNDLE_UPDATE_RANGE;
@@ -340,12 +340,12 @@ public class DeployerTest {
         EasyMock.expectLastCall().anyTimes();
         callback.callListeners(DeploymentEvent.DEPLOYMENT_STARTED);
         EasyMock.expectLastCall();
-        installSupport.installBundle(EasyMock.eq(ROOT_REGION), EasyMock.eq("a100"), EasyMock.<InputStream>anyObject());
+        installSupport.installBundle(EasyMock.eq(ROOT_REGION), EasyMock.eq("a100"), EasyMock.anyObject());
         EasyMock.expectLastCall().andReturn(serviceBundle1);
-        installSupport.replaceDigraph(EasyMock.<Map<String, Map<String, Map<String, Set<String>>>>>anyObject(),
-                EasyMock.<Map<String, Set<Long>>>anyObject());
+        installSupport.replaceDigraph(EasyMock.anyObject(),
+                EasyMock.anyObject());
         EasyMock.expectLastCall();
-        callback.saveState(EasyMock.<State>anyObject());
+        callback.saveState(EasyMock.anyObject());
         EasyMock.expectLastCall();
         installSupport.installConfigs(EasyMock.anyObject());
         EasyMock.expectLastCall();
@@ -353,9 +353,9 @@ public class DeployerTest {
         EasyMock.expectLastCall();
         callback.callListeners(DeploymentEvent.BUNDLES_INSTALLED);
         EasyMock.expectLastCall();
-        installSupport.resolveBundles(EasyMock.<Set<Bundle>>anyObject(),
-                EasyMock.<Map<Resource, List<Wire>>>anyObject(),
-                EasyMock.<Map<Resource, Bundle>>anyObject());
+        installSupport.resolveBundles(EasyMock.anyObject(),
+                EasyMock.anyObject(),
+                EasyMock.anyObject());
         EasyMock.expectLastCall();
         callback.callListeners(DeploymentEvent.BUNDLES_RESOLVED);
         EasyMock.expectLastCall();
@@ -374,7 +374,7 @@ public class DeployerTest {
         dstate.features.put(f1.getId(), f1);
         dstate.features.put(f2.getId(), f2);
         dstate.filtersPerRegion = new HashMap<>();
-        dstate.filtersPerRegion.put(ROOT_REGION, new HashMap<String, Map<String, Set<String>>>());
+        dstate.filtersPerRegion.put(ROOT_REGION, new HashMap<>());
 
         Deployer.DeploymentRequest request = new Deployer.DeploymentRequest();
         request.bundleUpdateRange = DEFAULT_BUNDLE_UPDATE_RANGE;
@@ -402,12 +402,12 @@ public class DeployerTest {
         EasyMock.expectLastCall().anyTimes();
         callback.callListeners(DeploymentEvent.DEPLOYMENT_STARTED);
         EasyMock.expectLastCall();
-        installSupport.installBundle(EasyMock.eq(ROOT_REGION), EasyMock.eq("b100"), EasyMock.<InputStream>anyObject());
+        installSupport.installBundle(EasyMock.eq(ROOT_REGION), EasyMock.eq("b100"), EasyMock.anyObject());
         EasyMock.expectLastCall().andReturn(serviceBundle2);
-        installSupport.replaceDigraph(EasyMock.<Map<String, Map<String, Map<String, Set<String>>>>>anyObject(),
-                EasyMock.<Map<String, Set<Long>>>anyObject());
+        installSupport.replaceDigraph(EasyMock.anyObject(),
+                EasyMock.anyObject());
         EasyMock.expectLastCall();
-        callback.saveState(EasyMock.<State>anyObject());
+        callback.saveState(EasyMock.anyObject());
         EasyMock.expectLastCall();
         installSupport.installConfigs(f2);
         EasyMock.expectLastCall();
@@ -415,9 +415,9 @@ public class DeployerTest {
         EasyMock.expectLastCall();
         callback.callListeners(DeploymentEvent.BUNDLES_INSTALLED);
         EasyMock.expectLastCall();
-        installSupport.resolveBundles(EasyMock.<Set<Bundle>>anyObject(),
-                EasyMock.<Map<Resource, List<Wire>>>anyObject(),
-                EasyMock.<Map<Resource, Bundle>>anyObject());
+        installSupport.resolveBundles(EasyMock.anyObject(),
+                EasyMock.anyObject(),
+                EasyMock.anyObject());
         EasyMock.expectLastCall();
         callback.callListeners(DeploymentEvent.BUNDLES_RESOLVED);
         EasyMock.expectLastCall();
@@ -441,7 +441,7 @@ public class DeployerTest {
         dstate.features.put(f1.getId(), f1);
         dstate.features.put(f2.getId(), f2);
         dstate.filtersPerRegion = new HashMap<>();
-        dstate.filtersPerRegion.put(ROOT_REGION, new HashMap<String, Map<String, Set<String>>>());
+        dstate.filtersPerRegion.put(ROOT_REGION, new HashMap<>());
 
         request = new Deployer.DeploymentRequest();
         request.bundleUpdateRange = DEFAULT_BUNDLE_UPDATE_RANGE;
@@ -524,8 +524,8 @@ public class DeployerTest {
         EasyMock.expectLastCall().atLeastOnce();
         installSupport.installLibraries(EasyMock.anyObject());
         EasyMock.expectLastCall().atLeastOnce();
-        installSupport.replaceDigraph(EasyMock.<Map<String, Map<String, Map<String, Set<String>>>>>anyObject(),
-                               EasyMock.<Map<String, Set<Long>>>anyObject());
+        installSupport.replaceDigraph(EasyMock.anyObject(),
+                               EasyMock.anyObject());
         expectLastCall().atLeastOnce();
         installSupport.resolveBundles(anyObject(Set.class), anyObject(Map.class), anyObject(Map.class));
         expectLastCall().atLeastOnce();

--- a/features/core/src/test/java/org/apache/karaf/features/internal/service/OverridesTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/service/OverridesTest.java
@@ -153,7 +153,7 @@ public class OverridesTest {
     }
 
     static Map<String, Resource> asResourceMap(Resource... resources) {
-        Map<String, Resource> map = new HashMap<String, Resource>();
+        Map<String, Resource> map = new HashMap<>();
         for (Resource resource : resources) {
             map.put(getUri(resource), resource);
         }
@@ -162,7 +162,7 @@ public class OverridesTest {
 
     static class Builder {
         String uri;
-        Map<String,String> headers = new HashMap<String,String>();
+        Map<String,String> headers = new HashMap<>();
         Builder(String uri) {
             this.uri = uri;
             this.headers.put("Bundle-ManifestVersion", "2");

--- a/features/core/src/test/java/org/apache/karaf/features/internal/service/StateStorageTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/service/StateStorageTest.java
@@ -39,7 +39,7 @@ public class StateStorageTest {
         oldState.bundleChecksums.put(4l, 32794l);
         oldState.requirements.put("bar", Collections.singleton("f1"));
         oldState.managedBundles.put("reg", Collections.singleton(32l));
-        oldState.managedBundles.put("reg2", new HashSet<Long>(Arrays.asList(24l, 43l)));
+        oldState.managedBundles.put("reg2", new HashSet<>(Arrays.asList(24l, 43l)));
         oldState.repositories.add("repo");
 
         TestStorage storage = new TestStorage();

--- a/http/src/main/java/org/apache/karaf/http/core/internal/ServletEventHandler.java
+++ b/http/src/main/java/org/apache/karaf/http/core/internal/ServletEventHandler.java
@@ -28,7 +28,7 @@ import org.osgi.framework.Bundle;
 
 public class ServletEventHandler implements ServletListener {
 
-	Map<String, ServletEvent> servletEvents =  new HashMap<String, ServletEvent>();
+	Map<String, ServletEvent> servletEvents = new HashMap<>();
 	
 	public synchronized void servletEvent(ServletEvent event) {
 		servletEvents.put(event.getServletName(), event);

--- a/http/src/main/java/org/apache/karaf/http/core/internal/ServletServiceImpl.java
+++ b/http/src/main/java/org/apache/karaf/http/core/internal/ServletServiceImpl.java
@@ -35,7 +35,7 @@ public class ServletServiceImpl implements ServletService {
 
     @Override
     public List<ServletInfo> getServlets() {
-        List<ServletInfo> servletInfos = new ArrayList<ServletInfo>();
+        List<ServletInfo> servletInfos = new ArrayList<>();
         Collection<ServletEvent> events = servletEventHandler.getServletEvents();
         for (ServletEvent event : events) {
             Servlet servlet = event.getServlet();
@@ -52,7 +52,7 @@ public class ServletServiceImpl implements ServletService {
 
             String alias = event.getAlias() != null ? event.getAlias() : " ";
 
-            String[] urls = (String[])(event.getUrlParameter() != null ? event.getUrlParameter() : new String[] {""});
+            String[] urls = event.getUrlParameter() != null ? event.getUrlParameter() : new String[] {""};
             ServletInfo info = new ServletInfo();
             info.setBundleId(event.getBundle().getBundleId());
             info.setName(servletName);

--- a/instance/src/main/java/org/apache/karaf/instance/core/InstanceSettings.java
+++ b/instance/src/main/java/org/apache/karaf/instance/core/InstanceSettings.java
@@ -42,7 +42,7 @@ public class InstanceSettings {
     }
 
     public InstanceSettings(int sshPort, int rmiRegistryPort, int rmiServerPort, String location, String javaOpts, List<String> featureURLs, List<String> features, String address) {
-        this(sshPort, rmiRegistryPort, rmiServerPort, location, javaOpts, featureURLs, features, address, new HashMap<String, URL>(), new HashMap<String, URL>());
+        this(sshPort, rmiRegistryPort, rmiServerPort, location, javaOpts, featureURLs, features, address, new HashMap<>(), new HashMap<>());
     }
 
     public InstanceSettings(int sshPort, int rmiRegistryPort, int rmiServerPort, String location, String javaOpts, List<String> featureURLs, List<String> features, String address, Map<String, URL> textResources, Map<String, URL> binaryResources) {
@@ -55,12 +55,12 @@ public class InstanceSettings {
         this.rmiServerPort = rmiServerPort;
         this.location = location;
         this.javaOpts = javaOpts;
-        this.featureURLs = featureURLs != null ? featureURLs : new ArrayList<String>();
-        this.features = features != null ? features : new ArrayList<String>();
+        this.featureURLs = featureURLs != null ? featureURLs : new ArrayList<>();
+        this.features = features != null ? features : new ArrayList<>();
         this.address = address;
-        this.textResources = textResources != null ? textResources : new HashMap<String, URL>();
-        this.binaryResources = binaryResources != null ? binaryResources : new HashMap<String, URL>();
-        this.profiles = profiles != null ? profiles : new ArrayList<String>();
+        this.textResources = textResources != null ? textResources : new HashMap<>();
+        this.binaryResources = binaryResources != null ? binaryResources : new HashMap<>();
+        this.profiles = profiles != null ? profiles : new ArrayList<>();
     }
 
 

--- a/instance/src/main/java/org/apache/karaf/instance/core/internal/InstanceServiceImpl.java
+++ b/instance/src/main/java/org/apache/karaf/instance/core/internal/InstanceServiceImpl.java
@@ -683,7 +683,7 @@ public class InstanceServiceImpl implements InstanceService {
             oldLocation.renameTo(newLocation);
             // create the properties map including the instance name and instance location
             // TODO: replacing is bad, we should re-extract the needed files
-            HashMap<String, String> props = new HashMap<String, String>();
+            HashMap<String, String> props = new HashMap<>();
             props.put(oldName, newName);
             props.put(oldLocationPath, newLocation.getPath());
             // replace all references to the "old" name by the new one in etc/system.properties
@@ -738,7 +738,7 @@ public class InstanceServiceImpl implements InstanceService {
             // create the properties map including the instance name, location, ssh and rmi port numbers
             // TODO: replacing stuff anywhere is not really good, we might end up replacing unwanted stuff
             // TODO: if no ports are overriden, shouldn't we choose new ports ?
-            HashMap<String, String> props = new HashMap<String, String>();
+            HashMap<String, String> props = new HashMap<>();
             props.put(name, cloneName);
             props.put(locationPath, cloneLocationPath);
             if (settings.getSshPort() > 0)

--- a/instance/src/main/java/org/apache/karaf/instance/core/internal/InstancesMBeanImpl.java
+++ b/instance/src/main/java/org/apache/karaf/instance/core/internal/InstancesMBeanImpl.java
@@ -229,7 +229,7 @@ public class InstancesMBeanImpl extends StandardMBean implements InstancesMBean 
     }
 
     private List<String> parseStringList(String value) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         if (value != null) {
             for (String el : value.split(",")) {
                 String trimmed = el.trim();

--- a/instance/src/main/java/org/apache/karaf/instance/main/Execute.java
+++ b/instance/src/main/java/org/apache/karaf/instance/main/Execute.java
@@ -58,7 +58,7 @@ public class Execute {
             StartCommand.class,
             StatusCommand.class,
             StopCommand.class};
-    private static final Map<String, Class<?>> COMMANDS = new TreeMap<String, Class<?>>();
+    private static final Map<String, Class<?>> COMMANDS = new TreeMap<>();
 
     static {
         for (Class<?> c : COMMAND_CLASSES) {
@@ -136,7 +136,7 @@ public class Execute {
 
     static void execute(InstanceCommandSupport command, File storageFile, String[] args) throws Exception {
         DefaultActionPreparator dap = new DefaultActionPreparator();
-        List<Object> params = new ArrayList<Object>(Arrays.asList(args));
+        List<Object> params = new ArrayList<>(Arrays.asList(args));
         params.remove(0); // this is the actual command name
 
         if (!dap.prepare(command, null, params)) {

--- a/instance/src/main/java/org/apache/karaf/jpm/impl/ProcessImpl.java
+++ b/instance/src/main/java/org/apache/karaf/jpm/impl/ProcessImpl.java
@@ -53,7 +53,7 @@ public class ProcessImpl implements Process {
 
     public boolean isRunning() throws IOException {
         if (ScriptUtils.isWindows()) {
-            Map<String, String> props = new HashMap<String, String>();
+            Map<String, String> props = new HashMap<>();
             props.put("${pid}", Integer.toString(pid));
             int ret = ScriptUtils.execute("running", props);
             return ret == 0;
@@ -75,7 +75,7 @@ public class ProcessImpl implements Process {
     public void destroy() throws IOException {
         int ret;
         if (ScriptUtils.isWindows()) {
-            Map<String, String> props = new HashMap<String, String>();
+            Map<String, String> props = new HashMap<>();
             props.put("${pid}", Integer.toString(pid));
             ret = ScriptUtils.execute("destroy", props);
         } else {
@@ -114,7 +114,7 @@ public class ProcessImpl implements Process {
         //File error = File.createTempFile("jpm.", ".error");
         File pidFile = File.createTempFile("jpm.", ".pid");
         try {
-            Map<String, String> props = new HashMap<String, String>();
+            Map<String, String> props = new HashMap<>();
             //props.put("${in.file}", input.getCanonicalPath());
             //props.put("${out.file}", output.getCanonicalPath());
             //props.put("${err.file}", error.getCanonicalPath());

--- a/instance/src/test/java/org/apache/karaf/instance/core/InstanceSettingsTest.java
+++ b/instance/src/test/java/org/apache/karaf/instance/core/InstanceSettingsTest.java
@@ -22,13 +22,12 @@ import java.util.List;
 
 import junit.framework.TestCase;
 
-import org.apache.karaf.instance.core.InstanceSettings;
 import org.junit.Assert;
 
 public class InstanceSettingsTest extends TestCase {
     public void testInstanceSettings() {
         InstanceSettings is =
-            new InstanceSettings(1, 1, 1, null, null, Collections.<String>emptyList(), Arrays.asList("hi"));
+            new InstanceSettings(1, 1, 1, null, null, Collections.emptyList(), Arrays.asList("hi"));
         assertEquals(1, is.getSshPort());
         assertEquals(1, is.getRmiRegistryPort());
         assertEquals(1, is.getRmiServerPort());
@@ -38,7 +37,7 @@ public class InstanceSettingsTest extends TestCase {
     }
     
     public void testEqualsHashCode() {
-        testEqualsHashCode(1, 1, 1, "top", "foo", Collections.<String>emptyList(), Arrays.asList("hi"));
+        testEqualsHashCode(1, 1, 1, "top", "foo", Collections.emptyList(), Arrays.asList("hi"));
         testEqualsHashCode(0, 0, 0, null, null, null, null);
     }
 
@@ -50,7 +49,7 @@ public class InstanceSettingsTest extends TestCase {
     }
     
     public void testEqualsHashCode2() {
-        InstanceSettings is = new InstanceSettings(1, 1, 1, "top", "foo", Collections.<String>emptyList(), Arrays.asList("hi"));
+        InstanceSettings is = new InstanceSettings(1, 1, 1, "top", "foo", Collections.emptyList(), Arrays.asList("hi"));
         Assert.assertFalse(is.equals(null));
         Assert.assertFalse(is.equals(new Object()));
         assertEquals(is, is);

--- a/instance/src/test/java/org/apache/karaf/instance/core/internal/InstanceServiceImplTest.java
+++ b/instance/src/test/java/org/apache/karaf/instance/core/internal/InstanceServiceImplTest.java
@@ -109,10 +109,10 @@ public class InstanceServiceImplTest {
     public void testTextResources() throws Exception {
         InstanceServiceImpl service = new InstanceServiceImpl();
         service.setStorageLocation(new File("target/instances/" + System.currentTimeMillis()));
-        Map<String, URL> textResources = new HashMap<String, URL>();
+        Map<String, URL> textResources = new HashMap<>();
         textResources.put("etc/myresource", getClass().getClassLoader().getResource("myresource"));
 
-        InstanceSettings settings = new InstanceSettings(8122, 1122, 44444, getName(), null, null, null, null, textResources, new HashMap<String, URL>());
+        InstanceSettings settings = new InstanceSettings(8122, 1122, 44444, getName(), null, null, null, null, textResources, new HashMap<>());
         Instance instance = service.createInstance(getName(), settings, false);
 
         assertFileExists(instance.getLocation(), "etc/myresource");

--- a/instance/src/test/java/org/apache/karaf/instance/core/management/internal/InstanceServiceMBeanImplTest.java
+++ b/instance/src/test/java/org/apache/karaf/instance/core/management/internal/InstanceServiceMBeanImplTest.java
@@ -36,7 +36,7 @@ public class InstanceServiceMBeanImplTest extends TestCase {
 
     public void testCreateInstance() throws Exception {
         final InstanceSettings instanceSettings = new InstanceSettings(123, 456,789, "somewhere", "someopts",
-                Collections.<String>emptyList(), Arrays.asList("webconsole", "funfeat"), "localhost");
+                Collections.emptyList(), Arrays.asList("webconsole", "funfeat"), "localhost");
         
         final Instance inst = EasyMock.createMock(Instance.class);
         EasyMock.expect(inst.getPid()).andReturn(42);
@@ -52,7 +52,7 @@ public class InstanceServiceMBeanImplTest extends TestCase {
     
     public void testCreateInstance2() throws Exception {
         final InstanceSettings instanceSettings = new InstanceSettings(0, 0, 0, null, null,
-                Collections.<String>emptyList(), Collections.<String>emptyList(), "localhost");
+                Collections.emptyList(), Collections.emptyList(), "localhost");
         
         InstanceService instanceService = EasyMock.createMock(InstanceService.class);
         EasyMock.expect(instanceService.createInstance("t1", instanceSettings, false)).andReturn(null);

--- a/itests/src/test/java/org/apache/karaf/itests/ImportServiceTest.java
+++ b/itests/src/test/java/org/apache/karaf/itests/ImportServiceTest.java
@@ -42,7 +42,7 @@ public class ImportServiceTest extends KarafTestSupport {
     @SuppressWarnings("deprecation")
     @Configuration
     public Option[] config() {
-        List<Option> options = new ArrayList<Option>(Arrays.asList(super.config()));
+        List<Option> options = new ArrayList<>(Arrays.asList(super.config()));
         InputStream testBundleImportService = bundle()
             .set(Constants.IMPORT_SERVICE, "FooService")
             .set(Constants.BUNDLE_SYMBOLICNAME, BUNDLE1_NAME)

--- a/itests/src/test/java/org/apache/karaf/itests/JMXSecurityTest.java
+++ b/itests/src/test/java/org/apache/karaf/itests/JMXSecurityTest.java
@@ -66,7 +66,7 @@ public class JMXSecurityTest extends KarafTestSupport {
 
     @Configuration
     public Option[] config() {
-        List<Option> options = new ArrayList<Option>(Arrays.asList(super.config()));
+        List<Option> options = new ArrayList<>(Arrays.asList(super.config()));
 
         // Add some extra options used by this test...
         options.addAll(Arrays.asList(
@@ -276,12 +276,12 @@ public class JMXSecurityTest extends KarafTestSupport {
                 new Object [] {serviceMBean.toString(), "getServices", new String [] {}},
                 new String [] {String.class.getName(), String.class.getName(), String[].class.getName()}));
 
-        Map<String, List<String>> map = new HashMap<String, List<String>>();
+        Map<String, List<String>> map = new HashMap<>();
         TabularData td = (TabularData) connection.invoke(securityMBean, "canInvoke", new Object [] {map}, new String [] {Map.class.getName()});
         assertEquals(0, td.size());
 
-        Map<String, List<String>> map2 = new HashMap<String, List<String>>();
-        map2.put(systemMBean.toString(), Collections.<String>emptyList());
+        Map<String, List<String>> map2 = new HashMap<>();
+        map2.put(systemMBean.toString(), Collections.emptyList());
         map2.put(serviceMBean.toString(), Arrays.asList("getServices(boolean)", "getServices(long)", "getServices(long,boolean)", "getServices()"));
         TabularData td2 = (TabularData) connection.invoke(securityMBean, "canInvoke", new Object [] {map2}, new String [] {Map.class.getName()});
         assertEquals(5, td2.size());
@@ -311,7 +311,7 @@ public class JMXSecurityTest extends KarafTestSupport {
         assertEquals("", cd5.get("Method"));
         assertTrue((Boolean) cd5.get("CanInvoke"));
 
-        Map<String, List<String>> map3 = new HashMap<String, List<String>>();
+        Map<String, List<String>> map3 = new HashMap<>();
         map3.put(serviceMBean.toString(), Collections.singletonList("getServices"));
         TabularData td3 = (TabularData) connection.invoke(securityMBean, "canInvoke", new Object [] {map3}, new String [] {Map.class.getName()});
         assertEquals(1, td3.size());
@@ -321,7 +321,7 @@ public class JMXSecurityTest extends KarafTestSupport {
         assertEquals("getServices", cd6.get("Method"));
         assertTrue((Boolean) cd6.get("CanInvoke"));
 
-        Map<String, List<String>> map4 = new HashMap<String, List<String>>();
+        Map<String, List<String>> map4 = new HashMap<>();
         map4.put(systemMBean.toString(), Collections.singletonList("halt"));
         TabularData td4 = (TabularData) connection.invoke(securityMBean, "canInvoke", new Object [] {map4}, new String [] {Map.class.getName()});
         assertEquals(1, td4.size());
@@ -363,7 +363,7 @@ public class JMXSecurityTest extends KarafTestSupport {
         else
             assertNull(m2.get("x"));
 
-        Map<String, String> newProps = new HashMap<String, String>();
+        Map<String, String> newProps = new HashMap<>();
         newProps.put("a.b.c", "abc");
         newProps.put("d.e.f", "def");
         assertJmxInvoke(shouldSucceed, connection, mbean, "update", new Object [] {pid, newProps}, new String [] {String.class.getName(), Map.class.getName()});
@@ -407,7 +407,7 @@ public class JMXSecurityTest extends KarafTestSupport {
         TabularType tt = new TabularType("PROPERTIES", "X", ct, new String [] {"Key"});
 
         TabularDataSupport tds = new TabularDataSupport(tt);
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         data.put("Key", "foo");
         data.put("Value", "bar");
         data.put("Type", "String");
@@ -428,7 +428,7 @@ public class JMXSecurityTest extends KarafTestSupport {
         assertJmxInvoke(shouldSucceed, connection, mbean, "delete", new Object [] {pid}, new String [] {String.class.getName()});
 
         TabularDataSupport tds2 = new TabularDataSupport(tt);
-        Map<String, Object> data2 = new HashMap<String, Object>();
+        Map<String, Object> data2 = new HashMap<>();
         data2.put("Key", "a.b.c");
         data2.put("Value", "d.e.f");
         data2.put("Type", "String");

--- a/itests/src/test/java/org/apache/karaf/itests/KarafTestSupport.java
+++ b/itests/src/test/java/org/apache/karaf/itests/KarafTestSupport.java
@@ -274,10 +274,10 @@ public class KarafTestSupport {
 
         FutureTask<String> commandFuture;
         if (principals.length == 0) {
-            commandFuture = new FutureTask<String>(commandCallable);
+            commandFuture = new FutureTask<>(commandCallable);
         } else {
             // If principals are defined, run the command callable via Subject.doAs()
-            commandFuture = new FutureTask<String>(new Callable<String>() {
+            commandFuture = new FutureTask<>(new Callable<String>() {
                 @Override
                 public String call() throws Exception {
                     Subject subject = new Subject();
@@ -390,7 +390,7 @@ public class KarafTestSupport {
     }
 
     protected void waitForService(String filter, long timeout) throws InvalidSyntaxException, InterruptedException {
-        ServiceTracker<Object, Object> st = new ServiceTracker<Object, Object>(bundleContext, bundleContext.createFilter(filter), null);
+        ServiceTracker<Object, Object> st = new ServiceTracker<>(bundleContext, bundleContext.createFilter(filter), null);
         try {
             st.open();
             st.waitForService(timeout);
@@ -438,7 +438,7 @@ public class KarafTestSupport {
      */
     @SuppressWarnings("rawtypes")
     private static Collection<ServiceReference> asCollection(ServiceReference[] references) {
-        return references != null ? Arrays.asList(references) : Collections.<ServiceReference>emptyList();
+        return references != null ? Arrays.asList(references) : Collections.emptyList();
     }
 
     public JMXConnector getJMXConnector() throws Exception {
@@ -447,7 +447,7 @@ public class KarafTestSupport {
 
     public JMXConnector getJMXConnector(String userName, String passWord) throws Exception {
         JMXServiceURL url = new JMXServiceURL(getJmxServiceUrl());
-        Hashtable<String, Object> env = new Hashtable<String, Object>();
+        Hashtable<String, Object> env = new Hashtable<>();
         String[] credentials = new String[]{ userName, passWord };
         env.put("jmx.remote.credentials", credentials);
         JMXConnector connector = JMXConnectorFactory.connect(url, env);
@@ -496,9 +496,9 @@ public class KarafTestSupport {
     }
 
     public void assertFeaturesInstalled(String ... expectedFeatures) throws Exception {
-        Set<String> expectedFeaturesSet = new HashSet<String>(Arrays.asList(expectedFeatures));
+        Set<String> expectedFeaturesSet = new HashSet<>(Arrays.asList(expectedFeatures));
         Feature[] features = featureService.listInstalledFeatures();
-        Set<String> installedFeatures = new HashSet<String>();
+        Set<String> installedFeatures = new HashSet<>();
         for (Feature feature : features) {
             installedFeatures.add(feature.getName());
         }

--- a/itests/src/test/java/org/apache/karaf/itests/PackageTest.java
+++ b/itests/src/test/java/org/apache/karaf/itests/PackageTest.java
@@ -77,7 +77,7 @@ public class PackageTest extends KarafTestSupport {
     public void duplicatePackageTest() throws Exception {
         // Leaving out version to make test easier to manage
         // We currently expect no duplicate package exports
-        Map<String, Integer> expectedDups = new HashMap<String, Integer>();
+        Map<String, Integer> expectedDups = new HashMap<>();
         List<PackageVersion> packageVersionMap = packageService.getExports();
        
         for (PackageVersion pVer : packageVersionMap) {

--- a/itests/src/test/java/org/apache/karaf/itests/ssh/SshCommandTestBase.java
+++ b/itests/src/test/java/org/apache/karaf/itests/ssh/SshCommandTestBase.java
@@ -52,7 +52,7 @@ public class SshCommandTestBase extends KarafTestSupport {
 
     @Before
     public void installSshFeature() throws Exception {
-        featuresBefore = new HashSet<Feature>(Arrays.asList(featureService.listInstalledFeatures()));
+        featuresBefore = new HashSet<>(Arrays.asList(featureService.listInstalledFeatures()));
         installAndAssertFeature("ssh");
     }
 

--- a/itests/src/test/java/org/apache/karaf/itests/util/RunIfRule.java
+++ b/itests/src/test/java/org/apache/karaf/itests/util/RunIfRule.java
@@ -45,7 +45,7 @@ public class RunIfRule implements MethodRule {
     }
 
     public Statement apply(Statement base, FrameworkMethod method, Object target) {
-        List<RunIf> ignores = findRunIfs(method.getAnnotations(), new ArrayList<RunIf>(), new HashSet<Class>());
+        List<RunIf> ignores = findRunIfs(method.getAnnotations(), new ArrayList<>(), new HashSet<>());
         if (ignores.isEmpty()) {
             return base;
         }

--- a/jaas/blueprint/config/src/main/java/org/apache/karaf/jaas/blueprint/config/impl/NamespaceHandler.java
+++ b/jaas/blueprint/config/src/main/java/org/apache/karaf/jaas/blueprint/config/impl/NamespaceHandler.java
@@ -56,7 +56,7 @@ public class NamespaceHandler implements org.apache.aries.blueprint.NamespaceHan
     }
 
     public Set<Class> getManagedClasses() {
-        return new HashSet<Class>(Arrays.asList(
+        return new HashSet<>(Arrays.asList(
                 Config.class,
                 ResourceKeystoreInstance.class
         ));

--- a/jaas/blueprint/jasypt/src/main/java/org/apache/karaf/jaas/blueprint/jasypt/handler/NamespaceHandler.java
+++ b/jaas/blueprint/jasypt/src/main/java/org/apache/karaf/jaas/blueprint/jasypt/handler/NamespaceHandler.java
@@ -57,7 +57,7 @@ public class NamespaceHandler implements org.apache.aries.blueprint.NamespaceHan
     }
 
     public Set<Class> getManagedClasses() {
-        return new HashSet<Class>(Arrays.asList(
+        return new HashSet<>(Arrays.asList(
                 EncryptablePropertyPlaceholder.class
         ));
     }

--- a/jaas/blueprint/jasypt/src/test/java/org/apache/karaf/jaas/blueprint/jasypt/handler/EncryptableConfigAdminPropertyPlaceholderTest.java
+++ b/jaas/blueprint/jasypt/src/test/java/org/apache/karaf/jaas/blueprint/jasypt/handler/EncryptableConfigAdminPropertyPlaceholderTest.java
@@ -90,7 +90,7 @@ public class EncryptableConfigAdminPropertyPlaceholderTest extends TestCase {
         StreamUtils.copy(bundle.build(), fos);
         fos.close();
         JarInputStream jis = new JarInputStream(new FileInputStream(file));
-        Map<String, String> headers = new HashMap<String, String>();
+        Map<String, String> headers = new HashMap<>();
         for (Map.Entry entry : jis.getManifest().getMainAttributes().entrySet()) {
             headers.put(entry.getKey().toString(), entry.getValue().toString());
         }
@@ -226,7 +226,7 @@ public class EncryptableConfigAdminPropertyPlaceholderTest extends TestCase {
      * Provides an iterable collection of references, even if the original array is null
      */
     private static final Collection<ServiceReference> asCollection(ServiceReference[] references) {
-        List<ServiceReference> result = new LinkedList<ServiceReference>();
+        List<ServiceReference> result = new LinkedList<>();
         if (references != null) {
             for (ServiceReference reference : references) {
                 result.add(reference);

--- a/jaas/blueprint/jasypt/src/test/java/org/apache/karaf/jaas/blueprint/jasypt/handler/EncryptablePropertyPlaceholderTest.java
+++ b/jaas/blueprint/jasypt/src/test/java/org/apache/karaf/jaas/blueprint/jasypt/handler/EncryptablePropertyPlaceholderTest.java
@@ -99,7 +99,7 @@ public class EncryptablePropertyPlaceholderTest extends TestCase {
         StreamUtils.copy(bundle.build(), fos);
         fos.close();
         JarInputStream jis = new JarInputStream(new FileInputStream(file));
-        Map<String, String> headers = new HashMap<String, String>();
+        Map<String, String> headers = new HashMap<>();
         for (Map.Entry entry : jis.getManifest().getMainAttributes().entrySet()) {
             headers.put(entry.getKey().toString(), entry.getValue().toString());
         }
@@ -199,7 +199,7 @@ public class EncryptablePropertyPlaceholderTest extends TestCase {
      * Provides an iterable collection of references, even if the original array is null
      */
     private static final Collection<ServiceReference> asCollection(ServiceReference[] references) {
-        List<ServiceReference> result = new LinkedList<ServiceReference>();
+        List<ServiceReference> result = new LinkedList<>();
         if (references != null) {
             for (ServiceReference reference : references) {
                 result.add(reference);

--- a/jaas/boot/src/main/java/org/apache/karaf/jaas/boot/principal/GroupPrincipal.java
+++ b/jaas/boot/src/main/java/org/apache/karaf/jaas/boot/principal/GroupPrincipal.java
@@ -25,7 +25,7 @@ public class GroupPrincipal implements Group, Serializable {
 
     private String name;
 
-    private Hashtable<String,Principal> members = new Hashtable<String, Principal>();
+    private Hashtable<String,Principal> members = new Hashtable<>();
 
     public GroupPrincipal(String name) {
         assert name != null;

--- a/jaas/boot/src/main/java/org/apache/karaf/jaas/boot/principal/RolePolicy.java
+++ b/jaas/boot/src/main/java/org/apache/karaf/jaas/boot/principal/RolePolicy.java
@@ -54,7 +54,7 @@ public enum RolePolicy {
 
     private String value;
 
-    private static final Map<String, RolePolicy> policies = new HashMap<String, RolePolicy>();
+    private static final Map<String, RolePolicy> policies = new HashMap<>();
 
     static {
         for (RolePolicy s : EnumSet.allOf(RolePolicy.class)) {

--- a/jaas/command/src/main/java/org/apache/karaf/jaas/command/JaasCommandSupport.java
+++ b/jaas/command/src/main/java/org/apache/karaf/jaas/command/JaasCommandSupport.java
@@ -89,14 +89,14 @@ public abstract class JaasCommandSupport implements Action {
         if (hidden) {
             return realms;
         } else {
-            Map<String, JaasRealm> map = new TreeMap<String, JaasRealm>();
+            Map<String, JaasRealm> map = new TreeMap<>();
             for (JaasRealm realm : realms) {
                 if (!map.containsKey(realm.getName())
                         || realm.getRank() > map.get(realm.getName()).getRank()) {
                     map.put(realm.getName(), realm);
                 }
             }
-            return new ArrayList<JaasRealm>(map.values());
+            return new ArrayList<>(map.values());
         }
     }
 

--- a/jaas/command/src/main/java/org/apache/karaf/jaas/command/ListUsersCommand.java
+++ b/jaas/command/src/main/java/org/apache/karaf/jaas/command/ListUsersCommand.java
@@ -67,7 +67,7 @@ public class ListUsersCommand extends JaasCommandSupport {
         table.column("Role");
 
         for (UserPrincipal user : users) {
-            List<String> reportedRoles = new ArrayList<String>();
+            List<String> reportedRoles = new ArrayList<>();
             String userName = user.getName();
 
             for (GroupPrincipal group : engine.listGroups(user)) {
@@ -95,7 +95,7 @@ public class ListUsersCommand extends JaasCommandSupport {
     }
 
     private List<String> displayGroupRoles(BackingEngine engine, String userName, GroupPrincipal group, ShellTable table) {
-        List<String> names = new ArrayList<String>();
+        List<String> names = new ArrayList<>();
         List<RolePrincipal> roles = engine.listRoles(group);
 
         if (roles != null && roles.size() >= 1) {

--- a/jaas/command/src/main/java/org/apache/karaf/jaas/command/ManageRealmCommand.java
+++ b/jaas/command/src/main/java/org/apache/karaf/jaas/command/ManageRealmCommand.java
@@ -138,7 +138,7 @@ public class ManageRealmCommand extends JaasCommandSupport {
 
             commands = (Queue<JaasCommandSupport>) this.session.get(JAAS_CMDS);
             if (commands == null) {
-                commands = new LinkedList<JaasCommandSupport>();
+                commands = new LinkedList<>();
             }
 
             this.session.put(JAAS_REALM, realm);

--- a/jaas/command/src/main/java/org/apache/karaf/jaas/command/completers/LoginModuleNameCompleter.java
+++ b/jaas/command/src/main/java/org/apache/karaf/jaas/command/completers/LoginModuleNameCompleter.java
@@ -58,7 +58,7 @@ public class LoginModuleNameCompleter implements Completer {
      * @return
      */
     private List<String> findLoginModuleClassNames(JaasRealm realm) {
-        List<String> moduleClassNames = new LinkedList<String>();
+        List<String> moduleClassNames = new LinkedList<>();
         for (AppConfigurationEntry entry : realm.getEntries()) {
             String moduleClass = (String) entry.getOptions().get(ProxyLoginModule.PROPERTY_MODULE);
             if (moduleClass != null) {

--- a/jaas/command/src/test/java/org/apache/karaf/jaas/command/ManageRealmCommandTest.java
+++ b/jaas/command/src/test/java/org/apache/karaf/jaas/command/ManageRealmCommandTest.java
@@ -70,7 +70,7 @@ public class ManageRealmCommandTest {
 
         // prepare command
         cmd.index = index;
-        cmd.setRealms(Arrays.<JaasRealm> asList(realms));
+        cmd.setRealms(Arrays.asList(realms));
         cmd.setSession(session);
 
         for (Config realm : realms)

--- a/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/Activator.java
+++ b/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/Activator.java
@@ -40,7 +40,7 @@ public class Activator implements BundleActivator {
 
         final OsgiKeystoreManager keystoreManager = new OsgiKeystoreManager();
 
-        keystoreInstanceServiceTracker = new ServiceTracker<KeystoreInstance, KeystoreInstance>(
+        keystoreInstanceServiceTracker = new ServiceTracker<>(
                 context, KeystoreInstance.class, new ServiceTrackerCustomizer<KeystoreInstance, KeystoreInstance>() {
             @Override
             public KeystoreInstance addingService(ServiceReference<KeystoreInstance> reference) {
@@ -48,9 +48,11 @@ public class Activator implements BundleActivator {
                 keystoreManager.register(service, null);
                 return service;
             }
+
             @Override
             public void modifiedService(ServiceReference<KeystoreInstance> reference, KeystoreInstance service) {
             }
+
             @Override
             public void removedService(ServiceReference<KeystoreInstance> reference, KeystoreInstance service) {
                 keystoreManager.unregister(service, null);
@@ -62,7 +64,7 @@ public class Activator implements BundleActivator {
         osgiConfiguration = new OsgiConfiguration();
         osgiConfiguration.init();
 
-        jaasRealmServiceTracker = new ServiceTracker<JaasRealm, JaasRealm>(
+        jaasRealmServiceTracker = new ServiceTracker<>(
                 context, JaasRealm.class, new ServiceTrackerCustomizer<JaasRealm, JaasRealm>() {
             @Override
             public JaasRealm addingService(ServiceReference<JaasRealm> reference) {
@@ -70,9 +72,11 @@ public class Activator implements BundleActivator {
                 osgiConfiguration.register(service, null);
                 return service;
             }
+
             @Override
             public void modifiedService(ServiceReference<JaasRealm> reference, JaasRealm service) {
-           }
+            }
+
             @Override
             public void removedService(ServiceReference<JaasRealm> reference, JaasRealm service) {
                 osgiConfiguration.unregister(service, null);

--- a/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/Config.java
+++ b/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/Config.java
@@ -75,7 +75,7 @@ public class Config implements JaasRealm {
             Module[] modules = this.modules;
             AppConfigurationEntry[] entries = new AppConfigurationEntry[modules.length];
             for (int i = 0; i < modules.length; i++) {
-                Map<String,Object> options = new HashMap<String,Object>();
+                Map<String,Object> options = new HashMap<>();
                 // put the bundle context in the options map
                 // it's required to be able to use the encryption service
                 // in the AbstractKarafLoginModule

--- a/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/OsgiConfiguration.java
+++ b/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/OsgiConfiguration.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 public class OsgiConfiguration extends Configuration {
 
-    private final List<JaasRealm> realms = new CopyOnWriteArrayIdentityList<JaasRealm>();
+    private final List<JaasRealm> realms = new CopyOnWriteArrayIdentityList<>();
     private Configuration defaultConfiguration;
 
     public void init() {

--- a/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/OsgiKeystoreManager.java
+++ b/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/OsgiKeystoreManager.java
@@ -38,7 +38,7 @@ public class OsgiKeystoreManager implements KeystoreManager {
 
     private final static transient Logger logger = LoggerFactory.getLogger(OsgiKeystoreManager.class);
 
-    private List<KeystoreInstance> keystores = new CopyOnWriteArrayIdentityList<KeystoreInstance>();
+    private List<KeystoreInstance> keystores = new CopyOnWriteArrayIdentityList<>();
 
     public void register(KeystoreInstance keystore, Map<String, ?> properties) {
         keystores.add(keystore);

--- a/jaas/jasypt/src/main/java/org/apache/karaf/jaas/jasypt/impl/Activator.java
+++ b/jaas/jasypt/src/main/java/org/apache/karaf/jaas/jasypt/impl/Activator.java
@@ -29,7 +29,7 @@ public class Activator implements BundleActivator {
 
     @Override
     public void start(BundleContext context) throws Exception {
-        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        Hashtable<String, Object> props = new Hashtable<>();
         props.put("name", "jasypt");
         registration = context.registerService(
                 EncryptionService.class,

--- a/jaas/jasypt/src/test/java/org/apache/karaf/jaas/jasypt/impl/JasyptEncryptionTest.java
+++ b/jaas/jasypt/src/test/java/org/apache/karaf/jaas/jasypt/impl/JasyptEncryptionTest.java
@@ -32,7 +32,7 @@ public class JasyptEncryptionTest extends TestCase {
      * @see junit.framework.TestCase#setUp()
      */
     public void setUp() {
-        Map<String,String> props = new HashMap<String,String>();
+        Map<String,String> props = new HashMap<>();
         props.put(EncryptionService.ALGORITHM, "MD5");
         this.encryption = new JasyptEncryption(props);
     }

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/AbstractKarafLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/AbstractKarafLoginModule.java
@@ -33,7 +33,7 @@ import org.osgi.framework.BundleContext;
  */
 public abstract class AbstractKarafLoginModule implements LoginModule {
 
-    protected Set<Principal> principals = new HashSet<Principal>();
+    protected Set<Principal> principals = new HashSet<>();
     protected Subject subject;
     protected String user;
     protected CallbackHandler callbackHandler;

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/audit/EventAdminAuditLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/audit/EventAdminAuditLoginModule.java
@@ -67,7 +67,7 @@ public class EventAdminAuditLoginModule extends AbstractAuditLoginModule {
             if (ref != null) {
                 EventAdmin eventAdmin = bundleContext.getService(ref);
                 try {
-                    Map<String, Object> props = new HashMap<String, Object>();
+                    Map<String, Object> props = new HashMap<>();
                     props.put("type", topic.substring(topic.lastIndexOf("/") + 1).toLowerCase());
                     props.put("timestamp", System.currentTimeMillis());
                     props.put("username", username);

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/encryption/EncryptionSupport.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/encryption/EncryptionSupport.java
@@ -49,7 +49,7 @@ public class EncryptionSupport {
 
     public Encryption getEncryption() {
         if (encryption == null) {
-            Map<String, String> encOpts = new HashMap<String, String>();
+            Map<String, String> encOpts = new HashMap<>();
             for (String key : options.keySet()) {
                 if (key.startsWith("encryption.")) {
                     encOpts.put(key.substring("encryption.".length()), options.get(key).toString());

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/impl/KarafRealm.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/impl/KarafRealm.java
@@ -61,7 +61,7 @@ public class KarafRealm implements JaasRealm {
 
     @Override
     public AppConfigurationEntry[] getEntries() {
-        Map<String, Object> propertiesOptions = new HashMap<String, Object>();
+        Map<String, Object> propertiesOptions = new HashMap<>();
         propertiesOptions.put(BundleContext.class.getName(), bundleContext);
         propertiesOptions.put(ProxyLoginModule.PROPERTY_MODULE, PROPERTIES_MODULE);
         propertiesOptions.put(ProxyLoginModule.PROPERTY_BUNDLE, Long.toString(bundleContext.getBundle().getBundleId()));
@@ -74,7 +74,7 @@ public class KarafRealm implements JaasRealm {
         propertiesOptions.put("encryption.algorithm", properties.get("encryption.algorithm"));
         propertiesOptions.put("encryption.encoding", properties.get("encryption.encoding"));
 
-        Map<String, Object> publicKeyOptions = new HashMap<String, Object>();
+        Map<String, Object> publicKeyOptions = new HashMap<>();
         publicKeyOptions.put(BundleContext.class.getName(), bundleContext);
         publicKeyOptions.put(ProxyLoginModule.PROPERTY_MODULE, PUBLIC_KEY_MODULE);
         publicKeyOptions.put(ProxyLoginModule.PROPERTY_BUNDLE, Long.toString(bundleContext.getBundle().getBundleId()));

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPLoginModule.java
@@ -106,7 +106,7 @@ public class LDAPLoginModule extends AbstractKarafLoginModule {
             tmpPassword = new char[0];
         }
         String password = new String(tmpPassword);
-        principals = new HashSet<Principal>();
+        principals = new HashSet<>();
 
         LDAPCache cache = LDAPCache.getCache(options);
 

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPOptions.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPOptions.java
@@ -120,7 +120,7 @@ public class LDAPOptions {
     }
 
     private Map<String, Set<String>> parseRoleMapping(String option) {
-        Map<String, Set<String>> roleMapping = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> roleMapping = new HashMap<>();
         if (option != null) {
             LOGGER.debug("Parse role mapping {}", option);
             String[] mappings = option.split(";");

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/ManagedSSLSocketFactory.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/ManagedSSLSocketFactory.java
@@ -22,7 +22,7 @@ import javax.net.ssl.SSLSocketFactory;
 
 public class ManagedSSLSocketFactory extends SSLSocketFactory implements Comparator<Object> {
 
-    private static final ThreadLocal<SSLSocketFactory> factories = new ThreadLocal<SSLSocketFactory>();
+    private static final ThreadLocal<SSLSocketFactory> factories = new ThreadLocal<>();
 
     public static void setSocketFactory(SSLSocketFactory factory) {
         factories.set(factory);

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/osgi/OsgiConfigLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/osgi/OsgiConfigLoginModule.java
@@ -86,7 +86,7 @@ public class OsgiConfigLoginModule extends AbstractKarafLoginModule {
             	}
             }
 
-            principals = new HashSet<Principal>();
+            principals = new HashSet<>();
             principals.add(new UserPrincipal(user));
             for (int i = 1; i < infos.length; i++) {
                 principals.add(new RolePrincipal(infos[i]));

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/properties/DigestPasswordLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/properties/DigestPasswordLoginModule.java
@@ -163,7 +163,7 @@ public class  DigestPasswordLoginModule extends AbstractKarafLoginModule {
         // user infos container read from the users properties file
         String userInfos = null;
         try {
-            userInfos = (String) users.get(user);
+            userInfos = users.get(user);
         } catch (NullPointerException e) {
             //error handled in the next statement
         }
@@ -205,13 +205,13 @@ public class  DigestPasswordLoginModule extends AbstractKarafLoginModule {
         	}
         }
 
-        principals = new HashSet<Principal>();
+        principals = new HashSet<>();
         principals.add(new UserPrincipal(user));
         for (int i = 1; i < infos.length; i++) {
             if (infos[i].trim().startsWith(PropertiesBackingEngine.GROUP_PREFIX)) {
                 // it's a group reference
                 principals.add(new GroupPrincipal(infos[i].trim().substring(PropertiesBackingEngine.GROUP_PREFIX.length())));
-                String groupInfo = (String) users.get(infos[i].trim());
+                String groupInfo = users.get(infos[i].trim());
                 if (groupInfo != null) {
                     String[] roles = groupInfo.split(",");
                     for (int j = 1; j < roles.length; j++) {

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/properties/PropertiesBackingEngine.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/properties/PropertiesBackingEngine.java
@@ -71,7 +71,7 @@ public class PropertiesBackingEngine implements BackingEngine {
             }
         }
 
-        String userInfos = (String) users.get(username);
+        String userInfos = users.get(username);
 
         //If user already exists, update password
         if (userInfos != null && userInfos.length() > 0) {
@@ -113,7 +113,7 @@ public class PropertiesBackingEngine implements BackingEngine {
 
     @Override
     public List<UserPrincipal> listUsers() {
-        List<UserPrincipal> result = new ArrayList<UserPrincipal>();
+        List<UserPrincipal> result = new ArrayList<>();
 
         for (Object user : users.keySet()) {
             String userName = (String) user;
@@ -137,8 +137,8 @@ public class PropertiesBackingEngine implements BackingEngine {
 
     private List<RolePrincipal> listRoles(String name) {
 
-        List<RolePrincipal> result = new ArrayList<RolePrincipal>();
-        String userInfo = (String) users.get(name);
+        List<RolePrincipal> result = new ArrayList<>();
+        String userInfo = users.get(name);
         String[] infos = userInfo.split(",");
         for (int i = 1; i < infos.length; i++) {
             String roleName = infos[i];
@@ -160,7 +160,7 @@ public class PropertiesBackingEngine implements BackingEngine {
 
     @Override
     public void addRole(String username, String role) {
-        String userInfos = (String) users.get(username);
+        String userInfos = users.get(username);
         if (userInfos != null) {
             for (RolePrincipal rp : listRoles(username)) {
                 if (role.equals(rp.getName())) {
@@ -187,7 +187,7 @@ public class PropertiesBackingEngine implements BackingEngine {
         String[] infos = null;
         StringBuffer userInfoBuffer = new StringBuffer();
 
-        String userInfos = (String) users.get(username);
+        String userInfos = users.get(username);
 
         //If user already exists, remove the role
         if (userInfos != null && userInfos.length() > 0) {
@@ -219,8 +219,8 @@ public class PropertiesBackingEngine implements BackingEngine {
     }
 
     private List<GroupPrincipal> listGroups(String userName) {
-        List<GroupPrincipal> result = new ArrayList<GroupPrincipal>();
-        String userInfo = (String) users.get(userName);
+        List<GroupPrincipal> result = new ArrayList<>();
+        String userInfo = users.get(userName);
         if (userInfo != null) {
             String[] infos = userInfo.split(",");
             for (int i = 1; i < infos.length; i++) {
@@ -271,7 +271,7 @@ public class PropertiesBackingEngine implements BackingEngine {
     }
 
     public Map<GroupPrincipal, String> listGroups() {
-        Map<GroupPrincipal, String> result = new HashMap<GroupPrincipal, String>();
+        Map<GroupPrincipal, String> result = new HashMap<>();
         for (String name : users.keySet()) {
             if (name.startsWith(GROUP_PREFIX)) {
                 result.put(new GroupPrincipal(name.substring(GROUP_PREFIX.length())), users.get(name));

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/properties/PropertiesLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/properties/PropertiesLoginModule.java
@@ -107,7 +107,7 @@ public class PropertiesLoginModule extends AbstractKarafLoginModule {
         String userInfos = null;
 
         try {
-            userInfos = (String) users.get(user);
+            userInfos = users.get(user);
         } catch (NullPointerException e) {
             //error handled in the next statement
         }
@@ -132,13 +132,13 @@ public class PropertiesLoginModule extends AbstractKarafLoginModule {
         	}
         }
 
-        principals = new HashSet<Principal>();
+        principals = new HashSet<>();
         principals.add(new UserPrincipal(user));
         for (int i = 1; i < infos.length; i++) {
             if (infos[i].trim().startsWith(PropertiesBackingEngine.GROUP_PREFIX)) {
                 // it's a group reference
                 principals.add(new GroupPrincipal(infos[i].trim().substring(PropertiesBackingEngine.GROUP_PREFIX.length())));
-                String groupInfo = (String) users.get(infos[i].trim());
+                String groupInfo = users.get(infos[i].trim());
                 if (groupInfo != null) {
                     String[] roles = groupInfo.split(",");
                     for (int j = 1; j < roles.length; j++) {

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/publickey/PublickeyBackingEngine.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/publickey/PublickeyBackingEngine.java
@@ -54,7 +54,7 @@ public class PublickeyBackingEngine implements BackingEngine {
 
         String newPublickey = publickey;
 
-        String userInfos = (String) users.get(username);
+        String userInfos = users.get(username);
 
         //If user already exists, update publickey
         if (userInfos != null && userInfos.length() > 0) {
@@ -96,7 +96,7 @@ public class PublickeyBackingEngine implements BackingEngine {
 
     @Override
     public List<UserPrincipal> listUsers() {
-        List<UserPrincipal> result = new ArrayList<UserPrincipal>();
+        List<UserPrincipal> result = new ArrayList<>();
 
         for (Object user : users.keySet()) {
             String userName = (String) user;
@@ -120,8 +120,8 @@ public class PublickeyBackingEngine implements BackingEngine {
 
     private List<RolePrincipal> listRoles(String name) {
 
-        List<RolePrincipal> result = new ArrayList<RolePrincipal>();
-        String userInfo = (String) users.get(name);
+        List<RolePrincipal> result = new ArrayList<>();
+        String userInfo = users.get(name);
         String[] infos = userInfo.split(",");
         for (int i = 1; i < infos.length; i++) {
             String roleName = infos[i];
@@ -143,7 +143,7 @@ public class PublickeyBackingEngine implements BackingEngine {
 
     @Override
     public void addRole(String username, String role) {
-        String userInfos = (String) users.get(username);
+        String userInfos = users.get(username);
         if (userInfos != null) {
             for (RolePrincipal rp : listRoles(username)) {
                 if (role.equals(rp.getName())) {
@@ -165,7 +165,7 @@ public class PublickeyBackingEngine implements BackingEngine {
         String[] infos = null;
         StringBuffer userInfoBuffer = new StringBuffer();
 
-        String userInfos = (String) users.get(username);
+        String userInfos = users.get(username);
 
         //If user already exists, remove the role
         if (userInfos != null && userInfos.length() > 0) {
@@ -197,8 +197,8 @@ public class PublickeyBackingEngine implements BackingEngine {
     }
 
     private List<GroupPrincipal> listGroups(String userName) {
-        List<GroupPrincipal> result = new ArrayList<GroupPrincipal>();
-        String userInfo = (String) users.get(userName);
+        List<GroupPrincipal> result = new ArrayList<>();
+        String userInfo = users.get(userName);
         if (userInfo != null) {
             String[] infos = userInfo.split(",");
             for (int i = 1; i < infos.length; i++) {
@@ -249,7 +249,7 @@ public class PublickeyBackingEngine implements BackingEngine {
     }
 
     public Map<GroupPrincipal, String> listGroups() {
-        Map<GroupPrincipal, String> result = new HashMap<GroupPrincipal, String>();
+        Map<GroupPrincipal, String> result = new HashMap<>();
         for (String name : users.keySet()) {
             if (name.startsWith(GROUP_PREFIX)) {
                 result.put(new GroupPrincipal(name.substring(GROUP_PREFIX.length())), users.get(name));

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/publickey/PublickeyLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/publickey/PublickeyLoginModule.java
@@ -56,7 +56,7 @@ public class PublickeyLoginModule extends AbstractKarafLoginModule {
 
     public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
         super.initialize(subject, callbackHandler, options);
-        usersFile = (String) options.get(USERS_FILE) + "";
+        usersFile = options.get(USERS_FILE) + "";
         if (debug) {
             LOG.debug("Initialized debug=" + debug + " usersFile=" + usersFile);
         }
@@ -94,7 +94,7 @@ public class PublickeyLoginModule extends AbstractKarafLoginModule {
         String userInfos = null;
 
         try {
-            userInfos = (String) users.get(user);
+            userInfos = users.get(user);
         } catch (NullPointerException e) {
             //error handled in the next statement
         }
@@ -119,13 +119,13 @@ public class PublickeyLoginModule extends AbstractKarafLoginModule {
             }
         }
 
-        principals = new HashSet<Principal>();
+        principals = new HashSet<>();
         principals.add(new UserPrincipal(user));
         for (int i = 1; i < infos.length; i++) {
             if (infos[i].trim().startsWith(PropertiesBackingEngine.GROUP_PREFIX)) {
                 // it's a group reference
                 principals.add(new GroupPrincipal(infos[i].trim().substring(PropertiesBackingEngine.GROUP_PREFIX.length())));
-                String groupInfo = (String) users.get(infos[i].trim());
+                String groupInfo = users.get(infos[i].trim());
                 if (groupInfo != null) {
                     String[] roles = groupInfo.split(",");
                     for (int j = 1; j < roles.length; j++) {

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/syncope/SyncopeBackingEngine.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/syncope/SyncopeBackingEngine.java
@@ -159,7 +159,7 @@ public class SyncopeBackingEngine implements BackingEngine {
     }
 
     public List<GroupPrincipal> listGroups(UserPrincipal principal) {
-        return new ArrayList<GroupPrincipal>();
+        return new ArrayList<>();
     }
 
     public void addGroup(String username, String group) {

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/syncope/SyncopeLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/syncope/SyncopeLoginModule.java
@@ -73,7 +73,7 @@ public class SyncopeLoginModule extends AbstractKarafLoginModule {
             tmpPassword = new char[0];
         }
         String password = new String(tmpPassword);
-        principals = new HashSet<Principal>();
+        principals = new HashSet<>();
 
         // authenticate the user on Syncope
         LOGGER.debug("Authenticate user {} on Syncope located {}", user, address);
@@ -82,7 +82,7 @@ public class SyncopeLoginModule extends AbstractKarafLoginModule {
         client.getCredentialsProvider().setCredentials(AuthScope.ANY, creds);
         HttpGet get = new HttpGet(address + "/users/self");
         get.setHeader("Content-Type", "application/xml");
-        List<String> roles = new ArrayList<String>();
+        List<String> roles = new ArrayList<>();
         try {
             CloseableHttpResponse response = client.execute(get);
             LOGGER.debug("Syncope HTTP response status code: {}", response.getStatusLine().getStatusCode());
@@ -116,7 +116,7 @@ public class SyncopeLoginModule extends AbstractKarafLoginModule {
      * @throws Exception in case of extraction failure.
      */
     protected List<String> extractingRoles(String response) throws Exception {
-        List<String> roles = new ArrayList<String>();
+        List<String> roles = new ArrayList<>();
         if (response != null && !response.isEmpty()) {
             // extract the <memberships> element if it exists
             int index = response.indexOf("<memberships>");

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/krb5/Krb5LoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/krb5/Krb5LoginModuleTest.java
@@ -422,7 +422,7 @@ public class Krb5LoginModuleTest extends AbstractKerberosITest {
     private String createKeytab() throws Exception {
         File file = folder.newFile("test.keytab");
 
-        List<KeytabEntry> entries = new ArrayList<KeytabEntry>();
+        List<KeytabEntry> entries = new ArrayList<>();
 
         entries.add(createKeytabEntry());
 

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapLoginModuleTest.java
@@ -372,7 +372,7 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
 
         assertEquals(4, subject.getPrincipals().size());
 
-        final List<String> roles = new ArrayList<String>(Arrays.asList("karaf", "test", "another"));
+        final List<String> roles = new ArrayList<>(Arrays.asList("karaf", "test", "another"));
 
         boolean foundUser = false;
         boolean foundRole = false;
@@ -418,7 +418,7 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
 
         assertEquals(4, subject.getPrincipals().size());
 
-        final List<String> roles = new ArrayList<String>(Arrays.asList("karaf", "test", "another"));
+        final List<String> roles = new ArrayList<>(Arrays.asList("karaf", "test", "another"));
 
         boolean foundUser = false;
         boolean foundRole = false;
@@ -468,7 +468,7 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
 
         assertEquals(2, subject.getPrincipals().size());
 
-        final List<String> roles = new ArrayList<String>(Arrays.asList("karaf"));
+        final List<String> roles = new ArrayList<>(Arrays.asList("karaf"));
 
         boolean foundUser = false;
         boolean foundRole = false;

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapPoolingTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapPoolingTest.java
@@ -79,7 +79,7 @@ public class LdapPoolingTest extends AbstractLdapTestUnit {
         System.setProperty("com.sun.jndi.ldap.connect.pool.maxsize", "2");
         System.setProperty("com.sun.jndi.ldap.connect.pool.protocol", "ssl");
         System.setProperty("com.sun.jndi.ldap.connect.pool.debug", "all");
-        Hashtable<String, String> env = new Hashtable<String, String>();
+        Hashtable<String, String> env = new Hashtable<>();
         env.put("com.sun.jndi.ldap.connect.pool", "true");
         env.put("java.naming.factory.initial", "com.sun.jndi.ldap.LdapCtxFactory");
         env.put("java.naming.provider.url", "ldaps://localhost:" + getLdapServer().getPortSSL() + "/ou=system");
@@ -111,7 +111,7 @@ public class LdapPoolingTest extends AbstractLdapTestUnit {
         System.setProperty("com.sun.jndi.ldap.connect.pool.maxsize", "2");
         System.setProperty("com.sun.jndi.ldap.connect.pool.protocol", "ssl");
         System.setProperty("com.sun.jndi.ldap.connect.pool.debug", "all");
-        Hashtable<String, String> env = new Hashtable<String, String>();
+        Hashtable<String, String> env = new Hashtable<>();
         env.put("com.sun.jndi.ldap.connect.pool", "false");
         env.put("java.naming.factory.initial", "com.sun.jndi.ldap.LdapCtxFactory");
         env.put("java.naming.provider.url", "ldaps://localhost:" + getLdapServer().getPortSSL() + "/ou=system");

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/properties/PropertiesLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/properties/PropertiesLoginModuleTest.java
@@ -47,7 +47,7 @@ public class PropertiesLoginModuleTest {
             pbe.addUser("pqr", "abc");
 
             PropertiesLoginModule module = new PropertiesLoginModule();
-            Map<String, String> options = new HashMap<String, String>();
+            Map<String, String> options = new HashMap<>();
             options.put(PropertiesLoginModule.USER_FILE, f.getAbsolutePath());
             CallbackHandler cb = new CallbackHandler() {
                 @Override
@@ -103,7 +103,7 @@ public class PropertiesLoginModuleTest {
             pbe.addUser("pqr", "abc");
 
             PropertiesLoginModule module = new PropertiesLoginModule();
-            Map<String, String> options = new HashMap<String, String>();
+            Map<String, String> options = new HashMap<>();
             options.put(PropertiesLoginModule.USER_FILE, f.getAbsolutePath());
             CallbackHandler cb = new CallbackHandler() {
                 @Override
@@ -144,7 +144,7 @@ public class PropertiesLoginModuleTest {
             pbe.addGroupRole("group1", "r1");
 
             PropertiesLoginModule module = new PropertiesLoginModule();
-            Map<String, String> options = new HashMap<String, String>();
+            Map<String, String> options = new HashMap<>();
             options.put(PropertiesLoginModule.USER_FILE, f.getAbsolutePath());
             CallbackHandler cb = new CallbackHandler() {
                 @Override
@@ -212,7 +212,7 @@ public class PropertiesLoginModuleTest {
             pbe.addGroupRole("group1", "r1");
 
             PropertiesLoginModule module = new PropertiesLoginModule();
-            Map<String, String> options = new HashMap<String, String>();
+            Map<String, String> options = new HashMap<>();
             options.put(PropertiesLoginModule.USER_FILE, f.getAbsolutePath());
             CallbackHandler cb = new CallbackHandler() {
                 @Override
@@ -264,7 +264,7 @@ public class PropertiesLoginModuleTest {
         PropertiesLoginModule module = new PropertiesLoginModule();
         Subject subject = new Subject();
         CallbackHandler handler = new NullHandler();
-        Map<String, String> options = new HashMap<String, String>();
+        Map<String, String> options = new HashMap<>();
         options.put(PropertiesLoginModule.USER_FILE, getTestUsersFile());
         module.initialize(subject, handler, null, options);
 
@@ -280,7 +280,7 @@ public class PropertiesLoginModuleTest {
         PropertiesLoginModule module = new PropertiesLoginModule();
         Subject sub = new Subject();
         CallbackHandler handler = new NamePasswordHandler("test", "test");
-        Map<String, String> options = new HashMap<String, String>();
+        Map<String, String> options = new HashMap<>();
         options.put(PropertiesLoginModule.USER_FILE, usersFilePath);
         module.initialize(sub, handler, null, options);
         module.login();
@@ -290,7 +290,7 @@ public class PropertiesLoginModuleTest {
     public void testNullCallbackHandler() {
         PropertiesLoginModule module = new PropertiesLoginModule();
         Subject subject = new Subject();
-        Map<String, String> options = new HashMap<String, String>();
+        Map<String, String> options = new HashMap<>();
         options.put(PropertiesLoginModule.USER_FILE, getTestUsersFile());
         module.initialize(subject, null, null, options );
         try {

--- a/jms/core/src/main/java/org/apache/karaf/jms/JmsMessage.java
+++ b/jms/core/src/main/java/org/apache/karaf/jms/JmsMessage.java
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 public class JmsMessage {
 
-    private Map<String, Object> properties = new HashMap<String, Object>();
+    private Map<String, Object> properties = new HashMap<>();
 
     private String content;
     private String charset = "UTF-8";

--- a/jms/pool/src/main/java/org/apache/karaf/jms/pool/internal/PooledConnection.java
+++ b/jms/pool/src/main/java/org/apache/karaf/jms/pool/internal/PooledConnection.java
@@ -54,9 +54,9 @@ public class PooledConnection implements TopicConnection, QueueConnection, Poole
 
     protected ConnectionPool pool;
     private volatile boolean stopped;
-    private final List<TemporaryQueue> connTempQueues = new CopyOnWriteArrayList<TemporaryQueue>();
-    private final List<TemporaryTopic> connTempTopics = new CopyOnWriteArrayList<TemporaryTopic>();
-    private final List<PooledSession> loanedSessions = new CopyOnWriteArrayList<PooledSession>();
+    private final List<TemporaryQueue> connTempQueues = new CopyOnWriteArrayList<>();
+    private final List<TemporaryTopic> connTempTopics = new CopyOnWriteArrayList<>();
+    private final List<PooledSession> loanedSessions = new CopyOnWriteArrayList<>();
 
     /**
      * Creates a new PooledConnection instance that uses the given ConnectionPool to create

--- a/jms/pool/src/main/java/org/apache/karaf/jms/pool/internal/PooledSession.java
+++ b/jms/pool/src/main/java/org/apache/karaf/jms/pool/internal/PooledSession.java
@@ -54,9 +54,9 @@ public class PooledSession implements Session, TopicSession, QueueSession, XASes
 
     private final SessionKey key;
     private final KeyedObjectPool<SessionKey, PooledSession> sessionPool;
-    private final CopyOnWriteArrayList<MessageConsumer> consumers = new CopyOnWriteArrayList<MessageConsumer>();
-    private final CopyOnWriteArrayList<QueueBrowser> browsers = new CopyOnWriteArrayList<QueueBrowser>();
-    private final CopyOnWriteArrayList<PooledSessionEventListener> sessionEventListeners = new CopyOnWriteArrayList<PooledSessionEventListener>();
+    private final CopyOnWriteArrayList<MessageConsumer> consumers = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<QueueBrowser> browsers = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<PooledSessionEventListener> sessionEventListeners = new CopyOnWriteArrayList<>();
 
     private MessageProducer producer;
     private TopicPublisher publisher;

--- a/jndi/src/main/java/org/apache/karaf/jndi/internal/JndiServiceImpl.java
+++ b/jndi/src/main/java/org/apache/karaf/jndi/internal/JndiServiceImpl.java
@@ -49,7 +49,7 @@ public class JndiServiceImpl implements JndiService {
 
     @Override
     public Map<String, String> names(String name) throws Exception {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         if (name.startsWith(OSGI_JNDI_CONTEXT_PREFIX)) {
             // OSGi service binding
             // make a lookup using directly the OSGi service
@@ -104,7 +104,7 @@ public class JndiServiceImpl implements JndiService {
     }
 
     public List<String> contexts(String name) throws Exception {
-        List<String> contexts = new ArrayList<String>();
+        List<String> contexts = new ArrayList<>();
         Context context = new InitialContext();
         NamingEnumeration<NameClassPair> pairs = context.list(name);
         while (pairs.hasMoreElements()) {

--- a/jndi/src/main/java/org/apache/karaf/jndi/internal/osgi/Activator.java
+++ b/jndi/src/main/java/org/apache/karaf/jndi/internal/osgi/Activator.java
@@ -45,7 +45,7 @@ public class Activator extends BaseActivator {
         JndiServiceImpl service = new JndiServiceImpl();
         service.setBundleContext(bundleContext);
         service.setProxyManager(proxyManager);
-        Hashtable<String, String> props = new Hashtable<String, String>();
+        Hashtable<String, String> props = new Hashtable<>();
         // bind the JNDI service itself in the JNDI context
         props.put("osgi.jndi.service.name", "jndi");
         register(JndiService.class, service, props);

--- a/jpa/hibernate/src/main/java/org/apache/karaf/jpa/hibernate/impl/Activator.java
+++ b/jpa/hibernate/src/main/java/org/apache/karaf/jpa/hibernate/impl/Activator.java
@@ -36,7 +36,7 @@ public class Activator implements BundleActivator, ServiceTrackerCustomizer<MBea
     @Override
     public void start(BundleContext context) throws Exception {
         this.context = context;
-        mbeanServerTracker = new ServiceTracker<MBeanServer, MBeanServer>(context, MBeanServer.class, this);
+        mbeanServerTracker = new ServiceTracker<>(context, MBeanServer.class, this);
         mbeanServerTracker.open();
     }
 

--- a/jpa/hibernate/src/main/java/org/apache/karaf/jpa/hibernate/impl/StatisticsPublisher.java
+++ b/jpa/hibernate/src/main/java/org/apache/karaf/jpa/hibernate/impl/StatisticsPublisher.java
@@ -51,7 +51,7 @@ public class StatisticsPublisher implements ServiceTrackerCustomizer<EntityManag
     public StatisticsPublisher(BundleContext context, MBeanServer mbeanServer) {
         this.context = context;
         this.mbeanServer = mbeanServer;
-        this.emfTracker = new ServiceTracker<EntityManagerFactory, EntityManagerFactory>(context, EntityManagerFactory.class, this);
+        this.emfTracker = new ServiceTracker<>(context, EntityManagerFactory.class, this);
     }
     
     public void start() {

--- a/kar/src/main/java/org/apache/karaf/kar/internal/Kar.java
+++ b/kar/src/main/java/org/apache/karaf/kar/internal/Kar.java
@@ -82,7 +82,7 @@ public class Kar {
         InputStream is = null;
         JarInputStream zipIs = null;
         FeatureDetector featureDetector = new FeatureDetector();
-        this.featureRepos = new ArrayList<URI>();
+        this.featureRepos = new ArrayList<>();
         this.shouldInstallFeatures = true;
 
         try {

--- a/kar/src/main/java/org/apache/karaf/kar/internal/KarServiceImpl.java
+++ b/kar/src/main/java/org/apache/karaf/kar/internal/KarServiceImpl.java
@@ -168,7 +168,7 @@ public class KarServiceImpl implements KarService {
 
 
     private List<URI> readFromFile(File repoListFile) {
-        ArrayList<URI> uriList = new ArrayList<URI>();
+        ArrayList<URI> uriList = new ArrayList<>();
         FileReader fr = null;
         try {
             fr = new FileReader(repoListFile);
@@ -237,7 +237,7 @@ public class KarServiceImpl implements KarService {
     
     @Override
     public List<String> list() throws Exception {
-        List<String> kars = new ArrayList<String>();
+        List<String> kars = new ArrayList<>();
         for (File kar : storage.listFiles()) {
             if (kar.isDirectory()) {
                 kars.add(kar.getName());
@@ -310,10 +310,10 @@ public class KarServiceImpl implements KarService {
             Manifest manifest = createNonAutoStartManifest(repo.getURI());
             jos = new JarOutputStream(new BufferedOutputStream(fos, 100000), manifest);
             
-            Map<URI, Integer> locationMap = new HashMap<URI, Integer>();
+            Map<URI, Integer> locationMap = new HashMap<>();
             copyResourceToJar(jos, repo.getURI(), locationMap);
         
-            Map<String, Feature> featureMap = new HashMap<String, Feature>();
+            Map<String, Feature> featureMap = new HashMap<>();
             for (Feature feature : repo.getFeatures()) {
                 featureMap.put(feature.getName(), feature);
             }
@@ -338,7 +338,7 @@ public class KarServiceImpl implements KarService {
     }
 
     private Set<Feature> getFeatures(Map<String, Feature> featureMap, List<String> features, int depth) {
-        Set<Feature> featureSet = new HashSet<Feature>();
+        Set<Feature> featureSet = new HashSet<>();
         if (depth > 5) {
             // Break after some recursions to avoid endless loops 
             return featureSet;
@@ -355,7 +355,7 @@ public class KarServiceImpl implements KarService {
             } else {
                 featureSet.add(feature);
                 List<Dependency> deps = feature.getDependencies();
-                List<String> depNames = new ArrayList<String>();
+                List<String> depNames = new ArrayList<>();
                 for (Dependency dependency : deps) {
                     depNames.add(dependency.getName());
                 }

--- a/log/src/main/java/org/apache/karaf/log/command/LogEntry.java
+++ b/log/src/main/java/org/apache/karaf/log/command/LogEntry.java
@@ -43,7 +43,7 @@ public class LogEntry implements Action {
     @Reference
     LogService logService;
 
-    private final Map<String,Integer> mappings = new HashMap<String,Integer>();
+    private final Map<String,Integer> mappings = new HashMap<>();
 
     public LogEntry() {
         mappings.put("ERROR", 1);

--- a/log/src/main/java/org/apache/karaf/log/command/LogTail.java
+++ b/log/src/main/java/org/apache/karaf/log/command/LogTail.java
@@ -102,7 +102,7 @@ public class LogTail extends DisplayLog {
             }
             out.flush();
             // Tail
-            final BlockingQueue<PaxLoggingEvent> queue = new LinkedBlockingQueue<PaxLoggingEvent>();
+            final BlockingQueue<PaxLoggingEvent> queue = new LinkedBlockingQueue<>();
             PaxAppender appender = new PaxAppender() {
                 public void doAppend(PaxLoggingEvent event) {
                         queue.add(event);

--- a/log/src/main/java/org/apache/karaf/log/core/internal/LogServiceLog4j1Impl.java
+++ b/log/src/main/java/org/apache/karaf/log/core/internal/LogServiceLog4j1Impl.java
@@ -44,7 +44,7 @@ public class LogServiceLog4j1Impl implements LogServiceInternal {
             String root = getLevelFromProperty((String) config.get(ROOT_LOGGER_PREFIX));
             loggers.put(ROOT_LOGGER, root);
             for (Enumeration<String> e = config.keys(); e.hasMoreElements(); ) {
-                String prop = (String) e.nextElement();
+                String prop = e.nextElement();
                 if (prop.startsWith(LOGGER_PREFIX)) {
                     String val = getLevelFromProperty((String) config.get(prop));
                     loggers.put(prop.substring(LOGGER_PREFIX.length()), val);

--- a/log/src/main/java/org/apache/karaf/log/core/internal/LruList.java
+++ b/log/src/main/java/org/apache/karaf/log/core/internal/LruList.java
@@ -43,7 +43,7 @@ public class LruList implements PaxAppender {
         }
         elements = new PaxLoggingEvent[size];
         maxElements = elements.length;
-        appenders = new ArrayList<PaxAppender>();
+        appenders = new ArrayList<>();
     }
 
     public synchronized int size() {

--- a/log/src/main/java/org/apache/karaf/log/core/internal/osgi/Activator.java
+++ b/log/src/main/java/org/apache/karaf/log/core/internal/osgi/Activator.java
@@ -56,7 +56,7 @@ public class Activator extends BaseActivator implements ManagedService {
         String traceColor = getString("traceColor", "39");
 
         LruList events = new LruList(size);
-        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        Hashtable<String, Object> props = new Hashtable<>();
         props.put("org.ops4j.pax.logging.appender.name", "VmLogAppender");
         register(PaxAppender.class, events, props);
 

--- a/main/src/main/java/org/apache/karaf/main/KarafActivatorManager.java
+++ b/main/src/main/java/org/apache/karaf/main/KarafActivatorManager.java
@@ -39,7 +39,7 @@ public class KarafActivatorManager {
 
     Logger LOG = Logger.getLogger(this.getClass().getName());
 
-    private List<BundleActivator> karafActivators = new ArrayList<BundleActivator>();
+    private List<BundleActivator> karafActivators = new ArrayList<>();
     private final ClassLoader classLoader;
     private final Framework framework;
     

--- a/main/src/main/java/org/apache/karaf/main/Main.java
+++ b/main/src/main/java/org/apache/karaf/main/Main.java
@@ -443,7 +443,7 @@ public class Main {
     }
 
     private ClassLoader createClassLoader(ArtifactResolver resolver) throws Exception {
-        List<URL> urls = new ArrayList<URL>();
+        List<URL> urls = new ArrayList<>();
         urls.add(resolver.resolve(config.frameworkBundle).toURL());
         File[] libs = new File(config.karafHome, "lib").listFiles();
         if (libs != null) {
@@ -494,7 +494,7 @@ public class Main {
     
     public List<BundleInfo> readBundlesFromStartupProperties(File startupPropsFile) {
         Properties startupProps = PropertiesLoader.loadPropertiesOrFail(startupPropsFile);
-        List<BundleInfo> bundeList = new ArrayList<BundleInfo>();
+        List<BundleInfo> bundeList = new ArrayList<>();
         for (String key : startupProps.keySet()) {
             try {
                 BundleInfo bi = new BundleInfo();
@@ -534,12 +534,12 @@ public class Main {
     }
 
     private boolean isNotFragment(Bundle b) {
-        String fragmentHostHeader = (String) b.getHeaders().get(Constants.FRAGMENT_HOST);
+        String fragmentHostHeader = b.getHeaders().get(Constants.FRAGMENT_HOST);
         return fragmentHostHeader == null || fragmentHostHeader.trim().length() == 0;
     }
 
     private List<File> getBundleRepos() {
-        List<File> bundleDirs = new ArrayList<File>();
+        List<File> bundleDirs = new ArrayList<>();
         File homeSystemRepo = new File(config.karafHome, config.defaultRepo);
         if (!homeSystemRepo.isDirectory()) {
             throw new RuntimeException("system repo folder not found: " + homeSystemRepo.getAbsolutePath());

--- a/main/src/test/java/org/apache/karaf/main/lock/BaseJDBCLockTest.java
+++ b/main/src/test/java/org/apache/karaf/main/lock/BaseJDBCLockTest.java
@@ -89,7 +89,7 @@ public abstract class BaseJDBCLockTest {
         expect(connection.isClosed()).andReturn(false);
         connection.setAutoCommit(false);
         expect(connection.getMetaData()).andReturn(metaData).anyTimes();
-        expect(metaData.getTables((String) isNull(), (String) isNull(), anyString(), aryEq(new String[]{"TABLE"}))).andReturn(resultSet);
+        expect(metaData.getTables(isNull(), isNull(), anyString(), aryEq(new String[]{"TABLE"}))).andReturn(resultSet);
         expect(resultSet.next()).andReturn(false);
         resultSet.close();
         expectLastCall().atLeastOnce();
@@ -111,7 +111,7 @@ public abstract class BaseJDBCLockTest {
     public void initShouldNotCreateTheSchemaIfItAlreadyExists() throws Exception {
         connection.setAutoCommit(false);
         expect(connection.getMetaData()).andReturn(metaData);
-        expect(metaData.getTables((String) isNull(), (String) isNull(), anyString(), aryEq(new String[]{"TABLE"}))).andReturn(resultSet);
+        expect(metaData.getTables(isNull(), isNull(), anyString(), aryEq(new String[]{"TABLE"}))).andReturn(resultSet);
         expect(resultSet.next()).andReturn(true);
         resultSet.close();
         expectLastCall().atLeastOnce();

--- a/management/server/src/main/java/org/apache/karaf/management/ConnectorServerFactory.java
+++ b/management/server/src/main/java/org/apache/karaf/management/ConnectorServerFactory.java
@@ -347,7 +347,7 @@ public class ConnectorServerFactory {
         }
 
         public ServerSocket createServerSocket(int port) throws IOException {
-            ServerSocket serverSocket = (ServerSocket) ServerSocketFactory.getDefault().createServerSocket(port, 50, InetAddress.getByName(rmiServerHost));
+            ServerSocket serverSocket = ServerSocketFactory.getDefault().createServerSocket(port, 50, InetAddress.getByName(rmiServerHost));
             return serverSocket;
         }
     }

--- a/management/server/src/main/java/org/apache/karaf/management/KarafMBeanServerGuard.java
+++ b/management/server/src/main/java/org/apache/karaf/management/KarafMBeanServerGuard.java
@@ -111,7 +111,7 @@ public class KarafMBeanServerGuard implements InvocationHandler {
         MBeanInfo info = mbeanServer.getMBeanInfo(objectName);
 
         for (MBeanOperationInfo operation : info.getOperations()) {
-            List<String> sig = new ArrayList<String>();
+            List<String> sig = new ArrayList<>();
             for (MBeanParameterInfo param : operation.getSignature()) {
                 sig.add(param.getType());
             }
@@ -168,7 +168,7 @@ public class KarafMBeanServerGuard implements InvocationHandler {
                 continue;
             }
 
-            List<String> sig = new ArrayList<String>();
+            List<String> sig = new ArrayList<>();
             for (MBeanParameterInfo param : op.getSignature()) {
                 sig.add(param.getType());
             }
@@ -285,7 +285,7 @@ public class KarafMBeanServerGuard implements InvocationHandler {
     }
     
     private boolean canBypassRBAC(BulkRequestContext context, ObjectName objectName, String operationName) {
-        List<String> allBypassObjectName = new ArrayList<String>();
+        List<String> allBypassObjectName = new ArrayList<>();
 
         List<Dictionary<String, Object>> configs = context.getWhitelistProperties();
         for (Dictionary<String, Object> config : configs) {
@@ -352,7 +352,7 @@ public class KarafMBeanServerGuard implements InvocationHandler {
             String generalPid = getGeneralPid(context.getAllPids(), pid);
             if (generalPid.length() > 0) {
                 Dictionary<String, Object> config = context.getConfiguration(generalPid);
-                List<String> roles = new ArrayList<String>();
+                List<String> roles = new ArrayList<>();
                 ACLConfigurationParser.Specificity s = ACLConfigurationParser.getRolesForInvocation(methodName, params, signature, config, roles);
                 if (s != ACLConfigurationParser.Specificity.NO_MATCH) {
                     return roles;
@@ -365,7 +365,7 @@ public class KarafMBeanServerGuard implements InvocationHandler {
     private String getGeneralPid(List<String> allPids, String pid) {
         String ret = "";
         String[] pidStrArray = pid.split(Pattern.quote("."));
-        Set<String[]> rets = new TreeSet<String[]>(WILDCARD_PID_COMPARATOR);
+        Set<String[]> rets = new TreeSet<>(WILDCARD_PID_COMPARATOR);
         for (String id : allPids) {
             String[] idStrArray = id.split(Pattern.quote("."));
             if (idStrArray.length == pidStrArray.length) {
@@ -401,7 +401,7 @@ public class KarafMBeanServerGuard implements InvocationHandler {
     }
 
     private List<String> getNameSegments(ObjectName objectName) {
-        List<String> segments = new ArrayList<String>();
+        List<String> segments = new ArrayList<>();
         segments.add(objectName.getDomain());
         // TODO can an ObjectName property contain a comma as key or value ?
         // TODO support quoting as described in http://docs.oracle.com/javaee/1.4/api/javax/management/ObjectName.html
@@ -435,7 +435,7 @@ public class KarafMBeanServerGuard implements InvocationHandler {
      * @return the PIDs corresponding with the ObjectName in the above order.
      */
     private List<String> iterateDownPids(List<String> segments) {
-        List<String> res = new ArrayList<String>();
+        List<String> res = new ArrayList<>();
         for (int i = segments.size(); i > 0; i--) {
             StringBuilder sb = new StringBuilder();
             sb.append(JMX_ACL_PID_PREFIX);

--- a/management/server/src/main/java/org/apache/karaf/management/RmiRegistryFactory.java
+++ b/management/server/src/main/java/org/apache/karaf/management/RmiRegistryFactory.java
@@ -131,7 +131,7 @@ public class RmiRegistryFactory {
         }
         if (registry != null) {
             // register the registry as an OSGi service
-            Hashtable<String, Object> props = new Hashtable<String, Object>();
+            Hashtable<String, Object> props = new Hashtable<>();
             props.put("port", getPort());
             props.put("host", getHost());
             bundleContext.registerService(Registry.class, registry, props);

--- a/management/server/src/main/java/org/apache/karaf/management/internal/Activator.java
+++ b/management/server/src/main/java/org/apache/karaf/management/internal/Activator.java
@@ -120,7 +120,7 @@ public class Activator extends BaseActivator implements ManagedService {
         connectorServerFactory.setDaemon(daemon);
         connectorServerFactory.setThreaded(threaded);
         connectorServerFactory.setObjectName(objectName);
-        Map<String, Object> environment = new HashMap<String, Object>();
+        Map<String, Object> environment = new HashMap<>();
         environment.put("jmx.remote.authenticator", jaasAuthenticator);
         try {
             connectorServerFactory.setEnvironment(environment);
@@ -145,7 +145,7 @@ public class Activator extends BaseActivator implements ManagedService {
 
         register(MBeanServer.class, mbeanServer);
         
-        keystoreInstanceServiceTracker = new ServiceTracker<KeystoreInstance, KeystoreInstance>(
+        keystoreInstanceServiceTracker = new ServiceTracker<>(
             bundleContext, KeystoreInstance.class, new ServiceTrackerCustomizer<KeystoreInstance, KeystoreInstance>() {
                 @Override
                 public KeystoreInstance addingService(ServiceReference<KeystoreInstance> reference) {

--- a/management/server/src/main/java/org/apache/karaf/management/internal/BulkRequestContext.java
+++ b/management/server/src/main/java/org/apache/karaf/management/internal/BulkRequestContext.java
@@ -43,8 +43,8 @@ import org.osgi.service.cm.ConfigurationAdmin;
  */
 public class BulkRequestContext {
 
-    private List<String> allPids = new ArrayList<String>();
-    private List<Dictionary<String, Object>> whiteListProperties = new ArrayList<Dictionary<String, Object>>();
+    private List<String> allPids = new ArrayList<>();
+    private List<Dictionary<String, Object>> whiteListProperties = new ArrayList<>();
 
     private ConfigurationAdmin configAdmin;
 
@@ -54,7 +54,7 @@ public class BulkRequestContext {
     private Set<Principal> principals = new HashSet<>();
 
     // cache with lifecycle bound to BulkRequestContext instance
-    private Map<String, Dictionary<String, Object>> cachedConfigurations = new HashMap<String, Dictionary<String, Object>>();
+    private Map<String, Dictionary<String, Object>> cachedConfigurations = new HashMap<>();
 
     private BulkRequestContext() {}
 

--- a/management/server/src/main/java/org/apache/karaf/management/internal/JMXSecurityMBeanImpl.java
+++ b/management/server/src/main/java/org/apache/karaf/management/internal/JMXSecurityMBeanImpl.java
@@ -94,7 +94,7 @@ public class JMXSecurityMBeanImpl extends StandardMBean implements JMXSecurityMB
                 table.put(data);
             } else {
                 for (String method : methods) {
-                    List<String> argTypes = new ArrayList<String>();
+                    List<String> argTypes = new ArrayList<>();
                     String name = parseMethodName(method, argTypes);
 
                     boolean res;

--- a/management/server/src/test/java/org/apache/karaf/management/KarafMBeanServerGuardTest.java
+++ b/management/server/src/test/java/org/apache/karaf/management/KarafMBeanServerGuardTest.java
@@ -39,7 +39,7 @@ import java.util.*;
 public class KarafMBeanServerGuardTest extends TestCase {
 
     public void testRequiredRolesMethodNameOnly() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("doit", "master");
         configuration.put("fryit", "editor,viewer");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -56,11 +56,11 @@ public class KarafMBeanServerGuardTest extends TestCase {
 
     @SuppressWarnings("unchecked")
     public void testRequiredRolesMethodNameEmpty() throws Exception {
-        Dictionary<String, Object> conf1 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf1 = new Hashtable<>();
         conf1.put("doit", "");
         conf1.put("fryit", "editor, viewer");
         conf1.put(Constants.SERVICE_PID, "jmx.acl.foo.bar.Test");
-        Dictionary<String, Object> conf2 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf2 = new Hashtable<>();
         conf2.put("doit", "editor");
         conf2.put(Constants.SERVICE_PID, "jmx.acl.foo.bar");
         ConfigurationAdmin ca = getMockConfigAdmin2(conf1, conf2);
@@ -75,7 +75,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testRequiredRolesSignature() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("testit", "master");
         configuration.put("testit(java.lang.String)", "viewer");
         configuration.put("testit(java.lang.String, java.lang.String)", "editor");
@@ -90,7 +90,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testRequiredRolesSignatureEmpty() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("testit", "master");
         configuration.put("testit(java.lang.String)", "viewer");
         configuration.put("testit(java.lang.String, java.lang.String)", "");
@@ -105,7 +105,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testRequiredRolesExact() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("testit", "master");
         configuration.put("testit(java.lang.String)", "viewer");
         configuration.put("testit(java.lang.String, java.lang.String)", "editor");
@@ -136,7 +136,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testRequiredRolesExact2() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("foo(java.lang.String,java.lang.String)[\"a\",\",\"]", "editor #this is the editor rule");
         configuration.put("foo(java.lang.String,java.lang.String)[\",\" , \"a\"]", "viewer");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -154,7 +154,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testRequiredRolesNumeric() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("bar(int)[\"17\"]", "editor #this is the editor rule");
         configuration.put("bar", "viewer");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -170,7 +170,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testRequiredRolesExactNobody() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("foo(java.lang.String)[\"a\"]", "");
         configuration.put("foo(java.lang.String)[\"aa\"]", "#hello");
         configuration.put("foo", "test");
@@ -187,7 +187,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testRequiredRolesRegExp() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("  testit   (java.lang.String)  [  /ab/]", "manager");
         configuration.put("testit(java.lang.String)[/c\"d/]", "tester");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -208,7 +208,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testRequiredRolesRegExpNobody() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("testit(java.lang.String)[/ab/]", "");
         configuration.put("test*", "tester");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -222,7 +222,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testRequiredRolesRegExp2() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("foo(java.lang.String,java.lang.String)[/a/,/b/]", "editor");
         configuration.put("foo(java.lang.String,java.lang.String)[/[bc]/ , /[^b]/]", "viewer");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -243,17 +243,17 @@ public class KarafMBeanServerGuardTest extends TestCase {
 
     @SuppressWarnings("unchecked")
     public void testRequiredRolesHierarchy() throws Exception {
-        Dictionary<String, Object> conf1 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf1 = new Hashtable<>();
         conf1.put("foo", "editor");
         conf1.put(Constants.SERVICE_PID, "jmx.acl.foo.bar.Test");
-        Dictionary<String, Object> conf2 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf2 = new Hashtable<>();
         conf2.put("bar", "viewer");
         conf2.put("foo", "viewer");
         conf2.put(Constants.SERVICE_PID, "jmx.acl.foo.bar");
-        Dictionary<String, Object> conf3 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf3 = new Hashtable<>();
         conf3.put("tar", "admin");
         conf3.put(Constants.SERVICE_PID, "jmx.acl.foo");
-        Dictionary<String, Object> conf4 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf4 = new Hashtable<>();
         conf4.put("zar", "visitor");
         conf4.put(Constants.SERVICE_PID, "jmx.acl");
 
@@ -278,10 +278,10 @@ public class KarafMBeanServerGuardTest extends TestCase {
 
     @SuppressWarnings("unchecked")
     public void testRequiredRolesHierarchyWildcard1() throws Exception {
-        Dictionary<String, Object> conf1 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf1 = new Hashtable<>();
         conf1.put("foo", "viewer");
         conf1.put(Constants.SERVICE_PID, "jmx.acl._.bar.Test");
-        Dictionary<String, Object> conf2 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf2 = new Hashtable<>();
         conf2.put("foo", "editor");
         conf2.put(Constants.SERVICE_PID, "jmx.acl.foo.bar.Test");
 
@@ -303,10 +303,10 @@ public class KarafMBeanServerGuardTest extends TestCase {
 
     @SuppressWarnings("unchecked")
     public void testRequiredRolesHierarchyWildcard2() throws Exception {
-        Dictionary<String, Object> conf1 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf1 = new Hashtable<>();
         conf1.put("foo", "viewer");
         conf1.put(Constants.SERVICE_PID, "jmx.acl.foo.bar.Test");
-        Dictionary<String, Object> conf2 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf2 = new Hashtable<>();
         conf2.put("foo", "editor");
         conf2.put(Constants.SERVICE_PID, "jmx.acl._.bar.Test");
 
@@ -328,10 +328,10 @@ public class KarafMBeanServerGuardTest extends TestCase {
 
     @SuppressWarnings("unchecked")
     public void testRequiredRolesHierarchyWildcard3() throws Exception {
-        Dictionary<String, Object> conf1 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf1 = new Hashtable<>();
         conf1.put("foo", "viewer");
         conf1.put(Constants.SERVICE_PID, "jmx.acl._.bar.Test");
-        Dictionary<String, Object> conf2 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf2 = new Hashtable<>();
         conf2.put("foo", "editor");
         conf2.put(Constants.SERVICE_PID, "jmx.acl.foo._.Test");
 
@@ -354,7 +354,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testRequiredRolesMethodNameWildcard() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("getFoo", "viewer");
         configuration.put("get*", " tester , editor,manager");
         configuration.put("*", "admin");
@@ -373,7 +373,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testRequiredRolesMethodNameWildcard2() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("ge", "janitor");
         configuration.put("get", "admin");
         configuration.put("get*", "viewer");
@@ -393,7 +393,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testRequiredRolesMethodNameWildcard3() throws Exception {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("get*", "viewer");
         configuration.put("*", "admin");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -412,11 +412,11 @@ public class KarafMBeanServerGuardTest extends TestCase {
 
     @SuppressWarnings("unchecked")
     public void testRequiredRolesMethodNameWildcardEmpty() throws Exception {
-        Dictionary<String, Object> conf1 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf1 = new Hashtable<>();
         conf1.put("get*", " ");
         conf1.put("*", "admin");
         conf1.put(Constants.SERVICE_PID, "jmx.acl.foo.bar.Test");
-        Dictionary<String, Object> conf2 = new Hashtable<String, Object>();
+        Dictionary<String, Object> conf2 = new Hashtable<>();
         conf2.put("get*", "viewer");
         conf2.put(Constants.SERVICE_PID, "jmx.acl");
         ConfigurationAdmin ca = getMockConfigAdmin2(conf1, conf2);
@@ -438,7 +438,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     private ConfigurationAdmin getMockConfigAdmin2(Dictionary<String, Object>... configurations) throws IOException, InvalidSyntaxException {
-        List<Configuration> allConfigs = new ArrayList<Configuration>();
+        List<Configuration> allConfigs = new ArrayList<>();
         for (Dictionary<String, Object> configuration : configurations) {
             Configuration conf = EasyMock.createMock(Configuration.class);
             EasyMock.expect(conf.getPid()).andReturn((String) configuration.get(Constants.SERVICE_PID)).anyTimes();
@@ -488,7 +488,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     }
 
     public void testInvoke() throws Throwable {
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("someMethod", "editor");
         configuration.put("someOtherMethod", "viewer");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -543,7 +543,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(mbeanInfo).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("getToast", "admin");
         configuration.put("isToast", "editor");
         configuration.put("getTest*", "admin");
@@ -592,7 +592,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(mbeanInfo).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("getToast", "editor");
         configuration.put("getTest*", "admin");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -640,7 +640,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(mbeanInfo).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("isT*", "editor");
         configuration.put("getToast", "admin");
         configuration.put("getButter", "editor");
@@ -691,7 +691,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(mbeanInfo).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("setSomething", "editor");
         configuration.put("setValue*", "admin");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -747,7 +747,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(mbeanInfo).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("setSomething", "editor");
         configuration.put("setValue*", "admin");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -812,7 +812,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on2)).andReturn(info2).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("doit(java.lang.String)[/11/]", "admin");
         configuration.put("doit(java.lang.String)", "viewer");
         configuration.put("doit(java.lang.String,java.lang.String)", "viewer");
@@ -855,7 +855,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("doit(java.lang.String)[/11/]", "admin");
         configuration.put("doit(java.lang.String)", "admin");
         configuration.put("doit(java.lang.String,java.lang.String)", "admin");
@@ -900,7 +900,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("doit(java.lang.String)", "admin");
         configuration.put("doit(java.lang.String,java.lang.String)", "viewer");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -941,7 +941,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("foit(java.lang.String)", "viewer");
         configuration.put("doit(java.lang.String,java.lang.String)", "admin");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -975,7 +975,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("doit(java.lang.String)", "admin");
         configuration.put("doit(java.lang.String,java.lang.String)", "viewer");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -1011,7 +1011,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("getFoo(java.lang.String)", "admin");
         configuration.put("getFoo()", "viewer");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -1047,7 +1047,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("getFoo(java.lang.String)", "viewer");
         configuration.put("getFoo()", "admin");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -1083,7 +1083,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("getFoo(java.lang.String)", "admin");
         configuration.put("getFoo()", "admin");
         configuration.put("isFoo()", "viewer");
@@ -1120,7 +1120,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("getFoo(java.lang.String)", "viewer");
         configuration.put("getFoo()", "viewer");
         configuration.put("isFoo()", "admin");
@@ -1157,7 +1157,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("setFoo(java.lang.String)", "admin");
         configuration.put("setFoo(boolean)", "viewer");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -1193,7 +1193,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("setFoo(java.lang.String)", "viewer");
         configuration.put("setFoo(boolean)", "admin");
         ConfigurationAdmin ca = getMockConfigAdmin(configuration);
@@ -1229,7 +1229,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("get*", "admin");
         configuration.put("is*", "viewer");
         configuration.put("*", "admin");
@@ -1267,7 +1267,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("get*", "admin");
         configuration.put("is*", "viewer");
         configuration.put("*", "admin");
@@ -1305,7 +1305,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("getA1", "viewer");
         configuration.put("is*", "admin");
         configuration.put("*", "admin");
@@ -1343,7 +1343,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("get*", "admin");
         configuration.put("setA2", "viewer");
         configuration.put("*", "admin");
@@ -1381,7 +1381,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         EasyMock.expect(mbs.getMBeanInfo(on)).andReturn(info).anyTimes();
         EasyMock.replay(mbs);
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("get*", "admin");
         configuration.put("setA2", "admin");
         configuration.put("*", "admin");
@@ -1408,7 +1408,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     public void testCanInvokeMethod() throws Exception {
         final ObjectName on = ObjectName.getInstance("foo.bar:type=Test");
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("doit(java.lang.String)[/11/]", "admin");
         configuration.put("doit(java.lang.String)", "viewer");
         configuration.put("doit(java.lang.String,java.lang.String)", "viewer");
@@ -1443,7 +1443,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
     public void testCanInvokeMethod2() throws Exception {
         final ObjectName on = ObjectName.getInstance("foo.bar:type=Test");
 
-        Dictionary<String, Object> configuration = new Hashtable<String, Object>();
+        Dictionary<String, Object> configuration = new Hashtable<>();
         configuration.put("doit(java.lang.String)[/11/]", "viewer");
         configuration.put("doit(java.lang.String)", "admin");
         configuration.put("doit(java.lang.String,java.lang.String)", "admin");
@@ -1489,7 +1489,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
         private Subject subject;
 
         private static Principal[] getPrincipals(String... roles) {
-            List<Principal> principals = new ArrayList<Principal>();
+            List<Principal> principals = new ArrayList<>();
             for (String role : roles) {
                 principals.add(new RolePrincipal(role));
             }

--- a/management/server/src/test/java/org/apache/karaf/management/internal/JMXSecurityMBeanImplTestCase.java
+++ b/management/server/src/test/java/org/apache/karaf/management/internal/JMXSecurityMBeanImplTestCase.java
@@ -171,10 +171,10 @@ public class JMXSecurityMBeanImplTestCase extends TestCase {
         JMXSecurityMBeanImpl mb = new JMXSecurityMBeanImpl();
         mb.setMBeanServer(mbs);
         mb.setGuard(testGuard);
-        Map<String, List<String>> query = new HashMap<String, List<String>>();
+        Map<String, List<String>> query = new HashMap<>();
         query.put(objectName, Arrays.asList("otherMethod", "testMethod(long)", "testMethod(java.lang.String)"));
-        query.put(objectName2, Collections.<String>emptyList());
-        query.put(objectName3, Collections.<String>emptyList());
+        query.put(objectName2, Collections.emptyList());
+        query.put(objectName3, Collections.emptyList());
         TabularData result = mb.canInvoke(query);
         assertEquals(5, result.size());
 
@@ -224,7 +224,7 @@ public class JMXSecurityMBeanImplTestCase extends TestCase {
         JMXSecurityMBeanImpl mb = new JMXSecurityMBeanImpl();
         mb.setMBeanServer(mbs);
         mb.setGuard(testGuard);
-        Map<String, List<String>> query = new HashMap<String, List<String>>();
+        Map<String, List<String>> query = new HashMap<>();
         query.put(objectName, Arrays.asList("duplicateMethod1(long)", "duplicateMethod1(java.lang.String)", "duplicateMethod1(long)", "duplicateMethod2", "duplicateMethod2"));
         TabularData result = mb.canInvoke(query);
         assertEquals(3, result.size());
@@ -278,7 +278,7 @@ public class JMXSecurityMBeanImplTestCase extends TestCase {
         JMXSecurityMBeanImpl mb = new JMXSecurityMBeanImpl();
         mb.setMBeanServer(mbs);
         mb.setGuard(guard);
-        Map<String, List<String>> query = new HashMap<String, List<String>>();
+        Map<String, List<String>> query = new HashMap<>();
         query.put(objectName, Collections.singletonList("testMethod(java.lang.String)"));
         query.put(objectName2, Collections.singletonList("testMethod(long)"));
         TabularData result = mb.canInvoke(query);

--- a/obr/src/main/java/org/apache/karaf/obr/command/ResolveCommand.java
+++ b/obr/src/main/java/org/apache/karaf/obr/command/ResolveCommand.java
@@ -57,7 +57,7 @@ public class ResolveCommand extends ObrCommandSupport {
     List<String> requirements;
 
     protected void doExecute(RepositoryAdmin admin) throws Exception {
-        List<Repository> repositories = new ArrayList<Repository>();
+        List<Repository> repositories = new ArrayList<>();
         repositories.add(admin.getSystemRepository());
         if (!noLocal) {
             repositories.add(admin.getLocalRepository());

--- a/package/src/main/java/org/apache/karaf/packages/command/Exports.java
+++ b/package/src/main/java/org/apache/karaf/packages/command/Exports.java
@@ -130,7 +130,7 @@ public class Exports implements Action {
     }
 
     private SortedMap<String, PackageVersion> getDuplicatePackages(Bundle[] bundles) {
-        SortedMap<String, PackageVersion> packageVersionMap = new TreeMap<String, PackageVersion>();
+        SortedMap<String, PackageVersion> packageVersionMap = new TreeMap<>();
         for (Bundle bundle : bundles) {
             BundleRevision rev = bundle.adapt(BundleRevision.class);
             if (rev != null) {

--- a/package/src/main/java/org/apache/karaf/packages/core/PackageVersion.java
+++ b/package/src/main/java/org/apache/karaf/packages/core/PackageVersion.java
@@ -26,7 +26,7 @@ public class PackageVersion {
 
     private String packageName;
     private Version version;
-    private Set<Bundle> bundles = new HashSet<Bundle>();
+    private Set<Bundle> bundles = new HashSet<>();
     
     public PackageVersion(String packageName, Version version) {
         this.packageName = packageName;

--- a/package/src/main/java/org/apache/karaf/packages/core/internal/PackageServiceImpl.java
+++ b/package/src/main/java/org/apache/karaf/packages/core/internal/PackageServiceImpl.java
@@ -44,7 +44,7 @@ public class PackageServiceImpl implements PackageService {
 
     public List<PackageVersion> getExports() {
         Bundle[] bundles = bundleContext.getBundles();
-        SortedMap<String, PackageVersion> packageVersionMap = new TreeMap<String, PackageVersion>();
+        SortedMap<String, PackageVersion> packageVersionMap = new TreeMap<>();
         for (Bundle bundle : bundles) {
             BundleRevision rev = bundle.adapt(BundleRevision.class);
             if (rev != null) {
@@ -101,7 +101,7 @@ public class PackageServiceImpl implements PackageService {
         Bundle bundle = bundleContext.getBundle(bundleId);
         BundleRevision rev = bundle.adapt(BundleRevision.class);
         List<BundleCapability> caps = rev.getDeclaredCapabilities(BundleRevision.PACKAGE_NAMESPACE);
-        List<String> exports = new ArrayList<String>();
+        List<String> exports = new ArrayList<>();
         for (BundleCapability cap : caps) {
             Map<String, Object> attr = cap.getAttributes();
             String packageName = (String)attr.get(BundleRevision.PACKAGE_NAMESPACE);
@@ -115,7 +115,7 @@ public class PackageServiceImpl implements PackageService {
         Bundle bundle = bundleContext.getBundle(bundleId);
         BundleRevision rev = bundle.adapt(BundleRevision.class);
         List<BundleRequirement> reqs = rev.getDeclaredRequirements(BundleRevision.PACKAGE_NAMESPACE);
-        List<String> imports = new ArrayList<String>();
+        List<String> imports = new ArrayList<>();
         for (BundleRequirement req : reqs) {
             PackageRequirement packageReq = create(req, bundle);
             imports.add(packageReq.getPackageName());

--- a/package/src/main/java/org/apache/karaf/packages/core/internal/filter/ExprTokenizer.java
+++ b/package/src/main/java/org/apache/karaf/packages/core/internal/filter/ExprTokenizer.java
@@ -28,7 +28,7 @@ public class ExprTokenizer {
     public ExprTokenizer(String expr) {
         this.expr = expr;
         this.currentPos = 0;
-        operatorMap = new HashMap<Character, String>();
+        operatorMap = new HashMap<>();
         for (String operator : operators) {
             operatorMap.put(operator.charAt(0), operator);
         }

--- a/package/src/main/java/org/apache/karaf/packages/core/internal/filter/FilterParser.java
+++ b/package/src/main/java/org/apache/karaf/packages/core/internal/filter/FilterParser.java
@@ -45,7 +45,7 @@ public class FilterParser {
     }
     
     private Expression[] parseFilterList(ExprTokenizer tokenizer) {
-        List<Expression> exprList = new ArrayList<Expression>();
+        List<Expression> exprList = new ArrayList<>();
         while ("(".equals(tokenizer.peekNextToken())) {
             tokenizer.nextToken();
             exprList.add(parseFilterComp(tokenizer));

--- a/profile/src/main/java/org/apache/karaf/profile/command/ProfileDisplay.java
+++ b/profile/src/main/java/org/apache/karaf/profile/command/ProfileDisplay.java
@@ -88,10 +88,10 @@ public class ProfileDisplay implements Action {
         Map<String, Map<String, Object>> configuration = new HashMap<>(profile.getConfigurations());
         Map<String, byte[]> resources = profile.getFileConfigurations();
         Map<String,Object> agentConfiguration = profile.getConfiguration(Profile.INTERNAL_PID);
-        List<String> agentProperties = new ArrayList<String>();
-        List<String> systemProperties = new ArrayList<String>();
-        List<String> configProperties = new ArrayList<String>();
-        List<String> otherResources = new ArrayList<String>();
+        List<String> agentProperties = new ArrayList<>();
+        List<String> systemProperties = new ArrayList<>();
+        List<String> configProperties = new ArrayList<>();
+        List<String> otherResources = new ArrayList<>();
         for (Map.Entry<String, Object> entry : agentConfiguration.entrySet()) {
             String key = entry.getKey();
             Object value = entry.getValue();

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/command/support/ScriptJob.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/command/support/ScriptJob.java
@@ -40,7 +40,7 @@ public class ScriptJob implements Job {
     @Override
     public void execute(JobContext context) {
         try {
-            script.execute(session, Collections.<Object>singletonList(context));
+            script.execute(session, Collections.singletonList(context));
         } catch (Exception e) {
             LOGGER.warn("Error executing script", e);
         }

--- a/scr/management/src/main/java/org/apache/karaf/scr/management/internal/ScrServiceMBeanImpl.java
+++ b/scr/management/src/main/java/org/apache/karaf/scr/management/internal/ScrServiceMBeanImpl.java
@@ -74,7 +74,7 @@ public class ScrServiceMBeanImpl extends StandardMBean implements ScrServiceMBea
     @Activate
     public void activate() throws Exception {
         LOGGER.info("Activating the " + COMPONENT_LABEL);
-        Map<Object, String> mbeans = new HashMap<Object, String>();
+        Map<Object, String> mbeans = new HashMap<>();
         mbeans.put(this, "org.apache.karaf:type=scr,name=${karaf.name}");
         try {
             lock.writeLock().lock();

--- a/service/core/src/main/java/org/apache/karaf/service/command/ListServices.java
+++ b/service/core/src/main/java/org/apache/karaf/service/command/ListServices.java
@@ -60,7 +60,7 @@ public class ListServices implements Action {
             listNames();
             return null;
         }
-        List<ServiceReference<?>> serviceRefs = new ArrayList<ServiceReference<?>>();
+        List<ServiceReference<?>> serviceRefs = new ArrayList<>();
         Bundle[] bundles = bundleContext.getBundles();
         for (Bundle bundle : bundles) {
             ServiceReference<?>[] services = bundle.getRegisteredServices();
@@ -86,7 +86,7 @@ public class ListServices implements Action {
     
     private void listNames() {
         Map<String, Integer> serviceNames = getServiceNamesMap(bundleContext);
-        ArrayList<String> serviceNamesList = new ArrayList<String>(serviceNames.keySet());
+        ArrayList<String> serviceNamesList = new ArrayList<>(serviceNames.keySet());
         Collections.sort(serviceNamesList);
         for (String name : serviceNamesList) {
             System.out.println(name + " (" + serviceNames.get(name) + ")");
@@ -94,7 +94,7 @@ public class ListServices implements Action {
     }
     
     public static Map<String, Integer> getServiceNamesMap(BundleContext bundleContext) {
-        Map<String, Integer> serviceNames = new HashMap<String, Integer>();
+        Map<String, Integer> serviceNames = new HashMap<>();
         Bundle[] bundles = bundleContext.getBundles();
         for (Bundle bundle : bundles) {
             ServiceReference<?>[] services = bundle.getRegisteredServices();

--- a/service/core/src/main/java/org/apache/karaf/service/command/ObjectClassCompleter.java
+++ b/service/core/src/main/java/org/apache/karaf/service/command/ObjectClassCompleter.java
@@ -47,7 +47,7 @@ public class ObjectClassCompleter implements Completer {
     public int complete(final Session session, final CommandLine commandLine, final List<String> candidates) {
         Map<String, Integer> serviceNamesMap = ListServices.getServiceNamesMap(context);
         Set<String> serviceNames = serviceNamesMap.keySet();
-        List<String> strings = new ArrayList<String>();
+        List<String> strings = new ArrayList<>();
         for (String name : serviceNames) {
             strings.add(ObjectClassMatcher.getShortName(name));
         }

--- a/service/core/src/main/java/org/apache/karaf/service/command/Wait.java
+++ b/service/core/src/main/java/org/apache/karaf/service/command/Wait.java
@@ -62,7 +62,7 @@ public class Wait implements Action {
                 filter = "(" + filter + ")";
             }
             Filter osgiFilter = FrameworkUtil.createFilter(filter);
-            tracker = new ServiceTracker<Object, Object>(bundleContext, osgiFilter, null);
+            tracker = new ServiceTracker<>(bundleContext, osgiFilter, null);
             tracker.open(true);
             Object svc = tracker.getService();
             if (timeout >= 0) {

--- a/service/core/src/main/java/org/apache/karaf/service/core/internal/ServicesMBeanImpl.java
+++ b/service/core/src/main/java/org/apache/karaf/service/core/internal/ServicesMBeanImpl.java
@@ -99,7 +99,7 @@ public class ServicesMBeanImpl extends StandardMBean implements ServicesMBean {
                     if (serviceReferences != null) {
                         for (ServiceReference reference : serviceReferences) {
                             String[] interfaces = (String[]) reference.getProperty("objectClass");
-                            List<String> properties = new ArrayList<String>();
+                            List<String> properties = new ArrayList<>();
                             for (String key : reference.getPropertyKeys()) {
                                 properties.add(key + " = " + reference.getProperty(key));
                             }

--- a/service/core/src/test/java/org/apache/karaf/service/command/TestBundleFactory.java
+++ b/service/core/src/test/java/org/apache/karaf/service/command/TestBundleFactory.java
@@ -35,11 +35,11 @@ public class TestBundleFactory {
         if (keyProp.length % 2 != 0) {
             throw new IllegalArgumentException("");
         }
-        Hashtable<String, Object> keyPropMap = new Hashtable<String, Object>();
+        Hashtable<String, Object> keyPropMap = new Hashtable<>();
         int c = 0;
         while (c < keyProp.length) {
             String key = (String)keyProp[c++];
-            Object value = (Object)keyProp[c++];
+            Object value = keyProp[c++];
             keyPropMap.put(key, value);
             expect(serviceRef.getProperty(key)).andReturn(value).anyTimes();
         }
@@ -50,7 +50,7 @@ public class TestBundleFactory {
     Bundle createBundle(long id, String name) {
         Bundle bundle = createMock(Bundle.class);
         expect(bundle.getBundleId()).andReturn(id).anyTimes();
-        Dictionary<String, String> headers = new Hashtable<String, String>();
+        Dictionary<String, String> headers = new Hashtable<>();
         headers.put(Constants.BUNDLE_NAME, name);
         expect(bundle.getHeaders()).andReturn(headers).anyTimes();
         return bundle;

--- a/service/guard/src/main/java/org/apache/karaf/service/guard/impl/GuardProxyCatalog.java
+++ b/service/guard/src/main/java/org/apache/karaf/service/guard/impl/GuardProxyCatalog.java
@@ -74,12 +74,12 @@ public class GuardProxyCatalog implements ServiceListener {
     private static final String ROLE_WILDCARD = "*";
 
     private final BundleContext myBundleContext;
-    private final Map<String, Filter> filters = new ConcurrentHashMap<String, Filter>();
+    private final Map<String, Filter> filters = new ConcurrentHashMap<>();
 
     final ServiceTracker<ConfigurationAdmin, ConfigurationAdmin> configAdminTracker;
     final ServiceTracker<ProxyManager, ProxyManager> proxyManagerTracker;
-    final ConcurrentMap<Long, ServiceRegistrationHolder> proxyMap = new ConcurrentHashMap<Long, ServiceRegistrationHolder>();
-    final BlockingQueue<CreateProxyRunnable> createProxyQueue = new LinkedBlockingQueue<CreateProxyRunnable>();
+    final ConcurrentMap<Long, ServiceRegistrationHolder> proxyMap = new ConcurrentHashMap<>();
+    final BlockingQueue<CreateProxyRunnable> createProxyQueue = new LinkedBlockingQueue<>();
     final String compulsoryRoles;
 
     // These two variables control the proxy creator thread, which is started as soon as a ProxyManager Service
@@ -104,12 +104,12 @@ public class GuardProxyCatalog implements ServiceListener {
 
         Filter caFilter = getNonProxyFilter(bc, ConfigurationAdmin.class);
         LOG.trace("Creating Config Admin Tracker using filter {}", caFilter);
-        configAdminTracker = new ServiceTracker<ConfigurationAdmin, ConfigurationAdmin>(bc, caFilter, null);
+        configAdminTracker = new ServiceTracker<>(bc, caFilter, null);
         configAdminTracker.open();
 
         Filter pmFilter = getNonProxyFilter(bc, ProxyManager.class);
         LOG.trace("Creating Proxy Manager Tracker using filter {}", pmFilter);
-        proxyManagerTracker = new ServiceTracker<ProxyManager, ProxyManager>(bc, pmFilter, new ServiceProxyCreatorCustomizer());
+        proxyManagerTracker = new ServiceTracker<>(bc, pmFilter, new ServiceProxyCreatorCustomizer());
         proxyManagerTracker.open();
     }
 
@@ -294,7 +294,7 @@ public class GuardProxyCatalog implements ServiceListener {
     }
 
     private static Dictionary<String, Object> copyProperties(ServiceReference<?> sr) {
-        Dictionary<String, Object> p = new Hashtable<String, Object>();
+        Dictionary<String, Object> p = new Hashtable<>();
 
         for (String key : sr.getPropertyKeys()) {
             p.put(key, sr.getProperty(key));
@@ -306,7 +306,7 @@ public class GuardProxyCatalog implements ServiceListener {
     // as there can be different roles for different methods and also roles based on arguments passed in.
     Set<String> getServiceInvocationRoles(ServiceReference<?> serviceReference) throws Exception {
         boolean definitionFound = false;
-        Set<String> allRoles = new HashSet<String>();
+        Set<String> allRoles = new HashSet<>();
 
         // This can probably be optimized. Maybe we can cache the config object relevant instead of
         // walking through all of the ones that have 'service.guard'.
@@ -407,7 +407,7 @@ public class GuardProxyCatalog implements ServiceListener {
 
         @Override
         public Object getService(Bundle bundle, ServiceRegistration<Object> registration) {
-            Set<Class<?>> allClasses = new HashSet<Class<?>>();
+            Set<Class<?>> allClasses = new HashSet<>();
 
             // This needs to be done on the Client BundleContext since the bundle might be backed by a Service Factory
             // in which case it needs to be given a chance to produce the right service for this client.
@@ -466,7 +466,7 @@ public class GuardProxyCatalog implements ServiceListener {
             }
 
             // The ordering of the keys is important because the first value when iterating has the highest specificity
-            TreeMap<Specificity, List<String>> roleMappings = new TreeMap<ACLConfigurationParser.Specificity, List<String>>();
+            TreeMap<Specificity, List<String>> roleMappings = new TreeMap<>();
             boolean foundMatchingConfig = false;
 
             // This can probably be optimized. Maybe we can cache the config object relevant instead of
@@ -478,7 +478,7 @@ public class GuardProxyCatalog implements ServiceListener {
                     Filter filter = myBundleContext.createFilter((String) guardFilter);
                     if (filter.match(serviceReference)) {
                         foundMatchingConfig = true;
-                        List<String> roles = new ArrayList<String>();
+                        List<String> roles = new ArrayList<>();
                         Specificity s = ACLConfigurationParser.
                                 getRolesForInvocation(m.getName(), args, sig, config.getProperties(), roles);
                         if (s != Specificity.NO_MATCH) {

--- a/service/guard/src/main/java/org/apache/karaf/service/guard/tools/ACLConfigurationParser.java
+++ b/service/guard/src/main/java/org/apache/karaf/service/guard/tools/ACLConfigurationParser.java
@@ -150,7 +150,7 @@ public class ACLConfigurationParser {
     }
 
     private static Dictionary<String, Object> trimKeys(Dictionary<String, Object> properties) {
-        Dictionary<String, Object> d = new Hashtable<String, Object>();
+        Dictionary<String, Object> d = new Hashtable<>();
         for (Enumeration<String> e = properties.keys(); e.hasMoreElements(); ) {
             String key = e.nextElement();
             Object value = properties.get(key);
@@ -194,7 +194,7 @@ public class ACLConfigurationParser {
             roleStr = roleStr.substring(0, hashIdx);
         }
 
-        List<String> roles = new ArrayList<String>();
+        List<String> roles = new ArrayList<>();
         for (String role : roleStr.split("[,]")) {
             String trimmed = role.trim();
             if (trimmed.length() > 0) {
@@ -242,7 +242,7 @@ public class ACLConfigurationParser {
     }
 
     private static List<String> getRegexRoles(Dictionary<String, Object> properties, String methodName, String[] signature, Object[] params) {
-        List<String> roles = new ArrayList<String>();
+        List<String> roles = new ArrayList<>();
         boolean matchFound = false;
         String methodSig = getSignature(methodName, signature);
         String prefix = methodSig + "[/";
@@ -263,7 +263,7 @@ public class ACLConfigurationParser {
     }
 
     private static List<String> getExactArgOrRegexRoles(Dictionary<String, Object> properties, String methodName, String[] signature) {
-        List<String> roles = new ArrayList<String>();
+        List<String> roles = new ArrayList<>();
         boolean matchFound = false;
         String methodSig = getSignature(methodName, signature);
         String prefix = methodSig + "[";
@@ -281,7 +281,7 @@ public class ACLConfigurationParser {
     }
 
     private static List<String> getMethodNameWildcardRoles(Dictionary<String, Object> properties, String methodName) {
-        SortedMap<String, String> wildcardRules = new TreeMap<String, String>(new Comparator<String>() {
+        SortedMap<String, String> wildcardRules = new TreeMap<>(new Comparator<String>() {
             public int compare(String s1, String s2) {
                 // returns longer entries before shorter ones...
                 return s2.length() - s1.length();
@@ -333,7 +333,7 @@ public class ACLConfigurationParser {
     }
 
     private static List<String> getRegexDecl(String key) {
-        List<String> l = new ArrayList<String>();
+        List<String> l = new ArrayList<>();
 
         boolean inRegex = false;
         StringBuilder curRegex = new StringBuilder();

--- a/service/guard/src/test/java/org/apache/karaf/service/guard/impl/GuardProxyCatalogTest.java
+++ b/service/guard/src/test/java/org/apache/karaf/service/guard/impl/GuardProxyCatalogTest.java
@@ -111,22 +111,22 @@ public class GuardProxyCatalogTest {
 
         GuardProxyCatalog gpc = new GuardProxyCatalog(bc);
 
-        Dictionary<String, Object> props = new Hashtable<String, Object>();
+        Dictionary<String, Object> props = new Hashtable<>();
         props.put(GuardProxyCatalog.PROXY_SERVICE_KEY, Boolean.TRUE);
         assertTrue(gpc.isProxy(mockServiceReference(props)));
-        assertFalse(gpc.isProxy(mockServiceReference(new Hashtable<String, Object>())));
+        assertFalse(gpc.isProxy(mockServiceReference(new Hashtable<>())));
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testHandleProxificationForHook() throws Exception {
-        Dictionary<String, Object> config = new Hashtable<String, Object>();
+        Dictionary<String, Object> config = new Hashtable<>();
         config.put(Constants.SERVICE_PID, GuardProxyCatalog.SERVICE_ACL_PREFIX + "foo");
         config.put(GuardProxyCatalog.SERVICE_GUARD_KEY, "(a>=5)");
         BundleContext bc = mockConfigAdminBundleContext(config);
         GuardProxyCatalog gpc = new GuardProxyCatalog(bc);
 
-        Dictionary<String, Object> props = new Hashtable<String, Object>();
+        Dictionary<String, Object> props = new Hashtable<>();
         props.put(Constants.SERVICE_ID, 13L);
         props.put("a", "6");
         props.put(GuardProxyCatalog.PROXY_SERVICE_KEY, Boolean.TRUE);
@@ -135,7 +135,7 @@ public class GuardProxyCatalogTest {
                 gpc.handleProxificationForHook(sref2));
         assertEquals("No proxy should have been created", 0, gpc.proxyMap.size());
 
-        Dictionary<String, Object> props4 = new Hashtable<String, Object>();
+        Dictionary<String, Object> props4 = new Hashtable<>();
         props4.put(Constants.SERVICE_ID, 15L);
         props4.put("a", "7");
         ServiceReference<?> sref4 = mockServiceReference(props4);
@@ -152,13 +152,13 @@ public class GuardProxyCatalogTest {
         EasyMock.replay(clientBC);
         EasyMock.replay(client2BC);
 
-        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        Hashtable<String, Object> props = new Hashtable<>();
         long originalServiceID = 12345678901234L;
         props.put(Constants.SERVICE_ID, new Long(originalServiceID));
         props.put("foo", "bar");
         ServiceReference<?> originalRef = mockServiceReference(props);
 
-        Hashtable<String, Object> props2 = new Hashtable<String, Object>();
+        Hashtable<String, Object> props2 = new Hashtable<>();
         long anotherServiceID = 5123456789012345L;
         props2.put(Constants.SERVICE_ID, anotherServiceID);
         ServiceReference<?> anotherRef = mockServiceReference(props2);
@@ -191,7 +191,7 @@ public class GuardProxyCatalogTest {
         assertEquals("Registered events should be ignored", 2, gpc.proxyMap.size());
         assertEquals("Registered events should be ignored", 2, gpc.createProxyQueue.size());
 
-        Hashtable<String, Object> proxyProps = new Hashtable<String, Object>(props);
+        Hashtable<String, Object> proxyProps = new Hashtable<>(props);
         proxyProps.put(GuardProxyCatalog.PROXY_SERVICE_KEY, Boolean.TRUE);
         ServiceReference<?> proxyRef = mockServiceReference(proxyProps);
         gpc.serviceChanged(new ServiceEvent(ServiceEvent.UNREGISTERING, proxyRef));
@@ -245,7 +245,7 @@ public class GuardProxyCatalogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testAssignRoles() throws Exception {
-        Dictionary<String, Object> config = new Hashtable<String, Object>();
+        Dictionary<String, Object> config = new Hashtable<>();
         config.put(Constants.SERVICE_PID, "foobar");
         config.put("service.guard", "(objectClass=" + TestServiceAPI.class.getName() + ")");
         config.put("somemethod", "a,b");
@@ -258,14 +258,14 @@ public class GuardProxyCatalogTest {
         BundleContext bc = mockConfigAdminBundleContext(config);
 
         Dictionary<String, Object> proxyProps = testCreateProxy(bc, TestServiceAPI.class, new TestService());
-        assertEquals(new HashSet<String>(Arrays.asList("a", "b", "c", "d", "e", "f", "g")),
-                new HashSet<String>((Collection<String>) proxyProps.get(GuardProxyCatalog.SERVICE_GUARD_ROLES_PROPERTY)));
+        assertEquals(new HashSet<>(Arrays.asList("a", "b", "c", "d", "e", "f", "g")),
+                new HashSet<>((Collection<String>) proxyProps.get(GuardProxyCatalog.SERVICE_GUARD_ROLES_PROPERTY)));
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testAssignRoles2() throws Exception {
-        Dictionary<String, Object> config = new Hashtable<String, Object>();
+        Dictionary<String, Object> config = new Hashtable<>();
         config.put(Constants.SERVICE_PID, "foobar");
         config.put("service.guard", "(objectClass=" + TestServiceAPI2.class.getName() + ")");
         config.put("doit", "X");
@@ -282,14 +282,14 @@ public class GuardProxyCatalogTest {
     public void testAssignRoles3() throws Exception {
         abstract class MyAbstractClass implements TestServiceAPI, TestServiceAPI2 {};
 
-        Dictionary<String, Object> config = new Hashtable<String, Object>();
+        Dictionary<String, Object> config = new Hashtable<>();
         config.put(Constants.SERVICE_PID, "foobar");
         config.put("service.guard", "(objectClass=" + TestServiceAPI2.class.getName() + ")");
         config.put("doit", "X");
 
         BundleContext bc = mockConfigAdminBundleContext(config);
 
-        Map<ServiceReference, Object> serviceMap = new HashMap<ServiceReference, Object>();
+        Map<ServiceReference, Object> serviceMap = new HashMap<>();
         testCreateProxy(bc, new Class [] {TestServiceAPI.class, TestServiceAPI2.class}, new MyAbstractClass() {
             @Override
             public String doit() {
@@ -309,7 +309,7 @@ public class GuardProxyCatalogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testAssignRoles4() throws Exception {
-        Dictionary<String, Object> config = new Hashtable<String, Object>();
+        Dictionary<String, Object> config = new Hashtable<>();
         config.put(Constants.SERVICE_PID, "foobar");
         config.put("service.guard", "(objectClass=" + TestServiceAPI.class.getName() + ")");
         config.put("somemethod", "b");
@@ -327,11 +327,11 @@ public class GuardProxyCatalogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testInvocationBlocking1() throws Exception {
-        Dictionary<String, Object> c1 = new Hashtable<String, Object>();
+        Dictionary<String, Object> c1 = new Hashtable<>();
         c1.put(Constants.SERVICE_PID, "foobar");
         c1.put("service.guard", "(objectClass=" + TestServiceAPI.class.getName() + ")");
         c1.put("doit", "a,b");
-        Dictionary<String, Object> c2 = new Hashtable<String, Object>();
+        Dictionary<String, Object> c2 = new Hashtable<>();
         c2.put(Constants.SERVICE_PID, "barfoobar");
         c2.put("service.guard", "(objectClass=" + TestObjectWithoutInterface.class.getName() + ")");
         c2.put("compute", "c");
@@ -364,7 +364,7 @@ public class GuardProxyCatalogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testInvocationBlocking2() throws Exception {
-        Dictionary<String, Object> config = new Hashtable<String, Object>();
+        Dictionary<String, Object> config = new Hashtable<>();
         config.put(Constants.SERVICE_PID, "barfoobar");
         config.put("service.guard", "(objectClass=" + TestObjectWithoutInterface.class.getName() + ")");
         config.put("compute(long)[\"42\"]", "b");
@@ -408,11 +408,11 @@ public class GuardProxyCatalogTest {
             }
         };
 
-        Dictionary<String, Object> c1 = new Hashtable<String, Object>();
+        Dictionary<String, Object> c1 = new Hashtable<>();
         c1.put(Constants.SERVICE_PID, "foobar");
         c1.put("service.guard", "(objectClass=" + TestServiceAPI.class.getName() + ")");
         c1.put("do*", "c");
-        Dictionary<String, Object> c2 = new Hashtable<String, Object>();
+        Dictionary<String, Object> c2 = new Hashtable<>();
         c2.put(Constants.SERVICE_PID, "foobar2");
         c2.put("service.guard", "(objectClass=" + TestServiceAPI2.class.getName() + ")");
         c2.put("doit(java.lang.String)[/[tT][a]+/]", "b,d # a regex rule");
@@ -485,7 +485,7 @@ public class GuardProxyCatalogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testInvocationBlocking5() throws Exception {
-        Dictionary<String, Object> c1 = new Hashtable<String, Object>();
+        Dictionary<String, Object> c1 = new Hashtable<>();
         c1.put(Constants.SERVICE_PID, "foobar");
         c1.put("service.guard", "(objectClass=" + TestServiceAPI.class.getName() + ")");
         c1.put("doit", "a,b");
@@ -515,11 +515,11 @@ public class GuardProxyCatalogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testInvocationBlocking6() throws Exception {
-        Dictionary<String, Object> c1 = new Hashtable<String, Object>();
+        Dictionary<String, Object> c1 = new Hashtable<>();
         c1.put(Constants.SERVICE_PID, "foobar");
         c1.put("service.guard", "(objectClass=" + TestServiceAPI.class.getName() + ")");
         c1.put("doit", "a,b");
-        Dictionary<String, Object> c2 = new Hashtable<String, Object>();
+        Dictionary<String, Object> c2 = new Hashtable<>();
         c2.put(Constants.SERVICE_PID, "foobar2");
         c2.put("service.guard", "(objectClass=" + TestServiceAPI2.class.getName() + ")");
         c2.put("bar", "c");
@@ -555,7 +555,7 @@ public class GuardProxyCatalogTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testInvocationBlocking7() throws Exception {
-        Dictionary<String, Object> c1 = new Hashtable<String, Object>();
+        Dictionary<String, Object> c1 = new Hashtable<>();
         c1.put(Constants.SERVICE_PID, "foobar");
         c1.put("service.guard", "(objectClass=" + TestServiceAPI3.class.getName() + ")");
         c1.put("foo()", "a");
@@ -615,7 +615,7 @@ public class GuardProxyCatalogTest {
             }
         };
 
-        Dictionary<String, Object> c1 = new Hashtable<String, Object>();
+        Dictionary<String, Object> c1 = new Hashtable<>();
         c1.put(Constants.SERVICE_PID, "foobar");
         c1.put("service.guard", "(objectClass=" + TestServiceAPI.class.getName() + ")");
         c1.put("doit", MyRolePrincipal.class.getName() + ":role1");
@@ -711,16 +711,16 @@ public class GuardProxyCatalogTest {
         GuardProxyCatalog gpc = new GuardProxyCatalog(bc);
 
         // The service being proxied has these properties
-        final Hashtable<String, Object> serviceProps = new Hashtable<String, Object>();
+        final Hashtable<String, Object> serviceProps = new Hashtable<>();
         serviceProps.put(Constants.OBJECTCLASS, new String [] {TestServiceAPI.class.getName()});
         serviceProps.put(Constants.SERVICE_ID, 162L);
 
-        final Map<ServiceReference<?>, Object> serviceMap = new HashMap<ServiceReference<?>, Object>();
+        final Map<ServiceReference<?>, Object> serviceMap = new HashMap<>();
 
         // The mock bundle context for the bundle providing the service is set up here
         BundleContext providerBC = EasyMock.createMock(BundleContext.class);
         // These are the expected service properties of the proxy registration. Note the proxy marker...
-        final Hashtable<String, Object> expectedProxyProps = new Hashtable<String, Object>(serviceProps);
+        final Hashtable<String, Object> expectedProxyProps = new Hashtable<>(serviceProps);
         expectedProxyProps.put(GuardProxyCatalog.PROXY_SERVICE_KEY, Boolean.TRUE);
         EasyMock.expect(providerBC.registerService(
                 EasyMock.isA(String[].class),
@@ -834,11 +834,11 @@ public class GuardProxyCatalogTest {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test
     public void testHandleServiceModified() throws Exception {
-        Dictionary<String, Object> config = new Hashtable<String, Object>();
+        Dictionary<String, Object> config = new Hashtable<>();
         config.put(Constants.SERVICE_PID, "test.1.2.3");
         config.put("service.guard", "(objectClass=" + TestServiceAPI.class.getName() + ")");
         config.put("doit", "role.1");
-        Dictionary<String, Object> config2 = new Hashtable<String, Object>();
+        Dictionary<String, Object> config2 = new Hashtable<>();
         config2.put(Constants.SERVICE_PID, "test.1.2.4");
         config2.put("service.guard", "(objectClass=" + TestServiceAPI2.class.getName() + ")");
         config2.put("doit", "role.2");
@@ -847,7 +847,7 @@ public class GuardProxyCatalogTest {
         GuardProxyCatalog gpc = new GuardProxyCatalog(bc);
         // The service being proxied has these properties
         long serviceID = 1L;
-        final Hashtable<String, Object> serviceProps = new Hashtable<String, Object>();
+        final Hashtable<String, Object> serviceProps = new Hashtable<>();
         serviceProps.put(Constants.OBJECTCLASS, new String [] {TestServiceAPI.class.getName(), TestServiceAPI2.class.getName()});
         serviceProps.put(Constants.SERVICE_ID, serviceID);
         serviceProps.put(GuardProxyCatalog.SERVICE_GUARD_ROLES_PROPERTY, Arrays.asList("someone")); // will be overwritten
@@ -948,7 +948,7 @@ public class GuardProxyCatalogTest {
 
         // The service being proxied has these properties
         long serviceID = 1L;
-        final Hashtable<String, Object> serviceProps = new Hashtable<String, Object>();
+        final Hashtable<String, Object> serviceProps = new Hashtable<>();
         serviceProps.put(Constants.OBJECTCLASS, new String [] {TestServiceAPI.class.getName()});
         serviceProps.put(Constants.SERVICE_ID, serviceID);
 
@@ -1033,7 +1033,7 @@ public class GuardProxyCatalogTest {
     @Test
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void testServiceFactoryBehaviour() throws Exception {
-        final Map<ServiceReference, Object> serviceMap = new HashMap<ServiceReference, Object>();
+        final Map<ServiceReference, Object> serviceMap = new HashMap<>();
         TestServiceAPI testService = new TestService();
 
         BundleContext bc = mockConfigAdminBundleContext();
@@ -1041,7 +1041,7 @@ public class GuardProxyCatalogTest {
 
         // The service being proxied has these properties
         long serviceID = 117L;
-        final Hashtable<String, Object> serviceProps = new Hashtable<String, Object>();
+        final Hashtable<String, Object> serviceProps = new Hashtable<>();
         serviceProps.put(Constants.OBJECTCLASS, new String [] {TestServiceAPI.class.getName()});
         serviceProps.put(Constants.SERVICE_ID, serviceID);
         serviceProps.put("bar", 42L);
@@ -1145,17 +1145,17 @@ public class GuardProxyCatalogTest {
 
         // The service being proxied has these properties
         long serviceID = 456L;
-        final Hashtable<String, Object> serviceProps = new Hashtable<String, Object>();
+        final Hashtable<String, Object> serviceProps = new Hashtable<>();
         serviceProps.put(Constants.OBJECTCLASS, new String [] {intf.getName()});
         serviceProps.put(Constants.SERVICE_ID, serviceID);
         serviceProps.put(".foo", 123L);
 
-        final Map<ServiceReference<?>, Object> serviceMap = new HashMap<ServiceReference<?>, Object>();
+        final Map<ServiceReference<?>, Object> serviceMap = new HashMap<>();
 
         // The mock bundle context for the bundle providing the service is set up here
         BundleContext providerBC = EasyMock.createMock(BundleContext.class);
         // These are the expected service properties of the proxy registration. Note the proxy marker...
-        final Hashtable<String, Object> expectedProxyProps = new Hashtable<String, Object>(serviceProps);
+        final Hashtable<String, Object> expectedProxyProps = new Hashtable<>(serviceProps);
         expectedProxyProps.put(GuardProxyCatalog.PROXY_SERVICE_KEY, Boolean.TRUE);
         // This will check that the right proxy is being registered.
         EasyMock.expect(providerBC.registerService(
@@ -1258,12 +1258,12 @@ public class GuardProxyCatalogTest {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public Object testCreateProxy(Class<?> [] objectClasses, Object testService) throws Exception {
-        return testCreateProxy(mockConfigAdminBundleContext(), objectClasses, objectClasses, testService, new HashMap<ServiceReference, Object>());
+        return testCreateProxy(mockConfigAdminBundleContext(), objectClasses, objectClasses, testService, new HashMap<>());
     }
 
     @SuppressWarnings("rawtypes")
     public Object testCreateProxy(BundleContext bc, Class<?> [] objectClasses, Object testService) throws Exception {
-        return testCreateProxy(bc, objectClasses, objectClasses, testService, new HashMap<ServiceReference, Object>());
+        return testCreateProxy(bc, objectClasses, objectClasses, testService, new HashMap<>());
     }
 
     @SuppressWarnings("rawtypes")
@@ -1274,13 +1274,13 @@ public class GuardProxyCatalogTest {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public Object testCreateProxy(BundleContext bc, Class [] objectClasses, final Class [] proxyRegClasses, Object testService, final Map<ServiceReference, Object> serviceMap) throws Exception {
         // A linked hash map to keep iteration order over the keys predictable
-        final LinkedHashMap<String, Class> objClsMap = new LinkedHashMap<String, Class>();
+        final LinkedHashMap<String, Class> objClsMap = new LinkedHashMap<>();
         for (Class cls : objectClasses) {
             objClsMap.put(cls.getName(), cls);
         }
 
         // A linked hash map to keep iteration order over the keys predictable
-        final LinkedHashMap<String, Class> proxyRegClsMap = new LinkedHashMap<String, Class>();
+        final LinkedHashMap<String, Class> proxyRegClsMap = new LinkedHashMap<>();
         for (Class cls : proxyRegClasses) {
             proxyRegClsMap.put(cls.getName(), cls);
         }
@@ -1290,7 +1290,7 @@ public class GuardProxyCatalogTest {
 
         // The service being proxied has these properties
         long serviceID = Long.MAX_VALUE;
-        final Hashtable<String, Object> serviceProps = new Hashtable<String, Object>();
+        final Hashtable<String, Object> serviceProps = new Hashtable<>();
         serviceProps.put(Constants.OBJECTCLASS, objClsMap.keySet().toArray(new String [] {}));
         serviceProps.put(Constants.SERVICE_ID, serviceID);
         serviceProps.put(GuardProxyCatalog.SERVICE_GUARD_ROLES_PROPERTY, Arrays.asList("everyone")); // will be overwritten
@@ -1299,7 +1299,7 @@ public class GuardProxyCatalogTest {
         // The mock bundle context for the bundle providing the service is set up here
         BundleContext providerBC = EasyMock.createMock(BundleContext.class);
         // These are the expected service properties of the proxy registration. Note the proxy marker...
-        final Hashtable<String, Object> expectedProxyProps = new Hashtable<String, Object>(serviceProps);
+        final Hashtable<String, Object> expectedProxyProps = new Hashtable<>(serviceProps);
         expectedProxyProps.put(GuardProxyCatalog.PROXY_SERVICE_KEY, Boolean.TRUE);
         // This will check that the right proxy is being registered.
         EasyMock.expect(providerBC.registerService(
@@ -1421,7 +1421,7 @@ public class GuardProxyCatalogTest {
     }
 
     private Dictionary<String, Object> getServiceReferenceProperties(ServiceReference<?> sr) {
-        Dictionary<String, Object> dict = new Hashtable<String, Object>();
+        Dictionary<String, Object> dict = new Hashtable<>();
 
         for (String key : sr.getPropertyKeys()) {
             dict.put(key, sr.getProperty(key));

--- a/service/guard/src/test/java/org/apache/karaf/service/guard/impl/GuardingEventHookTest.java
+++ b/service/guard/src/test/java/org/apache/karaf/service/guard/impl/GuardingEventHookTest.java
@@ -49,7 +49,7 @@ public class GuardingEventHookTest {
     public void testEventHookEvents() throws Exception {
         BundleContext frameworkBC = mockBundleContext(0L);
 
-        Dictionary<String, Object> config = new Hashtable<String, Object>();
+        Dictionary<String, Object> config = new Hashtable<>();
         config.put("service.guard", "(service.id=*)");
         BundleContext hookBC = mockConfigAdminBundleContext(frameworkBC, config);
         GuardProxyCatalog gpc = new GuardProxyCatalog(hookBC);
@@ -57,13 +57,13 @@ public class GuardingEventHookTest {
         Filter serviceFilter = FrameworkUtil.createFilter("(foo=bar)");
         GuardingEventHook geh = new GuardingEventHook(hookBC, gpc, serviceFilter);
 
-        Dictionary<String, Object> props = new Hashtable<String, Object>();
+        Dictionary<String, Object> props = new Hashtable<>();
         props.put(Constants.SERVICE_ID, 13L);
         ServiceReference<?> sref = mockServiceReference(props);
 
         BundleContext client1BC = mockBundleContext(123L);
-        Map<BundleContext, Collection<ListenerInfo>> listeners = new HashMap<BundleContext, Collection<ListenerInfo>>();
-        listeners.put(client1BC, Collections.<ListenerInfo>emptyList());
+        Map<BundleContext, Collection<ListenerInfo>> listeners = new HashMap<>();
+        listeners.put(client1BC, Collections.emptyList());
 
         // Send the event. It should have no effect because the service doens't match the filter
         assertEquals("Precondition", 0, gpc.proxyMap.size());
@@ -72,7 +72,7 @@ public class GuardingEventHookTest {
         assertEquals("Nothing should have been removed from the listeners", 1, listeners.size());
 
         long service2ID = 887L;
-        Dictionary<String, Object> props2 = new Hashtable<String, Object>();
+        Dictionary<String, Object> props2 = new Hashtable<>();
         props2.put(Constants.SERVICE_ID, service2ID);
         props2.put("a", "b");
         props2.put("foo", "bar");
@@ -80,16 +80,16 @@ public class GuardingEventHookTest {
         ServiceEvent se2 = new ServiceEvent(ServiceEvent.REGISTERED, sref2);
 
         // Send the event to the system bundle and the bundle that contains the hook, should have no effect
-        Map<BundleContext, Collection<ListenerInfo>> listeners2 = new Hashtable<BundleContext, Collection<ListenerInfo>>();
-        listeners2.put(frameworkBC, Collections.<ListenerInfo>emptyList());
-        listeners2.put(hookBC, Collections.<ListenerInfo>emptyList());
+        Map<BundleContext, Collection<ListenerInfo>> listeners2 = new Hashtable<>();
+        listeners2.put(frameworkBC, Collections.emptyList());
+        listeners2.put(hookBC, Collections.emptyList());
         geh.event(se2, listeners2);
         assertEquals("No proxies to be created for the hook bundle or the system bundle", 0, gpc.proxyMap.size());
         assertEquals("Nothing should have been removed from the listeners", 2, listeners2.size());
 
         // This is the first time that a proxy actually does get created
-        Map<BundleContext, Collection<ListenerInfo>> listeners3 = new HashMap<BundleContext, Collection<ListenerInfo>>();
-        listeners3.put(client1BC, Collections.<ListenerInfo>emptyList());
+        Map<BundleContext, Collection<ListenerInfo>> listeners3 = new HashMap<>();
+        listeners3.put(client1BC, Collections.emptyList());
         geh.event(se2, listeners3);
         assertEquals("The service should be hidden from these listeners", 0, listeners3.size());
         assertEquals("Proxy should have been created for this client", 1, gpc.proxyMap.size());
@@ -97,26 +97,26 @@ public class GuardingEventHookTest {
 
         // Update the service, now an additional client is interested
         props2.put("a", "c"); // Will change the properties of sref
-        Map<BundleContext, Collection<ListenerInfo>> listeners4 = new HashMap<BundleContext, Collection<ListenerInfo>>();
+        Map<BundleContext, Collection<ListenerInfo>> listeners4 = new HashMap<>();
 
         BundleContext client2BC = mockBundleContext(11);
-        listeners4.put(client2BC, Collections.<ListenerInfo>emptyList());
-        listeners4.put(client1BC, Collections.<ListenerInfo>emptyList());
+        listeners4.put(client2BC, Collections.emptyList());
+        listeners4.put(client1BC, Collections.emptyList());
         geh.event(new ServiceEvent(ServiceEvent.MODIFIED, sref2), listeners4);
         assertEquals("The service should be hidden from these listeners", 0, listeners4.size());
         assertEquals("There should not be an additional proxy for client 2", 1, gpc.proxyMap.size());
         assertNotNull(gpc.proxyMap.get(service2ID));
 
         long service3ID = 1L;
-        Dictionary<String, Object> props3 = new Hashtable<String, Object>();
+        Dictionary<String, Object> props3 = new Hashtable<>();
         props3.put(Constants.SERVICE_ID, service3ID);
         props3.put("foo", "bar");
         ServiceReference<?> sref3 = mockServiceReference(props3);
 
         // An event for a new service
-        Map<BundleContext, Collection<ListenerInfo>> listeners5 = new HashMap<BundleContext, Collection<ListenerInfo>>();
-        listeners5.put(client1BC, Collections.<ListenerInfo>emptyList());
-        listeners5.put(client1BC, Collections.<ListenerInfo>emptyList()); // Should be ignored
+        Map<BundleContext, Collection<ListenerInfo>> listeners5 = new HashMap<>();
+        listeners5.put(client1BC, Collections.emptyList());
+        listeners5.put(client1BC, Collections.emptyList()); // Should be ignored
         geh.event(new ServiceEvent(ServiceEvent.REGISTERED, sref3), listeners5);
         assertEquals("There should be an additional procy for client1 to the new service", 2, gpc.proxyMap.size());
         assertEquals("The service should be hidden from these listeners", 0, listeners5.size());
@@ -129,7 +129,7 @@ public class GuardingEventHookTest {
     public void testEventHookProxyEvents() throws Exception {
         BundleContext frameworkBC = mockBundleContext(0L);
 
-        Dictionary<String, Object> config = new Hashtable<String, Object>();
+        Dictionary<String, Object> config = new Hashtable<>();
         config.put("service.guard", "(service.id=*)");
         BundleContext hookBC = mockConfigAdminBundleContext(frameworkBC, config);
         GuardProxyCatalog gpc = new GuardProxyCatalog(hookBC);
@@ -140,12 +140,12 @@ public class GuardingEventHookTest {
         BundleContext client1BC = mockBundleContext(123L);
 
         // Create a proxy service mock
-        Dictionary<String, Object> props = new Hashtable<String, Object>();
+        Dictionary<String, Object> props = new Hashtable<>();
         props.put(Constants.SERVICE_ID, 13L);
         props.put(GuardProxyCatalog.PROXY_SERVICE_KEY, Boolean.TRUE);
         ServiceReference<?> sref = mockServiceReference(props);
-        Map<BundleContext, Collection<ListenerInfo>> listeners = new HashMap<BundleContext, Collection<ListenerInfo>>();
-        listeners.put(client1BC, Collections.<ListenerInfo>emptyList());
+        Map<BundleContext, Collection<ListenerInfo>> listeners = new HashMap<>();
+        listeners.put(client1BC, Collections.emptyList());
 
         // Send the event. It should have no effect because the service is already a proxy for the client
         assertEquals("Precondition", 0, gpc.proxyMap.size());
@@ -154,8 +154,8 @@ public class GuardingEventHookTest {
         assertEquals("The event should be delivered to the client", 1, listeners.size());
 
         // send the event to a different client, this client should also see the event as the proxy Service Factory is shared
-        Map<BundleContext, Collection<ListenerInfo>> listeners2 = new HashMap<BundleContext, Collection<ListenerInfo>>();
-        listeners2.put(mockBundleContext(51L), Collections.<ListenerInfo>emptyList());
+        Map<BundleContext, Collection<ListenerInfo>> listeners2 = new HashMap<>();
+        listeners2.put(mockBundleContext(51L), Collections.emptyList());
         geh.event(new ServiceEvent(ServiceEvent.REGISTERED, sref), listeners2);
         assertEquals("No changes expected for the proxy map.", 0, gpc.proxyMap.size());
         assertEquals("The event should be delivered to the client", 1, listeners2.size());

--- a/service/guard/src/test/java/org/apache/karaf/service/guard/impl/GuardingFindHookTest.java
+++ b/service/guard/src/test/java/org/apache/karaf/service/guard/impl/GuardingFindHookTest.java
@@ -43,7 +43,7 @@ public class GuardingFindHookTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testFindHook() throws Exception {
-        Dictionary<String, Object> config = new Hashtable<String, Object>();
+        Dictionary<String, Object> config = new Hashtable<>();
         config.put("service.guard", "(|(moo=foo)(foo=*))");
 
         BundleContext hookBC = mockConfigAdminBundleContext(config);
@@ -54,12 +54,12 @@ public class GuardingFindHookTest {
 
         BundleContext clientBC = mockBundleContext(31L);
 
-        Dictionary<String, Object> props = new Hashtable<String, Object>();
+        Dictionary<String, Object> props = new Hashtable<>();
         props.put(Constants.SERVICE_ID, 16L);
         props.put("moo", "foo");
         ServiceReference<?> sref = mockServiceReference(props);
 
-        Collection<ServiceReference<?>> refs = new ArrayList<ServiceReference<?>>();
+        Collection<ServiceReference<?>> refs = new ArrayList<>();
         refs.add(sref);
 
         assertEquals("Precondition", 0, gpc.proxyMap.size());
@@ -69,12 +69,12 @@ public class GuardingFindHookTest {
                 Collections.singletonList(sref), refs);
 
         long service2ID = 17L;
-        Dictionary<String, Object> props2 = new Hashtable<String, Object>();
+        Dictionary<String, Object> props2 = new Hashtable<>();
         props2.put(Constants.SERVICE_ID, service2ID);
         props2.put("foo", new Object());
         ServiceReference<?> sref2 = mockServiceReference(props2);
 
-        Collection<ServiceReference<?>> refs2 = new ArrayList<ServiceReference<?>>();
+        Collection<ServiceReference<?>> refs2 = new ArrayList<>();
         refs2.add(sref2);
 
         gfh.find(clientBC, null, null, true, refs2);
@@ -83,7 +83,7 @@ public class GuardingFindHookTest {
         assertEquals("A proxy creation job should have been created", 1, gpc.createProxyQueue.size());
         assertEquals(sref2.getProperty(Constants.SERVICE_ID), gpc.proxyMap.keySet().iterator().next());
 
-        Collection<ServiceReference<?>> refs3 = new ArrayList<ServiceReference<?>>();
+        Collection<ServiceReference<?>> refs3 = new ArrayList<>();
         refs3.add(sref2);
 
         // Ensure that the hook bundle has nothing hidden
@@ -106,7 +106,7 @@ public class GuardingFindHookTest {
         assertEquals("No additional jobs should have been scheduled", 0, gpc.createProxyQueue.size());
         assertEquals("No change expected", sref2.getProperty(Constants.SERVICE_ID), gpc.proxyMap.keySet().iterator().next());
 
-        Collection<ServiceReference<?>> refs4 = new ArrayList<ServiceReference<?>>();
+        Collection<ServiceReference<?>> refs4 = new ArrayList<>();
         refs4.add(sref2);
 
         // another client should not get another proxy
@@ -121,7 +121,7 @@ public class GuardingFindHookTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testFindHookProxyServices() throws Exception {
-        Dictionary<String, Object> config = new Hashtable<String, Object>();
+        Dictionary<String, Object> config = new Hashtable<>();
         config.put("service.guard", "(service.id=*)");
 
         BundleContext hookBC = mockConfigAdminBundleContext(config);
@@ -132,12 +132,12 @@ public class GuardingFindHookTest {
 
         BundleContext clientBC = mockBundleContext(31L);
 
-        Dictionary<String, Object> props = new Hashtable<String, Object>();
+        Dictionary<String, Object> props = new Hashtable<>();
         props.put(Constants.SERVICE_ID, 16L);
         props.put(GuardProxyCatalog.PROXY_SERVICE_KEY, Boolean.TRUE);
         ServiceReference<?> sref = mockServiceReference(props);
 
-        Collection<ServiceReference<?>> refs = new ArrayList<ServiceReference<?>>();
+        Collection<ServiceReference<?>> refs = new ArrayList<>();
         refs.add(sref);
         gfh.find(clientBC, null, null, false, refs);
         assertEquals("No proxy should have been created for the proxy find", 0, gpc.proxyMap.size());

--- a/service/guard/src/test/java/org/apache/karaf/service/guard/tools/ACLConfigurationParserTest.java
+++ b/service/guard/src/test/java/org/apache/karaf/service/guard/tools/ACLConfigurationParserTest.java
@@ -41,7 +41,7 @@ public class ACLConfigurationParserTest {
 
     @Test
     public void testGetRolesForInvocation() {
-        Dictionary<String, Object> config = new Hashtable<String, Object>();
+        Dictionary<String, Object> config = new Hashtable<>();
         config.put("foo", "r1, r2");
         config.put("bar(java.lang.String, int)[/aa/,/42/]", "ra");
         config.put("bar(java.lang.String, int)[/bb/,/42/]", "rb");
@@ -51,52 +51,52 @@ public class ACLConfigurationParserTest {
         config.put("bar", "rf");
         config.put("ba*", "rg #Wildcard");
 
-        List<String> roles1 = new ArrayList<String>();
+        List<String> roles1 = new ArrayList<>();
         assertEquals(Specificity.NAME_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("foo", new Object [] {}, new String [] {}, config, roles1));
         assertEquals(Arrays.asList("r1", "r2"), roles1);
 
-        List<String> roles2 = new ArrayList<String>();
+        List<String> roles2 = new ArrayList<>();
         assertEquals(Specificity.NAME_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("foo", new Object [] {"test"}, new String [] {"java.lang.String"}, config, roles2));
         assertEquals(Arrays.asList("r1", "r2"), roles2);
 
-        List<String> roles3 = new ArrayList<String>();
+        List<String> roles3 = new ArrayList<>();
         assertEquals(Specificity.NO_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("test", new Object [] {}, new String [] {}, config, roles3));
         assertEquals(0, roles3.size());
 
-        List<String> roles4 = new ArrayList<String>();
+        List<String> roles4 = new ArrayList<>();
         assertEquals(Specificity.ARGUMENT_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("bar", new Object [] {"aa", 42}, new String [] {"java.lang.String", "int"}, config, roles4));
         assertEquals(Arrays.asList("ra"), roles4);
 
-        List<String> roles5 = new ArrayList<String>();
+        List<String> roles5 = new ArrayList<>();
         assertEquals(Specificity.ARGUMENT_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("bar", new Object [] {"bb", 42}, new String [] {"java.lang.String", "int"}, config, roles5));
         assertEquals(Arrays.asList("rb"), roles5);
 
-        List<String> roles6 = new ArrayList<String>();
+        List<String> roles6 = new ArrayList<>();
         assertEquals(Specificity.ARGUMENT_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("bar", new Object [] {"cc", 17}, new String [] {"java.lang.String", "int"}, config, roles6));
         assertEquals(Arrays.asList("rc"), roles6);
 
-        List<String> roles7 = new ArrayList<String>();
+        List<String> roles7 = new ArrayList<>();
         assertEquals(Specificity.SIGNATURE_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("bar", new Object [] {"aaa", 42}, new String [] {"java.lang.String", "int"}, config, roles7));
         assertEquals(Arrays.asList("rd"), roles7);
 
-        List<String> roles8 = new ArrayList<String>();
+        List<String> roles8 = new ArrayList<>();
         assertEquals(Specificity.SIGNATURE_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("bar", new Object [] {"aa"}, new String [] {"java.lang.String"}, config, roles8));
         assertEquals(Arrays.asList("re"), roles8);
 
-        List<String> roles9 = new ArrayList<String>();
+        List<String> roles9 = new ArrayList<>();
         assertEquals(Specificity.NAME_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("bar", new Object [] {42}, new String [] {"int"}, config, roles9));
         assertEquals(Arrays.asList("rf"), roles9);
 
-        List<String> roles10 = new ArrayList<String>();
+        List<String> roles10 = new ArrayList<>();
         assertEquals(Specificity.WILDCARD_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("barr", new Object [] {42}, new String [] {"int"}, config, roles10));
         assertEquals(Arrays.asList("rg"), roles10);

--- a/services/eventadmin/src/main/java/org/apache/felix/eventadmin/impl/Configuration.java
+++ b/services/eventadmin/src/main/java/org/apache/felix/eventadmin/impl/Configuration.java
@@ -179,7 +179,7 @@ public class Configuration
                     interfaceNames = new String[] {ManagedService.class.getName(), MetaTypeProvider.class.getName()};
                     service = enhancedService;
                 }
-                Dictionary<String, Object> props = new Hashtable<String, Object>();
+                Dictionary<String, Object> props = new Hashtable<>();
                 props.put( Constants.SERVICE_PID, PID );
                 m_managedServiceReg = m_bundleContext.registerService( interfaceNames, service, props );
             }

--- a/services/eventadmin/src/main/java/org/apache/felix/eventadmin/impl/handler/EventAdminImpl.java
+++ b/services/eventadmin/src/main/java/org/apache/felix/eventadmin/impl/handler/EventAdminImpl.java
@@ -148,7 +148,7 @@ public class EventAdminImpl implements EventAdmin
         }
         if (needTimeStamp || needSubject) {
             String[] names = event.getPropertyNames();
-            HashMap<String, Object> map = new HashMap<String, Object>(names.length + 1);
+            HashMap<String, Object> map = new HashMap<>(names.length + 1);
             for (int i = 0; i < names.length; i++) {
                 if (!EventConstants.EVENT_TOPIC.equals(names[i])) {
                     map.put(names[i], event.getProperty(names[i]));

--- a/services/staticcm/src/main/java/org/apache/karaf/services/staticcm/Configurations.java
+++ b/services/staticcm/src/main/java/org/apache/karaf/services/staticcm/Configurations.java
@@ -72,7 +72,7 @@ public class Configurations {
             Map<String, String> cfg = entry.getValue();
             InterpolationHelper.performSubstitution(cfg, context);
             cfg.put(Constants.SERVICE_PID, pid[0]);
-            configurations.add(new StaticConfigurationImpl(pid[0], pid[1], new Hashtable<String, Object>(cfg)));
+            configurations.add(new StaticConfigurationImpl(pid[0], pid[1], new Hashtable<>(cfg)));
         }
         return configurations;
     }

--- a/shell/commands/src/main/java/org/apache/karaf/shell/commands/impl/InfoAction.java
+++ b/shell/commands/src/main/java/org/apache/karaf/shell/commands/impl/InfoAction.java
@@ -127,7 +127,7 @@ public class InfoAction implements Action {
         }
 
         //Display Information from external information providers.
-        Map<String, Map<Object, Object>> properties = new HashMap<String, Map<Object, Object>>();
+        Map<String, Map<Object, Object>> properties = new HashMap<>();
         if (infoProviders != null) {
             // dump all properties to Map, KARAF-425
             for (InfoProvider provider : infoProviders) {
@@ -137,10 +137,10 @@ public class InfoAction implements Action {
                 properties.get(provider.getName()).putAll(provider.getProperties());
             }
 
-            List<String> sections = new ArrayList<String>(properties.keySet());
+            List<String> sections = new ArrayList<>(properties.keySet());
             Collections.sort(sections);
             for (String section : sections) {
-                List<Object> keys = new ArrayList<Object>(properties.get(section).keySet());
+                List<Object> keys = new ArrayList<>(properties.get(section).keySet());
                 if (keys.size() > 0) {
                     System.out.println(section);
 

--- a/shell/commands/src/main/java/org/apache/karaf/shell/commands/impl/ThreadsAction.java
+++ b/shell/commands/src/main/java/org/apache/karaf/shell/commands/impl/ThreadsAction.java
@@ -71,7 +71,7 @@ public class ThreadsAction implements Action {
 
     @Override
     public Object execute() throws Exception {
-        Map<Long, ThreadInfo> threadInfos = new TreeMap<Long, ThreadInfo>();
+        Map<Long, ThreadInfo> threadInfos = new TreeMap<>();
         ThreadMXBean threadsBean = ManagementFactory.getThreadMXBean();
         ThreadInfo[] infos;
         if (threadsBean.isObjectMonitorUsageSupported() && threadsBean.isSynchronizerUsageSupported()) {
@@ -139,7 +139,7 @@ public class ThreadsAction implements Action {
                     break;
                 }
             }
-            groups = new ArrayList<ThreadGroupData>();
+            groups = new ArrayList<>();
             for (ThreadGroup tg : childGroups) {
                 if (tg != null) {
                     groups.add(new ThreadGroupData(tg, infos));
@@ -154,7 +154,7 @@ public class ThreadsAction implements Action {
                     break;
                 }
             }
-            threads = new ArrayList<ThreadData>();
+            threads = new ArrayList<>();
             for (Thread t : childThreads) {
                 if (t != null) {
                     threads.add(new ThreadData(t, infos.get(t.getId())));

--- a/shell/commands/src/main/java/org/apache/karaf/shell/commands/impl/info/Activator.java
+++ b/shell/commands/src/main/java/org/apache/karaf/shell/commands/impl/info/Activator.java
@@ -29,7 +29,7 @@ public class Activator implements BundleActivator {
 
     @Override
     public void start(BundleContext context) throws Exception {
-        tracker = new BundleTracker<ServiceRegistration<InfoProvider>>(context, Bundle.ACTIVE, new InfoBundleTrackerCustomizer());
+        tracker = new BundleTracker<>(context, Bundle.ACTIVE, new InfoBundleTrackerCustomizer());
         tracker.open();
     }
 

--- a/shell/console/src/main/java/jline/console/completer/StringsCompleter.java
+++ b/shell/console/src/main/java/jline/console/completer/StringsCompleter.java
@@ -25,7 +25,7 @@ import static jline.internal.Preconditions.checkNotNull;
 public class StringsCompleter
         implements Completer
 {
-    private final SortedSet<String> strings = new TreeSet<String>();
+    private final SortedSet<String> strings = new TreeSet<>();
 
     public StringsCompleter() {
         // empty

--- a/shell/console/src/main/java/org/apache/felix/gogo/commands/basic/DefaultActionPreparator.java
+++ b/shell/console/src/main/java/org/apache/felix/gogo/commands/basic/DefaultActionPreparator.java
@@ -80,9 +80,9 @@ public class DefaultActionPreparator implements ActionPreparator {
     };
 
     public boolean prepare(Action action, CommandSession session, List<Object> params) throws Exception {
-        Map<Option, Field> options = new HashMap<Option, Field>();
-        Map<Argument, Field> arguments = new HashMap<Argument, Field>();
-        List<Argument> orderedArguments = new ArrayList<Argument>();
+        Map<Option, Field> options = new HashMap<>();
+        Map<Argument, Field> arguments = new HashMap<>();
+        List<Argument> orderedArguments = new ArrayList<>();
         // Introspect
         for (Class type = action.getClass(); type != null; type = type.getSuperclass()) {
             for (Field field : type.getDeclaredFields()) {
@@ -144,8 +144,8 @@ public class DefaultActionPreparator implements ActionPreparator {
             }
         }
         // Populate
-        Map<Option, Object> optionValues = new HashMap<Option, Object>();
-        Map<Argument, Object> argumentValues = new HashMap<Argument, Object>();
+        Map<Option, Object> optionValues = new HashMap<>();
+        Map<Argument, Object> argumentValues = new HashMap<>();
         boolean processOptions = true;
         int argIndex = 0;
         for (Iterator<Object> it = params.iterator(); it.hasNext(); ) {
@@ -214,7 +214,7 @@ public class DefaultActionPreparator implements ActionPreparator {
                 if (option.multiValued()) {
                     List<Object> l = (List<Object>) optionValues.get(option);
                     if (l == null) {
-                        l = new ArrayList<Object>();
+                        l = new ArrayList<>();
                         optionValues.put(option, l);
                     }
                     l.add(value);
@@ -246,7 +246,7 @@ public class DefaultActionPreparator implements ActionPreparator {
                 if (argument.multiValued()) {
                     List<Object> l = (List<Object>) argumentValues.get(argument);
                     if (l == null) {
-                        l = new ArrayList<Object>();
+                        l = new ArrayList<>();
                         argumentValues.put(argument, l);
                     }
                     l.add(param);
@@ -362,13 +362,13 @@ public class DefaultActionPreparator implements ActionPreparator {
         Command command = action.getClass().getAnnotation(Command.class);
         if (command != null) {
             
-            List<Argument> arguments = new ArrayList<Argument>(argsMap.keySet());
+            List<Argument> arguments = new ArrayList<>(argsMap.keySet());
             Collections.sort(arguments, new Comparator<Argument>() {
                 public int compare(Argument o1, Argument o2) {
                     return Integer.valueOf(o1.index()).compareTo(Integer.valueOf(o2.index()));
                 }
             });
-            Set<Option> options = new HashSet<Option>(optionsMap.keySet());
+            Set<Option> options = new HashSet<>(optionsMap.keySet());
             options.add(HELP);
             boolean globalScope = NameScoping.isGlobalScope(session, command.scope());
             if (command != null && (command.description() != null || command.name() != null)) {

--- a/shell/console/src/main/java/org/apache/felix/gogo/commands/converter/DefaultConverter.java
+++ b/shell/console/src/main/java/org/apache/felix/gogo/commands/converter/DefaultConverter.java
@@ -384,7 +384,7 @@ public class DefaultConverter {
     private static final Map<Class, Class> primitives;
 
     static {
-        primitives = new HashMap<Class, Class>();
+        primitives = new HashMap<>();
         primitives.put(byte.class, Byte.class);
         primitives.put(short.class, Short.class);
         primitives.put(char.class, Character.class);

--- a/shell/console/src/main/java/org/apache/felix/gogo/commands/converter/GenericType.java
+++ b/shell/console/src/main/java/org/apache/felix/gogo/commands/converter/GenericType.java
@@ -34,7 +34,7 @@ public class GenericType extends ReifiedType {
 
     private static final GenericType[] EMPTY = new GenericType[0];
 
-    private static final Map<String, Class> primitiveClasses = new HashMap<String, Class>();
+    private static final Map<String, Class> primitiveClasses = new HashMap<>();
 
     static {
         primitiveClasses.put("int", int.class);

--- a/shell/console/src/main/java/org/apache/karaf/shell/commands/basic/SimpleCommand.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/commands/basic/SimpleCommand.java
@@ -71,7 +71,7 @@ public class SimpleCommand extends AbstractCommand {
         {
             throw new IllegalArgumentException("Action class is not annotated with @Command");
         }
-        Hashtable<String, String> props = new Hashtable<String, String>();
+        Hashtable<String, String> props = new Hashtable<>();
         props.put("osgi.command.scope", cmd.scope());
         props.put("osgi.command.function", cmd.name());
         SimpleCommand command = new SimpleCommand(actionClass);

--- a/shell/console/src/main/java/org/apache/karaf/shell/commands/converter/DefaultConverter.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/commands/converter/DefaultConverter.java
@@ -384,7 +384,7 @@ public class DefaultConverter
 
     private static final Map<Class, Class> primitives;
     static {
-        primitives = new HashMap<Class, Class>();
+        primitives = new HashMap<>();
         primitives.put(byte.class, Byte.class);
         primitives.put(short.class, Short.class);
         primitives.put(char.class, Character.class);

--- a/shell/console/src/main/java/org/apache/karaf/shell/commands/converter/GenericType.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/commands/converter/GenericType.java
@@ -34,7 +34,7 @@ public class GenericType extends ReifiedType {
 
 	private static final GenericType[] EMPTY = new GenericType[0];
 
-    private static final Map<String, Class> primitiveClasses = new HashMap<String, Class>();
+    private static final Map<String, Class> primitiveClasses = new HashMap<>();
 
     static {
         primitiveClasses.put("int", int.class);

--- a/shell/console/src/main/java/org/apache/karaf/shell/commands/meta/ActionMetaData.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/commands/meta/ActionMetaData.java
@@ -92,13 +92,13 @@ public class ActionMetaData {
 
     public void printUsage(Action action, PrintStream out, boolean globalScope, int termWidth) {
         if (command != null) {
-            List<Argument> argumentsSet = new ArrayList<Argument>(arguments.keySet());
+            List<Argument> argumentsSet = new ArrayList<>(arguments.keySet());
             Collections.sort(argumentsSet, new Comparator<Argument>() {
                 public int compare(Argument o1, Argument o2) {
                     return Integer.valueOf(o1.index()).compareTo(Integer.valueOf(o2.index()));
                 }
             });
-            Set<Option> optionsSet = new HashSet<Option>(options.keySet());
+            Set<Option> optionsSet = new HashSet<>(options.keySet());
             optionsSet.add(HelpOption.HELP);
             if (command != null && (command.description() != null || command.name() != null)) {
                 out.println(INTENSITY_BOLD + "DESCRIPTION" + INTENSITY_NORMAL);

--- a/shell/console/src/main/java/org/apache/karaf/shell/commands/meta/ActionMetaDataFactory.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/commands/meta/ActionMetaDataFactory.java
@@ -34,9 +34,9 @@ public class ActionMetaDataFactory {
 
     public ActionMetaData create(Class<? extends Action> actionClass) {
         Command command = getCommand(actionClass);
-        Map<Option, Field> options = new HashMap<Option, Field>();
-        Map<Argument, Field> arguments = new HashMap<Argument, Field>();
-        List<Argument> orderedArguments = new ArrayList<Argument>();
+        Map<Option, Field> options = new HashMap<>();
+        Map<Argument, Field> arguments = new HashMap<>();
+        List<Argument> orderedArguments = new ArrayList<>();
 
         for (Class<?> type = actionClass; type != null; type = type.getSuperclass()) {
             for (Field field : type.getDeclaredFields()) {

--- a/shell/console/src/main/java/org/apache/karaf/shell/compat/ArgumentCompleter.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/compat/ArgumentCompleter.java
@@ -69,9 +69,9 @@ public class ArgumentCompleter {
     final List<Completer> argsCompleters;
     final Map<String, Completer> optionalCompleters;
     final CommandWithAction function;
-    final Map<Option, Field> fields = new HashMap<Option, Field>();
-    final Map<String, Option> options = new HashMap<String, Option>();
-    final Map<Integer, Field> arguments = new HashMap<Integer, Field>();
+    final Map<Option, Field> fields = new HashMap<>();
+    final Map<String, Option> options = new HashMap<>();
+    final Map<Integer, Field> arguments = new HashMap<>();
     boolean strict = true;
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -118,7 +118,7 @@ public class ArgumentCompleter {
             Map<String, Completer> focl = ((CompletableFunction) function).getOptionalCompleters();
             List<Completer> fcl = ((CompletableFunction) function).getCompleters();
             if (focl != null || fcl != null) {
-                argsCompleters = new ArrayList<Completer>();
+                argsCompleters = new ArrayList<>();
                 if (fcl != null) {
                     for (Completer c : fcl) {
                         argsCompleters.add(c == null ? NullCompleter.INSTANCE : c);
@@ -129,7 +129,7 @@ public class ArgumentCompleter {
         }
         if (argsCompleters == null) {
             final Map<Integer, Object> values = getCompleterValues(function);
-            argsCompleters = new ArrayList<Completer>();
+            argsCompleters = new ArrayList<>();
             boolean multi = false;
             for (int key = 0; key < arguments.size(); key++) {
                 Completer completer = null;
@@ -170,7 +170,7 @@ public class ArgumentCompleter {
             if (argsCompleters.isEmpty() || !multi) {
                 argsCompleters.add(NullCompleter.INSTANCE);
             }
-            optionalCompleters = new HashMap<String, Completer>();
+            optionalCompleters = new HashMap<>();
             for (Option option : fields.keySet()) {
                 Completer completer = null;
                 Field field = fields.get(option);
@@ -205,7 +205,7 @@ public class ArgumentCompleter {
     }
 
     private Map<Integer, Object> getCompleterValues(CommandWithAction function) {
-        final Map<Integer, Object> values = new HashMap<Integer, Object>();
+        final Map<Integer, Object> values = new HashMap<>();
         Action action = null;
         try {
             for (Class<?> type = function.getActionClass(); type != null; type = type.getSuperclass()) {
@@ -263,7 +263,7 @@ public class ArgumentCompleter {
         } else if (type.isAssignableFrom(Boolean.class) || type.isAssignableFrom(boolean.class)) {
             completer = new StringsCompleter(new String[] {"false", "true"}, false);
         } else if (type.isAssignableFrom(Enum.class)) {
-            Set<String> values = new HashSet<String>();
+            Set<String> values = new HashSet<>();
             for (Object o : EnumSet.allOf((Class<Enum>) type)) {
                 values.add(o.toString());
             }
@@ -425,7 +425,7 @@ public class ArgumentCompleter {
     }
 
     protected boolean verifyCompleter(Completer completer, String argument) {
-        List<String> candidates = new ArrayList<String>();
+        List<String> candidates = new ArrayList<>();
         return completer.complete(argument, argument.length(), candidates) != -1 && !candidates.isEmpty();
     }
 

--- a/shell/console/src/main/java/org/apache/karaf/shell/compat/CommandTracker.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/compat/CommandTracker.java
@@ -55,7 +55,7 @@ public class CommandTracker implements ServiceTrackerCustomizer<Object, Object> 
                 CommandProcessor.COMMAND_SCOPE, CommandProcessor.COMMAND_FUNCTION,
                 Constants.OBJECTCLASS, CommandWithAction.class.getName(),
                 Constants.OBJECTCLASS, org.apache.felix.gogo.commands.CommandWithAction.class.getName()));
-        this.tracker = new ServiceTracker<Object, Object>(context, filter, this);
+        this.tracker = new ServiceTracker<>(context, filter, this);
         this.tracker.open();
     }
 

--- a/shell/console/src/main/java/org/apache/karaf/shell/compat/OldArgumentCompleter.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/compat/OldArgumentCompleter.java
@@ -62,9 +62,9 @@ public class OldArgumentCompleter {
     final List<Completer> argsCompleters;
     final Map<String, Completer> optionalCompleters;
     final CommandWithAction function;
-    final Map<Option, Field> fields = new HashMap<Option, Field>();
-    final Map<String, Option> options = new HashMap<String, Option>();
-    final Map<Integer, Field> arguments = new HashMap<Integer, Field>();
+    final Map<Option, Field> fields = new HashMap<>();
+    final Map<String, Option> options = new HashMap<>();
+    final Map<Integer, Field> arguments = new HashMap<>();
     boolean strict = true;
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -103,7 +103,7 @@ public class OldArgumentCompleter {
 //        options.put(HelpOption.HELP.name(), HelpOption.HELP);
         optionsCompleter = new StringsCompleter(options.keySet());
         // Build arguments completers
-        argsCompleters = new ArrayList<Completer>();
+        argsCompleters = new ArrayList<>();
 
         if (function instanceof CompletableFunction) {
             Map<String, Completer> opt;
@@ -111,7 +111,7 @@ public class OldArgumentCompleter {
                 //
                 opt = ((CompletableFunction) function).getOptionalCompleters();
             } catch (Throwable t) {
-                opt = new HashMap<String, Completer>();
+                opt = new HashMap<>();
             }
             optionalCompleters = opt;
             List<Completer> fcl = ((CompletableFunction) function).getCompleters();
@@ -123,8 +123,8 @@ public class OldArgumentCompleter {
                 argsCompleters.add(NullCompleter.INSTANCE);
             }
         } else {
-            optionalCompleters = new HashMap<String, Completer>();
-            final Map<Integer, Method> methods = new HashMap<Integer, Method>();
+            optionalCompleters = new HashMap<>();
+            final Map<Integer, Method> methods = new HashMap<>();
             for (Class<?> type = function.getActionClass(); type != null; type = type.getSuperclass()) {
                 for (Method method : type.getDeclaredMethods()) {
                     CompleterValues completerMethod = method.getAnnotation(CompleterValues.class);
@@ -180,7 +180,7 @@ public class OldArgumentCompleter {
                     } else if (type.isAssignableFrom(Boolean.class) || type.isAssignableFrom(boolean.class)) {
                         argCompleter = new StringsCompleter(new String[] {"false", "true"}, false);
                     } else if (type.isAssignableFrom(Enum.class)) {
-                        Set<String> values = new HashSet<String>();
+                        Set<String> values = new HashSet<>();
                         for (Object o : EnumSet.allOf((Class<Enum>) type)) {
                             values.add(o.toString());
                         }
@@ -355,7 +355,7 @@ public class OldArgumentCompleter {
     }
 
     protected boolean verifyCompleter(Completer completer, String argument) {
-        List<String> candidates = new ArrayList<String>();
+        List<String> candidates = new ArrayList<>();
         return completer.complete(argument, argument.length(), candidates) != -1 && !candidates.isEmpty();
     }
 

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/CommandSessionHolder.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/CommandSessionHolder.java
@@ -23,7 +23,7 @@ import org.apache.felix.service.command.CommandSession;
 @Deprecated
 public class CommandSessionHolder {
 
-    private static final ThreadLocal<CommandSession> session = new ThreadLocal<CommandSession>();
+    private static final ThreadLocal<CommandSession> session = new ThreadLocal<>();
 
     public static CommandSession getSession() {
         return session.get();

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/MultiException.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/MultiException.java
@@ -25,7 +25,7 @@ import java.util.List;
 @Deprecated
 public class MultiException extends Exception {
 
-    private List<Exception> exceptions = new ArrayList<Exception>();
+    private List<Exception> exceptions = new ArrayList<>();
 
     public MultiException(String message) {
         super(message);

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/OsgiCommandSupport.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/OsgiCommandSupport.java
@@ -63,7 +63,7 @@ public abstract class OsgiCommandSupport extends AbstractAction implements Actio
 
     protected <T> List<T> getAllServices(Class<T> clazz, String filter) throws InvalidSyntaxException {
         Collection<ServiceReference<T>> references = getBundleContext().getServiceReferences(clazz, filter);
-        List<T> services = new ArrayList<T>();
+        List<T> services = new ArrayList<>();
         if (references != null) {
             for (ServiceReference<T> ref : references) {
                 T t = getService(clazz, ref);
@@ -86,7 +86,7 @@ public abstract class OsgiCommandSupport extends AbstractAction implements Actio
         T t = getBundleContext().getService(reference);
         if (t != null) {
             if (usedReferences == null) {
-                usedReferences = new ArrayList<ServiceReference<?>>();
+                usedReferences = new ArrayList<>();
             }
             usedReferences.add(reference);
         }

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/commands/GenericType.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/commands/GenericType.java
@@ -34,7 +34,7 @@ public class GenericType extends ReifiedType {
 
 	private static final GenericType[] EMPTY = new GenericType[0];
 
-    private static final Map<String, Class> primitiveClasses = new HashMap<String, Class>();
+    private static final Map<String, Class> primitiveClasses = new HashMap<>();
 
     static {
         primitiveClasses.put("int", int.class);

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/commands/NamespaceHandler.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/commands/NamespaceHandler.java
@@ -88,9 +88,9 @@ public class NamespaceHandler implements org.apache.aries.blueprint.NamespaceHan
     }
 
 	public Set<Class> getManagedClasses() {
-		return new HashSet<Class>(Arrays.asList(
-			BlueprintCommand.class
-		));
+		return new HashSet<>(Arrays.asList(
+                BlueprintCommand.class
+        ));
 	}
 
     public ComponentMetadata decorate(Node node, ComponentMetadata component, ParserContext context) {
@@ -268,7 +268,7 @@ public class NamespaceHandler implements org.apache.aries.blueprint.NamespaceHan
     }
 
     private Metadata parseOptionalCompleters(ParserContext context, ComponentMetadata enclosingComponent, Element element) {
-        Metadata metadata = context.parseElement(MapMetadata.class, context.getEnclosingComponent(), (Element) element);
+        Metadata metadata = context.parseElement(MapMetadata.class, context.getEnclosingComponent(), element);
         return metadata;
     }
 

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/completer/AggregateCompleter.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/completer/AggregateCompleter.java
@@ -44,7 +44,7 @@ public class AggregateCompleter implements Completer
         // buffer could be null
         assert candidates != null;
 
-        List<Completion> completions = new ArrayList<Completion>(completers.size());
+        List<Completion> completions = new ArrayList<>(completers.size());
 
         // Run each completer, saving its completion results
         int max = -1;

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/completer/ArgumentCompleter.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/completer/ArgumentCompleter.java
@@ -66,9 +66,9 @@ public class ArgumentCompleter implements Completer {
     final List<Completer> argsCompleters;
     final Map<String, Completer> optionalCompleters;
     final CommandWithAction function;
-    final Map<Option, Field> fields = new HashMap<Option, Field>();
-    final Map<String, Option> options = new HashMap<String, Option>();
-    final Map<Integer, Field> arguments = new HashMap<Integer, Field>();
+    final Map<Option, Field> fields = new HashMap<>();
+    final Map<String, Option> options = new HashMap<>();
+    final Map<Integer, Field> arguments = new HashMap<>();
     boolean strict = true;
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -112,7 +112,7 @@ public class ArgumentCompleter implements Completer {
             Map<String, Completer> focl = ((CompletableFunction) function).getOptionalCompleters();
             List<Completer> fcl = ((CompletableFunction) function).getCompleters();
             if (focl != null || fcl != null) {
-                argsCompleters = new ArrayList<Completer>();
+                argsCompleters = new ArrayList<>();
                 if (fcl != null) {
                     for (Completer c : fcl) {
                         argsCompleters.add(c == null ? NullCompleter.INSTANCE : c);
@@ -123,7 +123,7 @@ public class ArgumentCompleter implements Completer {
         }
         if (argsCompleters == null) {
             final Map<Integer, Object> values = getCompleterValues(function);
-            argsCompleters = new ArrayList<Completer>();
+            argsCompleters = new ArrayList<>();
             boolean multi = false;
             for (int key = 0; key < arguments.size(); key++) {
                 Completer completer = null;
@@ -164,7 +164,7 @@ public class ArgumentCompleter implements Completer {
             if (argsCompleters.isEmpty() || !multi) {
                 argsCompleters.add(NullCompleter.INSTANCE);
             }
-            optionalCompleters = new HashMap<String, Completer>();
+            optionalCompleters = new HashMap<>();
             for (Option option : fields.keySet()) {
                 Completer completer = null;
                 Field field = fields.get(option);
@@ -199,7 +199,7 @@ public class ArgumentCompleter implements Completer {
     }
 
     private Map<Integer, Object> getCompleterValues(CommandWithAction function) {
-        final Map<Integer, Object> values = new HashMap<Integer, Object>();
+        final Map<Integer, Object> values = new HashMap<>();
         Action action = null;
         try {
             for (Class<?> type = function.getActionClass(); type != null; type = type.getSuperclass()) {
@@ -257,7 +257,7 @@ public class ArgumentCompleter implements Completer {
         } else if (type.isAssignableFrom(Boolean.class) || type.isAssignableFrom(boolean.class)) {
             completer = new StringsCompleter(new String[] {"false", "true"}, false);
         } else if (type.isAssignableFrom(Enum.class)) {
-            Set<String> values = new HashSet<String>();
+            Set<String> values = new HashSet<>();
             for (Object o : EnumSet.allOf((Class<Enum>) type)) {
                 values.add(o.toString());
             }
@@ -436,7 +436,7 @@ public class ArgumentCompleter implements Completer {
     }
 
     protected boolean verifyCompleter(Completer completer, String argument) {
-        List<String> candidates = new ArrayList<String>();
+        List<String> candidates = new ArrayList<>();
         return completer.complete(argument, argument.length(), candidates) != -1 && !candidates.isEmpty();
     }
 

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/completer/CommandNamesCompleter.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/completer/CommandNamesCompleter.java
@@ -42,7 +42,7 @@ public class CommandNamesCompleter implements Completer {
     public static final String COMMANDS = ".commands";
 
     private CommandSession session;
-    private final Set<String> commands = new CopyOnWriteArraySet<String>();
+    private final Set<String> commands = new CopyOnWriteArraySet<>();
 
     public CommandNamesCompleter() {
         this(CommandSessionHolder.getSession());
@@ -72,7 +72,7 @@ public class CommandNamesCompleter implements Completer {
     @SuppressWarnings("unchecked")
     protected void checkData() {
         if (commands.isEmpty()) {
-            Set<String> names = new HashSet<String>((Set<String>) session.get(COMMANDS));
+            Set<String> names = new HashSet<>((Set<String>) session.get(COMMANDS));
             for (String name : names) {
                 commands.add(name);
                 if (name.indexOf(':') > 0) {

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/completer/CommandsCompleter.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/completer/CommandsCompleter.java
@@ -56,9 +56,9 @@ public class CommandsCompleter implements Completer {
     private static final Logger LOGGER = LoggerFactory.getLogger(CommandsCompleter.class);
 
     private CommandSession session;
-    private final Map<String, Completer> globalCompleters = new HashMap<String, Completer>();
-    private final Map<String, Completer> localCompleters = new HashMap<String, Completer>();
-    private final Set<String> commands = new HashSet<String>();
+    private final Map<String, Completer> globalCompleters = new HashMap<>();
+    private final Map<String, Completer> localCompleters = new HashMap<>();
+    private final Set<String> commands = new HashSet<>();
     private CommandTracker tracker;
 
     public CommandsCompleter() {
@@ -97,7 +97,7 @@ public class CommandsCompleter implements Completer {
             if (subShell.isEmpty()) {
                 subShell = "*";
             }
-            List<Completer> completers = new ArrayList<Completer>();
+            List<Completer> completers = new ArrayList<>();
             for (String name : allCompleters[1].keySet()) {
                 if (name.startsWith(subShell + ":")) {
                     completers.add(allCompleters[1].get(name));
@@ -113,7 +113,7 @@ public class CommandsCompleter implements Completer {
 
         if ("FIRST".equalsIgnoreCase(completion)) {
             if (!subShell.isEmpty()) {
-                List<Completer> completers = new ArrayList<Completer>();
+                List<Completer> completers = new ArrayList<>();
                 for (String name : allCompleters[1].keySet()) {
                     if (name.startsWith(subShell + ":")) {
                         completers.add(allCompleters[1].get(name));
@@ -125,7 +125,7 @@ public class CommandsCompleter implements Completer {
                     return res;
                 }
             }
-            List<Completer> compl = new ArrayList<Completer>();
+            List<Completer> compl = new ArrayList<>();
             compl.add(new StringsCompleter(getAliases()));
             compl.addAll(allCompleters[0].values());
             int res = new AggregateCompleter(compl).complete(buffer, cursor, candidates);
@@ -133,7 +133,7 @@ public class CommandsCompleter implements Completer {
             return res;
         }
 
-        List<Completer> compl = new ArrayList<Completer>();
+        List<Completer> compl = new ArrayList<>();
         compl.add(new StringsCompleter(getAliases()));
         compl.addAll(allCompleters[0].values());
         int res = new AggregateCompleter(compl).complete(buffer, cursor, candidates);
@@ -144,7 +144,7 @@ public class CommandsCompleter implements Completer {
     protected void sort(Map<String, Completer>[] completers, List<String> scopes) {
         ScopeComparator comparator = new ScopeComparator(scopes);
         for (int i = 0; i < completers.length; i++) {
-            Map<String, Completer> map = new TreeMap<String, Completer>(comparator);
+            Map<String, Completer> map = new TreeMap<>(comparator);
             map.putAll(completers[i]);
             completers[i] = map;
         }
@@ -223,14 +223,14 @@ public class CommandsCompleter implements Completer {
         Set<String> names;
         boolean update;
         synchronized (this) {
-            names = new HashSet<String>((Set<String>) session.get(COMMANDS));
+            names = new HashSet<>((Set<String>) session.get(COMMANDS));
             update = !names.equals(commands);
         }
         if (update) {
             // get command aliases
-            Set<String> commands = new HashSet<String>();
-            Map<String, Completer> global = new HashMap<String, Completer>();
-            Map<String, Completer> local = new HashMap<String, Completer>();
+            Set<String> commands = new HashSet<>();
+            Map<String, Completer> global = new HashMap<>();
+            Map<String, Completer> local = new HashMap<>();
 
             // add argument completers for each command
             for (String command : names) {
@@ -267,8 +267,8 @@ public class CommandsCompleter implements Completer {
         }
         synchronized (this) {
             return new Map[] {
-                    new HashMap<String, Completer>(this.globalCompleters),
-                    new HashMap<String, Completer>(this.localCompleters)
+                    new HashMap<>(this.globalCompleters),
+                    new HashMap<>(this.localCompleters)
             };
         }
     }
@@ -281,7 +281,7 @@ public class CommandsCompleter implements Completer {
     @SuppressWarnings("unchecked")
     private Set<String> getAliases() {
         Set<String> vars = ((Set<String>) session.get(null));
-        Set<String> aliases = new HashSet<String>();
+        Set<String> aliases = new HashSet<>();
         for (String var : vars) {
             Object content = session.get(var);
             if (content != null && "org.apache.felix.gogo.runtime.Closure".equals(content.getClass().getName())) {

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/completer/OldArgumentCompleter.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/completer/OldArgumentCompleter.java
@@ -56,9 +56,9 @@ public class OldArgumentCompleter implements Completer {
     final List<Completer> argsCompleters;
     final Map<String, Completer> optionalCompleters;
     final CommandWithAction function;
-    final Map<Option, Field> fields = new HashMap<Option, Field>();
-    final Map<String, Option> options = new HashMap<String, Option>();
-    final Map<Integer, Field> arguments = new HashMap<Integer, Field>();
+    final Map<Option, Field> fields = new HashMap<>();
+    final Map<String, Option> options = new HashMap<>();
+    final Map<Integer, Field> arguments = new HashMap<>();
     boolean strict = true;
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -94,7 +94,7 @@ public class OldArgumentCompleter implements Completer {
 //        options.put(HelpOption.HELP.name(), HelpOption.HELP);
         optionsCompleter = new StringsCompleter(options.keySet());
         // Build arguments completers
-        argsCompleters = new ArrayList<Completer>();
+        argsCompleters = new ArrayList<>();
 
         if (function instanceof CompletableFunction) {
             Map<String, Completer> opt;
@@ -102,7 +102,7 @@ public class OldArgumentCompleter implements Completer {
                 //
                 opt = ((CompletableFunction) function).getOptionalCompleters();
             } catch (Throwable t) {
-                opt = new HashMap<String, Completer>();
+                opt = new HashMap<>();
             }
             optionalCompleters = opt;
             List<Completer> fcl = ((CompletableFunction) function).getCompleters();
@@ -114,8 +114,8 @@ public class OldArgumentCompleter implements Completer {
                 argsCompleters.add(NullCompleter.INSTANCE);
             }
         } else {
-            optionalCompleters = new HashMap<String, Completer>();
-            final Map<Integer, Method> methods = new HashMap<Integer, Method>();
+            optionalCompleters = new HashMap<>();
+            final Map<Integer, Method> methods = new HashMap<>();
             for (Class<?> type = function.getActionClass(); type != null; type = type.getSuperclass()) {
                 for (Method method : type.getDeclaredMethods()) {
                     CompleterValues completerMethod = method.getAnnotation(CompleterValues.class);
@@ -171,7 +171,7 @@ public class OldArgumentCompleter implements Completer {
                     } else if (type.isAssignableFrom(Boolean.class) || type.isAssignableFrom(boolean.class)) {
                         argCompleter = new StringsCompleter(new String[] {"false", "true"}, false);
                     } else if (type.isAssignableFrom(Enum.class)) {
-                        Set<String> values = new HashSet<String>();
+                        Set<String> values = new HashSet<>();
                         for (Object o : EnumSet.allOf((Class<Enum>) type)) {
                             values.add(o.toString());
                         }
@@ -343,7 +343,7 @@ public class OldArgumentCompleter implements Completer {
     }
 
     protected boolean verifyCompleter(Completer completer, String argument) {
-        List<String> candidates = new ArrayList<String>();
+        List<String> candidates = new ArrayList<>();
         return completer.complete(argument, argument.length(), candidates) != -1 && !candidates.isEmpty();
     }
 

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/completer/Parser.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/completer/Parser.java
@@ -136,7 +136,7 @@ public class Parser {
     }
 
     public List<List<List<String>>> program() {
-        program = new ArrayList<List<List<String>>>();
+        program = new ArrayList<>();
         ws();
         if (!eof()) {
             program.add(pipeline());
@@ -161,7 +161,7 @@ public class Parser {
     }
 
     public List<List<String>> pipeline() {
-        statements = new ArrayList<List<String>>();
+        statements = new ArrayList<>();
         statements.add(statement());
         while (peek() == '|') {
             current++;
@@ -170,7 +170,7 @@ public class Parser {
                 statements.add(statement());
             }
             else {
-                statements.add(new ArrayList<String>());
+                statements.add(new ArrayList<>());
                 break;
             }
         }
@@ -180,7 +180,7 @@ public class Parser {
     }
 
     public List<String> statement() {
-        statement = new ArrayList<String>();
+        statement = new ArrayList<>();
         statement.add(value());
         while (!eof()) {
             ws();

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/completer/StringsCompleter.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/completer/StringsCompleter.java
@@ -33,7 +33,7 @@ import org.apache.karaf.shell.console.Completer;
 public class StringsCompleter
     implements Completer
 {
-    private final SortedSet<String> strings = new TreeSet<String>();
+    private final SortedSet<String> strings = new TreeSet<>();
     private final boolean caseSensitive;
 
     public StringsCompleter() {

--- a/shell/console/src/main/java/org/apache/karaf/shell/security/impl/SecuredCommandConfigTransformer.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/security/impl/SecuredCommandConfigTransformer.java
@@ -77,7 +77,7 @@ public class SecuredCommandConfigTransformer implements ConfigurationListener {
 
         Dictionary<String, Object> configProps = config.getProperties();
 
-        Map<String, Dictionary<String, Object>> configMaps = new HashMap<String, Dictionary<String, Object>>();
+        Map<String, Dictionary<String, Object>> configMaps = new HashMap<>();
         for (Enumeration<String> e = configProps.keys(); e.hasMoreElements(); ) {
             String key = e.nextElement();
             String bareCommand = key;
@@ -96,7 +96,7 @@ public class SecuredCommandConfigTransformer implements ConfigurationListener {
             String pid = PROXY_SERVICE_ACL_PID_PREFIX + scopeName + "." + bareCommand;
             Dictionary<String, Object> map;
             if (!configMaps.containsKey(pid)) {
-                map = new Hashtable<String, Object>();
+                map = new Hashtable<>();
                 map.put("service.guard", "(&(" +
                         CommandProcessor.COMMAND_SCOPE + "=" + scopeName + ")(" +
                         CommandProcessor.COMMAND_FUNCTION + "=" + bareCommand + "))");
@@ -232,7 +232,7 @@ public class SecuredCommandConfigTransformer implements ConfigurationListener {
     }
     
     private Map<String, String> loadScopeBundleMaps() {
-        Map<String, String> scopeBundleMaps = new HashMap<String, String>();
+        Map<String, String> scopeBundleMaps = new HashMap<>();
         try {
             for (Configuration config : configAdmin.listConfigurations("(service.pid=" + ACL_SCOPE_BUNDLE_MAP + ")")) {
                 Enumeration<String> keys = config.getProperties().keys();

--- a/shell/console/src/main/java/org/apache/karaf/shell/security/impl/SecuredCommandProcessorImpl.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/security/impl/SecuredCommandProcessorImpl.java
@@ -116,7 +116,7 @@ public class SecuredCommandProcessorImpl extends CommandProcessorImpl {
             public Object addingService(ServiceReference<Object> reference) {
                 Object scope = reference.getProperty(CommandProcessor.COMMAND_SCOPE);
                 Object function = reference.getProperty(CommandProcessor.COMMAND_FUNCTION);
-                List<Object> commands = new ArrayList<Object>();
+                List<Object> commands = new ArrayList<>();
 
                 if (scope != null && function != null) {
                     if (function.getClass().isArray()) {

--- a/shell/console/src/main/java/org/apache/karaf/shell/util/ShellUtil.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/util/ShellUtil.java
@@ -48,7 +48,7 @@ public class ShellUtil {
 
     public static String getBundleName(Bundle bundle) {
         if (bundle != null) {
-            String name = (String) bundle.getHeaders().get(Constants.BUNDLE_NAME);
+            String name = bundle.getHeaders().get(Constants.BUNDLE_NAME);
             return (name == null)
                     ? "Bundle " + Long.toString(bundle.getBundleId())
                     : name + " (" + Long.toString(bundle.getBundleId()) + ")";

--- a/shell/core/src/main/java/org/apache/karaf/shell/api/console/Signal.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/api/console/Signal.java
@@ -54,7 +54,7 @@ public enum Signal {
     IO(29),
     PWR(30);
 
-    private static final Map<String, Signal> lookupTable = new HashMap<String, Signal>(40);
+    private static final Map<String, Signal> lookupTable = new HashMap<>(40);
 
     static {
         // registering the signals in the lookup table to allow faster

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/action/command/DefaultActionPreparator.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/action/command/DefaultActionPreparator.java
@@ -61,9 +61,9 @@ public class DefaultActionPreparator {
     public boolean prepare(Action action, Session session, List<Object> params) throws Exception {
 
         Command command = action.getClass().getAnnotation(Command.class);
-        Map<Option, Field> options = new HashMap<Option, Field>();
-        Map<Argument, Field> arguments = new HashMap<Argument, Field>();
-        List<Argument> orderedArguments = new ArrayList<Argument>();
+        Map<Option, Field> options = new HashMap<>();
+        Map<Argument, Field> arguments = new HashMap<>();
+        List<Argument> orderedArguments = new ArrayList<>();
 
         for (Class<?> type = action.getClass(); type != null; type = type.getSuperclass()) {
             for (Field field : type.getDeclaredFields()) {

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/action/command/ManagerImpl.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/action/command/ManagerImpl.java
@@ -43,7 +43,7 @@ public class ManagerImpl implements Manager {
 
     private final Registry dependencies;
     private final Registry registrations;
-    private final Map<Class<?>, Object> instances = new HashMap<Class<?>, Object>();
+    private final Map<Class<?>, Object> instances = new HashMap<>();
     private final boolean allowCustomServices;
 
     public ManagerImpl(Registry dependencies, Registry registrations) {
@@ -76,12 +76,12 @@ public class ManagerImpl implements Manager {
                     GenericType type = new GenericType(field.getGenericType());
                     Object value;
                     if (type.getRawClass() == List.class) {
-                        Set<Object> set = new HashSet<Object>();
+                        Set<Object> set = new HashSet<>();
                         set.addAll(registry.getServices(type.getActualTypeArgument(0).getRawClass()));
                         if (registry != this.dependencies) {
                             set.addAll(this.dependencies.getServices(type.getActualTypeArgument(0).getRawClass()));
                         }
-                        value = new ArrayList<Object>(set);
+                        value = new ArrayList<>(set);
                     } else {
                         value = registry.getService(type.getRawClass());
                         if (value == null && registry != this.dependencies) {

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/AggregateServiceTracker.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/AggregateServiceTracker.java
@@ -129,8 +129,8 @@ public abstract class AggregateServiceTracker {
 
     public class State {
 
-        private final Map<Class, List> multi = new HashMap<Class, List>();
-        private final Map<Class, Object> single = new HashMap<Class, Object>();
+        private final Map<Class, List> multi = new HashMap<>();
+        private final Map<Class, Object> single = new HashMap<>();
 
         public boolean isSatisfied() {
             return singleTrackers.keySet().stream()
@@ -146,7 +146,7 @@ public abstract class AggregateServiceTracker {
         }
 
         public List<String> getMissingServices() {
-            List<String> missing = new ArrayList<String>();
+            List<String> missing = new ArrayList<>();
             for (SingleServiceTracker tracker : singleTrackers.values()) {
                 if (!single.containsKey(tracker.getTrackedClass())) {
                     missing.add(tracker.getTrackedClass().getName());

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/CommandExtension.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/CommandExtension.java
@@ -58,7 +58,7 @@ public class CommandExtension implements Extension {
     private final Registry registry;
     private final CountDownLatch started;
     private final AggregateServiceTracker tracker;
-    private final List<Class> classes = new ArrayList<Class>();
+    private final List<Class> classes = new ArrayList<>();
     private Manager manager;
 
 

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/MultiServiceTracker.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/MultiServiceTracker.java
@@ -42,7 +42,7 @@ public abstract class MultiServiceTracker<T> {
 
     private final BundleContext ctx;
     private final Class<T> clazz;
-    private final Map<ServiceReference<T>, T> refs = new HashMap<ServiceReference<T>, T>();
+    private final Map<ServiceReference<T>, T> refs = new HashMap<>();
     private final AtomicBoolean open = new AtomicBoolean(false);
 
     private final ServiceListener listener = new ServiceListener() {
@@ -91,7 +91,7 @@ public abstract class MultiServiceTracker<T> {
 
             List<ServiceReference> oldRefs;
             synchronized (refs) {
-                oldRefs = new ArrayList<ServiceReference>(refs.keySet());
+                oldRefs = new ArrayList<>(refs.keySet());
                 refs.clear();
             }
             for (ServiceReference ref : oldRefs) {
@@ -101,7 +101,7 @@ public abstract class MultiServiceTracker<T> {
     }
 
     private void updateState() {
-        List<T> svcs = new ArrayList<T>();
+        List<T> svcs = new ArrayList<>();
         synchronized (refs) {
             svcs.addAll(refs.values());
         }

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/RegistryImpl.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/RegistryImpl.java
@@ -31,8 +31,8 @@ import org.apache.karaf.shell.api.console.Registry;
 public class RegistryImpl implements Registry {
 
     private final Registry parent;
-    private final Map<Object, Object> services = new LinkedHashMap<Object, Object>();
-    private final Map<String, List<Command>> commands = new HashMap<String, List<Command>>();
+    private final Map<Object, Object> services = new LinkedHashMap<>();
+    private final Map<String, List<Command>> commands = new HashMap<>();
 
     public RegistryImpl(Registry parent) {
         this.parent = parent;
@@ -63,7 +63,7 @@ public class RegistryImpl implements Registry {
     @Override
     public <T> void register(Callable<T> factory, Class<T> clazz) {
         synchronized (services) {
-            services.put(clazz, new Factory<T>(clazz, factory));
+            services.put(clazz, new Factory<>(clazz, factory));
         }
     }
 
@@ -133,7 +133,7 @@ public class RegistryImpl implements Registry {
 
     @Override
     public <T> List<T> getServices(Class<T> clazz) {
-        List<T> list = new ArrayList<T>();
+        List<T> list = new ArrayList<>();
         synchronized (services) {
             for (Object service : services.values()) {
                 if (service instanceof Factory) {

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/SingleServiceTracker.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/SingleServiceTracker.java
@@ -38,8 +38,8 @@ public abstract class SingleServiceTracker<T> {
 
     private final BundleContext ctx;
     private final Class<T> clazz;
-    private final AtomicReference<T> service = new AtomicReference<T>();
-    private final AtomicReference<ServiceReference<T>> ref = new AtomicReference<ServiceReference<T>>();
+    private final AtomicReference<T> service = new AtomicReference<>();
+    private final AtomicReference<ServiceReference<T>> ref = new AtomicReference<>();
     private final AtomicBoolean open = new AtomicBoolean(false);
 
     private final ServiceListener listener = new ServiceListener() {

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/CommandNamesCompleter.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/CommandNamesCompleter.java
@@ -34,7 +34,7 @@ public class CommandNamesCompleter extends org.apache.karaf.shell.support.comple
     public int complete(Session session, CommandLine commandLine, List<String> candidates) {
         // TODO: optimize
         List<Command> list = session.getRegistry().getCommands();
-        Set<String> names = new HashSet<String>();
+        Set<String> names = new HashSet<>();
         for (Command command : list) {
             names.add(command.getScope() + ":" + command.getName());
             names.add(command.getName());

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/RegistryImpl.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/RegistryImpl.java
@@ -31,8 +31,8 @@ import org.apache.karaf.shell.api.console.Registry;
 public class RegistryImpl implements Registry {
 
     protected final Registry parent;
-    protected final Map<Object, Object> services = new LinkedHashMap<Object, Object>();
-    private final Map<String, List<Command>> commands = new HashMap<String, List<Command>>();
+    protected final Map<Object, Object> services = new LinkedHashMap<>();
+    private final Map<String, List<Command>> commands = new HashMap<>();
 
     public RegistryImpl(Registry parent) {
         this.parent = parent;
@@ -63,7 +63,7 @@ public class RegistryImpl implements Registry {
     @Override
     public <T> void register(Callable<T> factory, Class<T> clazz) {
         synchronized (services) {
-            services.put(factory, new Factory<T>(clazz, factory));
+            services.put(factory, new Factory<>(clazz, factory));
         }
     }
 
@@ -126,7 +126,7 @@ public class RegistryImpl implements Registry {
 
     @Override
     public <T> List<T> getServices(Class<T> clazz) {
-        List<T> list = new ArrayList<T>();
+        List<T> list = new ArrayList<>();
         synchronized (services) {
             for (Object service : services.values()) {
                 if (service instanceof Factory) {

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/commands/SubShellCommand.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/commands/SubShellCommand.java
@@ -61,7 +61,7 @@ public class SubShellCommand extends TopLevelCommand {
     @Override
     protected void printHelp(Session session, PrintStream out) {
         try {
-            new HelpCommand(session.getFactory()).execute(session, Arrays.<Object>asList("shell|" + name));
+            new HelpCommand(session.getFactory()).execute(session, Arrays.asList("shell|" + name));
         } catch (Exception e) {
             throw new RuntimeException("Unable to print subshell help", e);
         }

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/commands/help/HelpCommand.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/commands/help/HelpCommand.java
@@ -134,7 +134,7 @@ public class HelpCommand implements Command {
                 return -1;
             }
             protected boolean verifyCompleter(Session session, Completer completer, String argument) {
-                List<String> candidates = new ArrayList<String>();
+                List<String> candidates = new ArrayList<>();
                 return completer.complete(session, new ArgumentCommandLine(argument, argument.length()), candidates) != -1 && !candidates.isEmpty();
             }
         };
@@ -175,7 +175,7 @@ public class HelpCommand implements Command {
         if (path == null) {
             path = "%root%";
         }
-        Map<String,String> props = new HashMap<String,String>();
+        Map<String,String> props = new HashMap<>();
         props.put("data", "${" + path + "}");
         final List<HelpProvider> providers = session.getRegistry().getServices(HelpProvider.class);
         InterpolationHelper.performSubstitution(props, new InterpolationHelper.SubstitutionCallback() {

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/commands/help/SimpleHelpProvider.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/commands/help/SimpleHelpProvider.java
@@ -28,7 +28,7 @@ public class SimpleHelpProvider implements HelpProvider {
     private final Map<String, String> help;
 
     public SimpleHelpProvider() {
-        help = new HashMap<String, String>();
+        help = new HashMap<>();
         help.put("%root%", "${command-list|}");
         help.put("all", "${command-list|}");
     }

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/osgi/EventAdminListener.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/osgi/EventAdminListener.java
@@ -36,7 +36,7 @@ public class EventAdminListener implements CommandSessionListener, Closeable
 
     public EventAdminListener(BundleContext bundleContext)
     {
-        tracker = new ServiceTracker<EventAdmin, EventAdmin>(bundleContext, EventAdmin.class.getName(), null);
+        tracker = new ServiceTracker<>(bundleContext, EventAdmin.class.getName(), null);
         tracker.open();
     }
 
@@ -48,7 +48,7 @@ public class EventAdminListener implements CommandSessionListener, Closeable
         if (command.toString().trim().length() > 0) {
             EventAdmin admin = tracker.getService();
             if (admin != null) {
-                Map<String, Object> props = new HashMap<String, Object>();
+                Map<String, Object> props = new HashMap<>();
                 props.put("command", command.toString());
                 Event event = new Event("org/apache/karaf/shell/console/EXECUTING", props);
                 admin.postEvent(event);

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/osgi/secured/SecuredSessionFactoryImpl.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/osgi/secured/SecuredSessionFactoryImpl.java
@@ -58,7 +58,7 @@ public class SecuredSessionFactoryImpl extends SessionFactoryImpl implements Con
     private static final Logger LOGGER = LoggerFactory.getLogger(SecuredSessionFactoryImpl.class);
 
     private BundleContext bundleContext;
-    private Map<String, Dictionary<String, Object>> scopes = new HashMap<String, Dictionary<String, Object>>();
+    private Map<String, Dictionary<String, Object>> scopes = new HashMap<>();
     private SingleServiceTracker<ConfigurationAdmin> configAdminTracker;
     private ServiceRegistration<ConfigurationListener> registration;
 
@@ -93,7 +93,7 @@ public class SecuredSessionFactoryImpl extends SessionFactoryImpl implements Con
     protected boolean isVisible(Command command) {
         Dictionary<String, Object> config = getScopeConfig(command.getScope());
         if (config != null) {
-            List<String> roles = new ArrayList<String>();
+            List<String> roles = new ArrayList<>();
             ACLConfigurationParser.getRolesForInvocation(command.getName(), null, null, config, roles);
             if (roles.isEmpty()) {
                 return true;
@@ -115,7 +115,7 @@ public class SecuredSessionFactoryImpl extends SessionFactoryImpl implements Con
             if (!isVisible(command)) {
                 throw new CommandNotFoundException(command.getScope() + ":" + command.getName());
             }
-            List<String> roles = new ArrayList<String>();
+            List<String> roles = new ArrayList<>();
             ACLConfigurationParser.Specificity s = ACLConfigurationParser.getRolesForInvocation(command.getName(), new Object[] { arguments.toString() }, null, config, roles);
             if (s == ACLConfigurationParser.Specificity.NO_MATCH) {
                 return;

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/parsing/KarafParser.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/parsing/KarafParser.java
@@ -111,7 +111,7 @@ public class KarafParser implements org.jline.reader.Parser {
             return new ParsedLineImpl(program, statement, cursor, statement.tokens());
         } else {
             // TODO:
-            return new ParsedLineImpl(program, program, cursor, Collections.<Token>singletonList(program));
+            return new ParsedLineImpl(program, program, cursor, Collections.singletonList(program));
         }
     }
 

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/standalone/Main.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/standalone/Main.java
@@ -244,7 +244,7 @@ public class Main {
     }
 
     private static List<URL> getFiles(File base) throws MalformedURLException {
-        List<URL> urls = new ArrayList<URL>();
+        List<URL> urls = new ArrayList<>();
         getFiles(base, urls);
         return urls;
     }

--- a/shell/core/src/main/java/org/apache/karaf/shell/support/RegexCommandLoggingFilter.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/support/RegexCommandLoggingFilter.java
@@ -56,7 +56,7 @@ public class RegexCommandLoggingFilter implements CommandLoggingFilter {
     private int group=1;
     private String replacement=DEFAULT_REPLACEMENT;
 
-    ArrayList<ReplaceRegEx> regexs = new ArrayList<ReplaceRegEx>();
+    ArrayList<ReplaceRegEx> regexs = new ArrayList<>();
 
     public CharSequence filter(CharSequence command) {
         if( pattern!=null ) {

--- a/shell/core/src/main/java/org/apache/karaf/shell/support/completers/StringsCompleter.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/support/completers/StringsCompleter.java
@@ -44,7 +44,7 @@ public class StringsCompleter
     }
 
     public StringsCompleter(final boolean caseSensitive) {
-        this.strings = new TreeSet<String>(new Comparator<String>() {
+        this.strings = new TreeSet<>(new Comparator<String>() {
             @Override
             public int compare(String o1, String o2) {
                 return caseSensitive ? o1.compareTo(o2) : o1.compareToIgnoreCase(o2);

--- a/shell/core/src/main/java/org/apache/karaf/shell/support/converter/DefaultConverter.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/support/converter/DefaultConverter.java
@@ -397,7 +397,7 @@ public class DefaultConverter
 
     private static final Map<Class, Class> primitives;
     static {
-        primitives = new HashMap<Class, Class>();
+        primitives = new HashMap<>();
         primitives.put(byte.class, Byte.class);
         primitives.put(short.class, Short.class);
         primitives.put(char.class, Character.class);

--- a/shell/core/src/main/java/org/apache/karaf/shell/support/converter/GenericType.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/support/converter/GenericType.java
@@ -34,7 +34,7 @@ public class GenericType extends ReifiedType {
 
     private static final GenericType[] EMPTY = new GenericType[0];
 
-    private static final Map<String, Class> primitiveClasses = new HashMap<String, Class>();
+    private static final Map<String, Class> primitiveClasses = new HashMap<>();
 
     static {
         primitiveClasses.put("int", int.class);

--- a/shell/core/src/main/java/org/apache/karaf/shell/support/parsing/GogoParser.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/support/parsing/GogoParser.java
@@ -139,7 +139,7 @@ public class GogoParser {
     }
 
     public List<List<List<String>>> program() {
-        program = new ArrayList<List<List<String>>>();
+        program = new ArrayList<>();
         ws();
         if (!eof()) {
             program.add(pipeline());
@@ -164,7 +164,7 @@ public class GogoParser {
     }
 
     public List<List<String>> pipeline() {
-        statements = new ArrayList<List<String>>();
+        statements = new ArrayList<>();
         statements.add(statement());
         while (peek() == '|') {
             current++;
@@ -173,7 +173,7 @@ public class GogoParser {
                 statements.add(statement());
             }
             else {
-                statements.add(new ArrayList<String>());
+                statements.add(new ArrayList<>());
                 break;
             }
         }
@@ -183,7 +183,7 @@ public class GogoParser {
     }
 
     public List<String> statement() {
-        statement = new ArrayList<String>();
+        statement = new ArrayList<>();
         statement.add(value());
         while (!eof()) {
             ws();

--- a/shell/core/src/main/java/org/apache/karaf/shell/support/table/Row.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/support/table/Row.java
@@ -24,8 +24,8 @@ public class Row {
     private List<String> content;
     
     Row() {
-        data = new ArrayList<Object>();
-        content = new ArrayList<String>();
+        data = new ArrayList<>();
+        content = new ArrayList<>();
     }
     
     Row(List<Col> cols) {

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/Activator.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/Activator.java
@@ -186,7 +186,7 @@ public class Activator extends BaseActivator implements ManagedService {
         server.setKeyExchangeFactories(SshUtils.buildKexAlgorithms(kexAlgorithms));
         server.setShellFactory(new ShellFactoryImpl(sessionFactory));
         server.setCommandFactory(new ScpCommandFactory.Builder().withDelegate(new ShellCommandFactory(sessionFactory)).build());
-        server.setSubsystemFactories(Arrays.<NamedFactory<org.apache.sshd.server.Command>>asList(new SftpSubsystemFactory()));
+        server.setSubsystemFactories(Arrays.asList(new SftpSubsystemFactory()));
         server.setKeyPairProvider(keyPairProvider);
         server.setPasswordAuthenticator(authenticator);
         server.setPublickeyAuthenticator(authenticator);

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/KarafJaasAuthenticator.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/KarafJaasAuthenticator.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 
 public class KarafJaasAuthenticator implements PasswordAuthenticator, PublickeyAuthenticator {
 
-    public static final Session.AttributeKey<Subject> SUBJECT_ATTRIBUTE_KEY = new Session.AttributeKey<Subject>();
+    public static final Session.AttributeKey<Subject> SUBJECT_ATTRIBUTE_KEY = new Session.AttributeKey<>();
     private final Logger LOGGER = LoggerFactory.getLogger(KarafJaasAuthenticator.class);
 
     private String realm;

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/SshUtils.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/SshUtils.java
@@ -40,7 +40,7 @@ public class SshUtils {
 
     public static <S> List<NamedFactory<S>> filter(Class<S> type,
             Collection<NamedFactory<S>> factories, String[] names) {
-        List<NamedFactory<S>> list = new ArrayList<NamedFactory<S>>();
+        List<NamedFactory<S>> list = new ArrayList<>();
         for (String name : names) {
             name = name.trim();
             boolean found = false;

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/UserAuthFactoriesFactory.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/UserAuthFactoriesFactory.java
@@ -50,8 +50,8 @@ public class UserAuthFactoriesFactory {
     private List<NamedFactory<UserAuth>> factories;
 
    public void setAuthMethods(String[] methods) {
-        this.methodSet = new HashSet<String>();
-        this.factories = new ArrayList<NamedFactory<UserAuth>>();
+        this.methodSet = new HashSet<>();
+        this.factories = new ArrayList<>();
         for (String am : methods) {
             if (PASSWORD_METHOD.equals(am)) {
                 this.factories.add(new UserAuthPasswordFactory());

--- a/shell/table/src/main/java/org/apache/karaf/shell/table/Row.java
+++ b/shell/table/src/main/java/org/apache/karaf/shell/table/Row.java
@@ -24,8 +24,8 @@ public class Row {
     private List<String> content;
     
     Row() {
-        data = new ArrayList<Object>();
-        content = new ArrayList<String>();
+        data = new ArrayList<>();
+        content = new ArrayList<>();
     }
     
     Row(List<Col> cols) {

--- a/shell/table/src/main/java/org/apache/karaf/shell/table/ShellTable.java
+++ b/shell/table/src/main/java/org/apache/karaf/shell/table/ShellTable.java
@@ -27,8 +27,8 @@ import java.util.List;
 @Deprecated
 public class ShellTable {
 
-    private List<Col> cols = new ArrayList<Col>();
-    private List<Row> rows = new ArrayList<Row>();
+    private List<Col> cols = new ArrayList<>();
+    private List<Row> rows = new ArrayList<>();
     boolean showHeaders = true;
     private String separator = " | ";
     private int size;

--- a/subsystem/src/main/java/org/apache/karaf/subsystem/commands/InfoAction.java
+++ b/subsystem/src/main/java/org/apache/karaf/subsystem/commands/InfoAction.java
@@ -89,10 +89,10 @@ public class InfoAction extends SubsystemSupport implements Action {
 
     protected String generateFormattedOutput(Subsystem subsystem) {
         StringBuilder output = new StringBuilder();
-        Map<String, Object> otherAttribs = new TreeMap<String, Object>();
-        Map<String, Object> subsystemAttribs = new TreeMap<String, Object>();
-        Map<String, Object> serviceAttribs = new TreeMap<String, Object>();
-        Map<String, Object> packagesAttribs = new TreeMap<String, Object>();
+        Map<String, Object> otherAttribs = new TreeMap<>();
+        Map<String, Object> subsystemAttribs = new TreeMap<>();
+        Map<String, Object> serviceAttribs = new TreeMap<>();
+        Map<String, Object> packagesAttribs = new TreeMap<>();
         Map<String, String> dict = subsystem.getSubsystemHeaders(null);
 
         // do an initial loop and separate the attributes in different groups
@@ -159,7 +159,7 @@ public class InfoAction extends SubsystemSupport implements Action {
             output.append('\n');
         }
 
-        Map<String, ClauseFormatter> formatters = new HashMap<String, ClauseFormatter>();
+        Map<String, ClauseFormatter> formatters = new HashMap<>();
         /*
         formatters.put(REQUIRE_BUNDLE_ATTRIB, new ClauseFormatter() {
             public void pre(Clause clause, StringBuilder output) {

--- a/subsystem/src/main/java/org/apache/karaf/subsystem/commands/SubsystemCompleter.java
+++ b/subsystem/src/main/java/org/apache/karaf/subsystem/commands/SubsystemCompleter.java
@@ -28,7 +28,7 @@ public class SubsystemCompleter extends SubsystemSupport implements Completer {
 
     @Override
     public int complete(Session session, CommandLine commandLine, List<String> candidates) {
-        List<String> strings = new ArrayList<String>();
+        List<String> strings = new ArrayList<>();
         for (Subsystem ss : getSubsystems()) {
             strings.add(Long.toString(ss.getSubsystemId()));
             strings.add(ss.getSymbolicName() + "/" + ss.getVersion());

--- a/subsystem/src/main/java/org/apache/karaf/subsystem/commands/SubsystemSupport.java
+++ b/subsystem/src/main/java/org/apache/karaf/subsystem/commands/SubsystemSupport.java
@@ -56,7 +56,7 @@ public abstract class SubsystemSupport {
         if (id == null || id.isEmpty()) {
             return getSubsystems();
         }
-        List<Subsystem> subsystems = new ArrayList<Subsystem>();
+        List<Subsystem> subsystems = new ArrayList<>();
         // Try with the id
         Pattern pattern = Pattern.compile("^\\d+$");
         Matcher matcher = pattern.matcher(id);
@@ -102,7 +102,7 @@ public abstract class SubsystemSupport {
     }
 
     protected List<Long> getSubsytemIds(Collection<Subsystem> subsystems) {
-        List<Long> ids = new ArrayList<Long>();
+        List<Long> ids = new ArrayList<>();
         for (Subsystem ss : subsystems) {
             long id = ss.getSubsystemId();
             if (!ids.contains(id)) {
@@ -114,9 +114,9 @@ public abstract class SubsystemSupport {
     }
 
     protected List<Subsystem> getSubsystems() {
-        Map<Long, Subsystem> subsystems = new TreeMap<Long, Subsystem>();
+        Map<Long, Subsystem> subsystems = new TreeMap<>();
         doGetSubsystems(subsystems, getRoot());
-        return new ArrayList<Subsystem>(subsystems.values());
+        return new ArrayList<>(subsystems.values());
     }
 
     private void doGetSubsystems(Map<Long, Subsystem> subsystems, Subsystem subsystem) {

--- a/system/src/main/java/org/apache/karaf/system/management/internal/SystemMBeanImpl.java
+++ b/system/src/main/java/org/apache/karaf/system/management/internal/SystemMBeanImpl.java
@@ -154,7 +154,7 @@ public class SystemMBeanImpl extends StandardMBean implements SystemMBean {
     @Override
     public Map<String, String> getProperties(boolean unset, boolean dumpToFile) throws MBeanException {
         try {
-            Map<String, String> result = new HashMap<String, String>();
+            Map<String, String> result = new HashMap<>();
 
             Properties props = (Properties) java.lang.System.getProperties().clone();
 

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
@@ -574,7 +574,7 @@ public class AssemblyMojo extends MojoSupport {
     }
 
     private List<String> nonNullList(List<String> list) {
-        return list == null ? new ArrayList<String>() : list;
+        return list == null ? new ArrayList<>() : list;
     }
 
 }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/KarMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/KarMojo.java
@@ -199,7 +199,7 @@ public class KarMojo extends MojoSupport {
      * @throws MojoExecutionException
      */
     private List<Artifact> readResources(File featuresFile) throws MojoExecutionException {
-        List<Artifact> resources = new ArrayList<Artifact>();
+        List<Artifact> resources = new ArrayList<>();
         try {
             Features features = JaxbUtil.unmarshal(featuresFile.toURI().toASCIIString(), false);
             for (Feature feature : features.getFeature()) {

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/AsciiDoctorCommandHelpPrinter.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/AsciiDoctorCommandHelpPrinter.java
@@ -37,7 +37,7 @@ public class AsciiDoctorCommandHelpPrinter extends AbstractCommandHelpPrinter {
     public void printHelp(Action action, PrintStream out, boolean includeHelpOption) {
         Command command = action.getClass().getAnnotation(Command.class);
         Set<Option> options = new HashSet<>();
-        List<Argument> arguments = new ArrayList<Argument>();
+        List<Argument> arguments = new ArrayList<>();
         Map<Argument, Field> argFields = new HashMap<>();
         Map<Option, Field> optFields = new HashMap<>();
         for (Class<?> type = action.getClass(); type != null; type = type.getSuperclass()) {

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/DocBookCommandHelpPrinter.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/DocBookCommandHelpPrinter.java
@@ -42,7 +42,7 @@ public class DocBookCommandHelpPrinter extends AbstractCommandHelpPrinter {
     public void printHelp(Action action, PrintStream out, boolean includeHelpOption) {
         Command command = action.getClass().getAnnotation(Command.class);
         Set<Option> options = new HashSet<>();
-        List<Argument> arguments = new ArrayList<Argument>();
+        List<Argument> arguments = new ArrayList<>();
         Map<Argument, Field> argFields = new HashMap<>();
         Map<Option, Field> optFields = new HashMap<>();
         for (Class<?> type = action.getClass(); type != null; type = type.getSuperclass()) {

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/GenerateHelpMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/GenerateHelpMojo.java
@@ -111,7 +111,7 @@ public class GenerateHelpMojo extends AbstractMojo {
                 helpPrinter = new DocBookCommandHelpPrinter();
             }
 
-            Map<String, Set<String>> commands = new TreeMap<String, Set<String>>();
+            Map<String, Set<String>> commands = new TreeMap<>();
 
             String commandSuffix = null;
             if (FORMAT_ASCIIDOC.equals(format)) {
@@ -167,7 +167,7 @@ public class GenerateHelpMojo extends AbstractMojo {
         Exception, MojoFailureException {
         ClassFinder finder;
         if ("project".equals(classloaderType)) {
-            List<URL> urls = new ArrayList<URL>();
+            List<URL> urls = new ArrayList<>();
             for (Object object : project.getCompileClasspathElements()) {
                 String path = (String) object;
                 urls.add(new File(path).toURI().toURL());

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/UserConfCommandHelpPrinter.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/UserConfCommandHelpPrinter.java
@@ -42,7 +42,7 @@ public class UserConfCommandHelpPrinter extends AbstractCommandHelpPrinter {
     public void printHelp(Action action, PrintStream out, boolean includeHelpOption) {
         Command command = action.getClass().getAnnotation(Command.class);
         Set<Option> options = new HashSet<>();
-        List<Argument> arguments = new ArrayList<Argument>();
+        List<Argument> arguments = new ArrayList<>();
         Map<Argument, Field> argFields = new HashMap<>();
         Map<Option, Field> optFields = new HashMap<>();
         for (Class<?> type = action.getClass(); type != null; type = type.getSuperclass()) {

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/AbstractFeatureMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/AbstractFeatureMojo.java
@@ -90,7 +90,7 @@ public abstract class AbstractFeatureMojo extends MojoSupport {
 
     public AbstractFeatureMojo() {
         super();
-        descriptorArtifacts = new HashSet<Artifact>();
+        descriptorArtifacts = new HashSet<>();
     }
 
     protected void addFeatureRepo(String featureUrl) throws MojoExecutionException {
@@ -228,17 +228,17 @@ public abstract class AbstractFeatureMojo extends MojoSupport {
     }
 
     protected Set<Feature> resolveFeatures() throws MojoExecutionException {
-        Set<Feature> featuresSet = new HashSet<Feature>();
+        Set<Feature> featuresSet = new HashSet<>();
         try {
-            Set<String> artifactsToCopy = new HashSet<String>();
-            Map<String, Feature> featuresMap = new HashMap<String, Feature>();
+            Set<String> artifactsToCopy = new HashSet<>();
+            Map<String, Feature> featuresMap = new HashMap<>();
             for (String uri : descriptors) {
                 retrieveDescriptorsRecursively(uri, artifactsToCopy, featuresMap);
             }
     
             // no features specified, handle all of them
             if (features == null) {
-                features = new ArrayList<String>(featuresMap.keySet());
+                features = new ArrayList<>(featuresMap.keySet());
             }
             
             addFeatures(features, featuresSet, featuresMap, addTransitiveFeatures);

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/ExportFeatureMetaDataMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/ExportFeatureMetaDataMojo.java
@@ -72,7 +72,7 @@ public class ExportFeatureMetaDataMojo extends AbstractFeatureMojo {
         Set<Feature> featuresSet = resolveFeatures();
         if (mergedFeature) {
             Feature feature = oneVersion ? mergeFeatureOneVersion(featuresSet) : mergeFeature(featuresSet);
-            featuresSet = new HashSet<Feature>();
+            featuresSet = new HashSet<>();
             featuresSet.add(feature);
         }
         try {
@@ -89,7 +89,7 @@ public class ExportFeatureMetaDataMojo extends AbstractFeatureMojo {
 
     private Feature mergeFeature(Set<Feature> featuresSet) throws MojoExecutionException {
         Feature merged = new Feature("merged");
-        Set<String> bundleIds = new HashSet<String>();
+        Set<String> bundleIds = new HashSet<>();
         for (Feature feature : featuresSet) {
             for (Bundle bundle : feature.getBundle()) {
                 String symbolicName = getBundleSymbolicName(bundle);

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -130,7 +130,7 @@ public class GenerateDescriptorMojo extends MojoSupport {
      *
      */
     @Parameter
-    private List<String> excludedArtifactIds = new ArrayList<String>();
+    private List<String> excludedArtifactIds = new ArrayList<>();
 
     /**
      * The resolver to use for the feature.  Normally null or "OBR" or "(OBR)"
@@ -459,7 +459,7 @@ public class GenerateDescriptorMojo extends MojoSupport {
         // the feature's Maven artifact to allow for multi-feature repositories)
         // TODO Initialise the repositories from the existing feature file if any
         Map<Dependency, Feature> otherFeatures = new HashMap<>();
-        Map<Feature, String> featureRepositories = new HashMap<Feature, String>();
+        Map<Feature, String> featureRepositories = new HashMap<>();
         for (final LocalDependency entry : localDependencies) {
             Object artifact = entry.getArtifact();
 
@@ -793,8 +793,8 @@ public class GenerateDescriptorMojo extends MojoSupport {
                 Features oldfeatures = readFeaturesFile(filteredDependencyCache);
                 Feature oldFeature = oldfeatures.getFeature().get(0);
 
-                List<Bundle> addedBundles = new ArrayList<Bundle>(feature.getBundle());
-                List<Bundle> removedBundles = new ArrayList<Bundle>();
+                List<Bundle> addedBundles = new ArrayList<>(feature.getBundle());
+                List<Bundle> removedBundles = new ArrayList<>();
                 for (Bundle test : oldFeature.getBundle()) {
                     boolean t1 = addedBundles.contains(test);
                     int s1 = addedBundles.size();
@@ -811,8 +811,8 @@ public class GenerateDescriptorMojo extends MojoSupport {
                     }
                 }
 
-                List<Dependency> addedDependencys = new ArrayList<Dependency>(feature.getFeature());
-                List<Dependency> removedDependencys = new ArrayList<Dependency>();
+                List<Dependency> addedDependencys = new ArrayList<>(feature.getFeature());
+                List<Dependency> removedDependencys = new ArrayList<>();
                 for (Dependency test : oldFeature.getFeature()) {
                     boolean t1 = addedDependencys.contains(test);
                     int s1 = addedDependencys.size();

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/Dependency30Helper.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/Dependency30Helper.java
@@ -339,7 +339,7 @@ public class Dependency30Helper implements DependencyHelper {
         id = MavenUtil.mvnToAether(id);
         ArtifactRequest request = new ArtifactRequest();
         request.setArtifact(new DefaultArtifact(id));
-        request.setRepositories((List<RemoteRepository>) projectRepositories);
+        request.setRepositories(projectRepositories);
 
         log.debug("Resolving artifact " + id + " from " + projectRepositories);
 

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/ManifestUtils.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/ManifestUtils.java
@@ -45,7 +45,7 @@ public class ManifestUtils {
      * @return the list of imports
      */
     public static List<Clause> getImports(Manifest manifest) {
-    	List<Clause> result = new LinkedList<Clause>();
+    	List<Clause> result = new LinkedList<>();
     	Clause[] clauses = Parser.parseHeader(getHeader(Constants.IMPORT_PACKAGE, manifest));
     	for (Clause clause : clauses) {
     		result.add(clause);
@@ -60,7 +60,7 @@ public class ManifestUtils {
      * @return the list of non-optional imports
      */
     public static List<Clause> getMandatoryImports(Manifest manifest) {
-        List<Clause> result = new LinkedList<Clause>();
+        List<Clause> result = new LinkedList<>();
         for (Clause clause : getImports(manifest)) {
             if (!isOptional(clause)) {
                 result.add(clause);
@@ -76,7 +76,7 @@ public class ManifestUtils {
      * @return the list of exports
      */
     public static List<Clause> getExports(Manifest manifest) {
-    	List<Clause> result = new LinkedList<Clause>();
+    	List<Clause> result = new LinkedList<>();
     	Clause[] clauses = Parser.parseHeader(getHeader(Constants.EXPORT_PACKAGE, manifest));
     	for (Clause clause : clauses) {
     		result.add(clause);

--- a/util/src/main/java/org/apache/karaf/util/XmlUtils.java
+++ b/util/src/main/java/org/apache/karaf/util/XmlUtils.java
@@ -41,9 +41,9 @@ import org.xml.sax.XMLReader;
  */
 public class XmlUtils {
 
-    private static final ThreadLocal<DocumentBuilderFactory> DOCUMENT_BUILDER_FACTORY = new ThreadLocal<DocumentBuilderFactory>();
-    private static final ThreadLocal<TransformerFactory> TRANSFORMER_FACTORY = new ThreadLocal<TransformerFactory>();
-    private static final ThreadLocal<SAXParserFactory> SAX_PARSER_FACTORY = new ThreadLocal<SAXParserFactory>();
+    private static final ThreadLocal<DocumentBuilderFactory> DOCUMENT_BUILDER_FACTORY = new ThreadLocal<>();
+    private static final ThreadLocal<TransformerFactory> TRANSFORMER_FACTORY = new ThreadLocal<>();
+    private static final ThreadLocal<SAXParserFactory> SAX_PARSER_FACTORY = new ThreadLocal<>();
 
     public static Document parse(String uri) throws TransformerException, IOException, SAXException, ParserConfigurationException {
         DocumentBuilder db = documentBuilder();

--- a/util/src/main/java/org/apache/karaf/util/tracker/BaseActivator.java
+++ b/util/src/main/java/org/apache/karaf/util/tracker/BaseActivator.java
@@ -49,7 +49,7 @@ public class BaseActivator implements BundleActivator, Runnable {
     protected BundleContext bundleContext;
 
     protected ExecutorService executor = new ThreadPoolExecutor(0, 1, 0L, TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<Runnable>());
+            new LinkedBlockingQueue<>());
     private AtomicBoolean scheduled = new AtomicBoolean();
 
     private long schedulerStopTimeout = TimeUnit.MILLISECONDS.convert(30, TimeUnit.SECONDS);

--- a/web/src/main/java/org/apache/karaf/web/internal/WebContainerServiceImpl.java
+++ b/web/src/main/java/org/apache/karaf/web/internal/WebContainerServiceImpl.java
@@ -68,13 +68,13 @@ public class WebContainerServiceImpl implements WebContainerService, BundleListe
     public List<WebBundle> list() throws Exception {
         Bundle[] bundles = bundleContext.getBundles();
         Map<Long, WebEvent> bundleEvents = webEventHandler.getBundleEvents();
-        List<WebBundle> webBundles = new ArrayList<WebBundle>();
+        List<WebBundle> webBundles = new ArrayList<>();
         if (bundles != null) {
             for (Bundle bundle : bundles) {
                 // first check if the bundle is a web bundle
-                String contextPath = (String) bundle.getHeaders().get("Web-ContextPath");
+                String contextPath = bundle.getHeaders().get("Web-ContextPath");
                 if (contextPath == null) {
-                    contextPath = (String) bundle.getHeaders().get("Webapp-Context"); // this one used by pax-web but is deprecated
+                    contextPath = bundle.getHeaders().get("Webapp-Context"); // this one used by pax-web but is deprecated
                 }
                 if (contextPath == null) {
                     // the bundle is not a web bundle
@@ -85,13 +85,13 @@ public class WebContainerServiceImpl implements WebContainerService, BundleListe
                 contextPath = contextPath.trim();
                 
                 // get the bundle name
-                String name = (String) bundle.getHeaders().get(Constants.BUNDLE_NAME);
+                String name = bundle.getHeaders().get(Constants.BUNDLE_NAME);
                 // if there is no name, then default to symbolic name
                 name = (name == null) ? bundle.getSymbolicName() : name;
                 // if there is no symbolic name, resort to location
                 name = (name == null) ? bundle.getLocation() : name;
                 // get the bundle version
-                String version = (String) bundle.getHeaders().get(Constants.BUNDLE_VERSION);
+                String version = bundle.getHeaders().get(Constants.BUNDLE_VERSION);
                 name = ((version != null)) ? name + " (" + version + ")" : name;
                 long bundleId = bundle.getBundleId();
                 int level = bundle.adapt(BundleStartLevel.class).getStartLevel();

--- a/web/src/main/java/org/apache/karaf/web/internal/WebEventHandler.java
+++ b/web/src/main/java/org/apache/karaf/web/internal/WebEventHandler.java
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 public class WebEventHandler implements WebListener {
 
-    private final Map<Long, WebEvent> bundleEvents = new HashMap<Long, WebEvent>();
+    private final Map<Long, WebEvent> bundleEvents = new HashMap<>();
 
     public Map<Long, WebEvent> getBundleEvents() {
         return bundleEvents;

--- a/web/src/main/java/org/apache/karaf/web/management/internal/WebMBeanImpl.java
+++ b/web/src/main/java/org/apache/karaf/web/management/internal/WebMBeanImpl.java
@@ -79,7 +79,7 @@ public class WebMBeanImpl extends StandardMBean implements WebMBean {
 
     public void start(Long bundleId) throws MBeanException {
         try {
-            List<Long> list = new ArrayList<Long>();
+            List<Long> list = new ArrayList<>();
             list.add(bundleId);
             webContainerService.start(list);
         } catch (Exception e) {
@@ -97,7 +97,7 @@ public class WebMBeanImpl extends StandardMBean implements WebMBean {
 
     public void stop(Long bundleId) throws MBeanException {
         try {
-            List<Long> list = new ArrayList<Long>();
+            List<Long> list = new ArrayList<>();
             list.add(bundleId);
             webContainerService.stop(list);
         } catch (Exception e) {

--- a/webconsole/features/src/main/java/org/apache/karaf/webconsole/features/FeaturesPlugin.java
+++ b/webconsole/features/src/main/java/org/apache/karaf/webconsole/features/FeaturesPlugin.java
@@ -302,7 +302,7 @@ public class FeaturesPlugin extends AbstractWebConsolePlugin {
     }
 
     private List<Repository> getRepositories() {
-        List<Repository> repositories = new ArrayList<Repository>();
+        List<Repository> repositories = new ArrayList<>();
 
         if (featuresService == null) {
             this.log.error("Features service is not available");
@@ -321,7 +321,7 @@ public class FeaturesPlugin extends AbstractWebConsolePlugin {
     }
 
     private List<ExtendedFeature> getFeatures(List<Repository> repositories) {
-        List<ExtendedFeature> features = new ArrayList<ExtendedFeature>();
+        List<ExtendedFeature> features = new ArrayList<>();
 
         if (featuresService == null) {
             this.log.error("Features service is not available");

--- a/webconsole/gogo/src/main/java/org/apache/karaf/webconsole/gogo/Terminal.java
+++ b/webconsole/gogo/src/main/java/org/apache/karaf/webconsole/gogo/Terminal.java
@@ -182,7 +182,7 @@ public class Terminal {
         cx = 0;
         cy = 0;
         // Tab stops
-        tab_stops = new ArrayList<Integer>();
+        tab_stops = new ArrayList<>();
         for (int i = 7; i < width; i += 8) {
             tab_stops.add(i);
         }
@@ -654,7 +654,7 @@ public class Terminal {
     }
 
     private void esc_DECSC() {
-        vt100_saved = new HashMap<String, Object>();
+        vt100_saved = new HashMap<>();
         vt100_saved.put("cx", cx);
         vt100_saved.put("cy", cy);
         vt100_saved.put("attr", attr);
@@ -851,7 +851,7 @@ public class Terminal {
             } else if ("2".equals(m)) {
                 tab_stops.remove(Integer.valueOf(cx));
             } else if ("5".equals(m)) {
-                tab_stops = new ArrayList<Integer>();
+                tab_stops = new ArrayList<>();
             }
         }
     }

--- a/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/HttpPlugin.java
+++ b/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/HttpPlugin.java
@@ -199,7 +199,7 @@ public class HttpPlugin extends AbstractWebConsolePlugin {
     protected List<ServletDetails> getServletDetails() {
 
         Collection<ServletEvent> events = servletEventHandler.getServletEvents();
-        List<ServletDetails> result = new ArrayList<ServletDetails>(events.size());
+        List<ServletDetails> result = new ArrayList<>(events.size());
 
         for (ServletEvent event : events) {
             Servlet servlet = event.getServlet();
@@ -215,7 +215,7 @@ public class HttpPlugin extends AbstractWebConsolePlugin {
 
             String alias = event.getAlias() != null ? event.getAlias() : " ";
 
-            String[] urls = (String[]) (event.getUrlParameter() != null ? event.getUrlParameter() : new String[]{""});
+            String[] urls = event.getUrlParameter() != null ? event.getUrlParameter() : new String[]{""};
 
             ServletDetails details = new ServletDetails();
             details.setId(event.getBundle().getBundleId());
@@ -232,7 +232,7 @@ public class HttpPlugin extends AbstractWebConsolePlugin {
     protected List<WebDetail> getWebDetails() {
         Map<Long, WebEvent> bundleEvents = webEventHandler.getBundleEvents();
 
-        List<WebDetail> result = new ArrayList<WebDetail>();
+        List<WebDetail> result = new ArrayList<>();
 
         for (WebEvent event : bundleEvents.values()) {
 
@@ -264,7 +264,7 @@ public class HttpPlugin extends AbstractWebConsolePlugin {
     }
 
     public String getStatusLine(List<ServletDetails> servlets, List<WebDetail> web) {
-        Map<String, Integer> states = new HashMap<String, Integer>();
+        Map<String, Integer> states = new HashMap<>();
         for (ServletDetails servlet : servlets) {
             states.merge(servlet.getState(), 1, (a, b) -> a + b);
         }

--- a/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/ServletEventHandler.java
+++ b/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/ServletEventHandler.java
@@ -32,7 +32,7 @@ import org.osgi.framework.BundleListener;
 public class ServletEventHandler implements ServletListener, BundleListener {
 
     BundleContext bundleContext;
-    Map<String, ServletEvent> servletEvents =  new HashMap<String, ServletEvent>();
+    Map<String, ServletEvent> servletEvents = new HashMap<>();
 
     public void setBundleContext(BundleContext bundleContext) {
         this.bundleContext = bundleContext;

--- a/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/WebEventHandler.java
+++ b/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/WebEventHandler.java
@@ -29,7 +29,7 @@ import org.osgi.framework.BundleListener;
 public class WebEventHandler implements WebListener, BundleListener {
 
     BundleContext bundleContext;
-    private final Map<Long, WebEvent> bundleEvents = new HashMap<Long, WebEvent>();
+    private final Map<Long, WebEvent> bundleEvents = new HashMap<>();
 
     public void setBundleContext(BundleContext bundleContext) {
         this.bundleContext = bundleContext;

--- a/webconsole/instance/src/main/java/org/apache/karaf/webconsole/instance/InstancePlugin.java
+++ b/webconsole/instance/src/main/java/org/apache/karaf/webconsole/instance/InstancePlugin.java
@@ -150,7 +150,7 @@ public class InstancePlugin extends AbstractWebConsolePlugin {
     }
 
     private List<String> parseStringList(String value) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         if (value != null) {
             for (String el : value.split(",")) {
                 String trimmed = el.trim();

--- a/webconsole/instance/src/test/java/org/apache/karaf/webconsole/instance/InstancePluginTest.java
+++ b/webconsole/instance/src/test/java/org/apache/karaf/webconsole/instance/InstancePluginTest.java
@@ -63,7 +63,7 @@ public class InstancePluginTest extends TestCase {
         InstancePlugin ap = new InstancePlugin();
         ap.setInstanceService(instanceService);
 
-        final Map<String, String> params = new HashMap<String, String>();
+        final Map<String, String> params = new HashMap<>();
         params.put("action", "create");
         params.put("name", "instance1");
         params.put("sshPort", "123");
@@ -72,7 +72,7 @@ public class InstancePluginTest extends TestCase {
         params.put("featureURLs", "http://someURL");
         params.put("features", "abc,def");
         HttpServletRequest req = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(req.getParameter((String) EasyMock.anyObject())).andAnswer(new IAnswer<String>() {
+        EasyMock.expect(req.getParameter(EasyMock.anyObject())).andAnswer(new IAnswer<String>() {
             public String answer() throws Throwable {
                 return params.get(EasyMock.getCurrentArguments()[0]);
             }


### PR DESCRIPTION
This patch removes redundant type specifiers:
* generic specifiers with assignments;
* useless casts;
* inferable generics.

Signed-off-by: Stephen Kitt <skitt@redhat.com>