### PR TITLE
[KARAF-5173] Provide an impl of CallbackHandler

### DIFF
--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/NamePasswordCallbackHandler.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/NamePasswordCallbackHandler.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  under the License.
+ */
+package org.apache.karaf.jaas.modules;
+
+import java.io.IOException;
+import java.util.Objects;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+/**
+ * {@link CallbackHandler} implementation handling a name and password.
+ */
+public class NamePasswordCallbackHandler implements CallbackHandler {
+    private final String name;
+    private final String password;
+
+    public NamePasswordCallbackHandler(String name, String password) {
+        this.name = Objects.requireNonNull(name);
+        this.password = Objects.requireNonNull(password);
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        for (Callback cb : callbacks) {
+            if (cb instanceof NameCallback) {
+                ((NameCallback) cb).setName(name);
+            } else if (cb instanceof PasswordCallback) {
+                ((PasswordCallback) cb).setPassword(password.toCharArray());
+            }
+        }
+    }
+}

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/jdbc/JdbcLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/jdbc/JdbcLoginModuleTest.java
@@ -15,7 +15,6 @@
  */
 package org.apache.karaf.jaas.modules.jdbc;
 
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -23,17 +22,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.security.auth.Subject;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.PasswordCallback;
-import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.sql.DataSource;
 
 import org.apache.derby.jdbc.EmbeddedDataSource40;
 import org.apache.karaf.jaas.boot.principal.GroupPrincipal;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
+import org.apache.karaf.jaas.modules.NamePasswordCallbackHandler;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -115,7 +110,7 @@ public class JdbcLoginModuleTest {
         JDBCLoginModule module = new JDBCLoginModule();
 
         Subject subject = new Subject();
-        module.initialize(subject, getCallbackHandler("abc", "xyz"), null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("abc", "xyz"), null, options);
 
         module.login();
         module.commit();
@@ -137,7 +132,7 @@ public class JdbcLoginModuleTest {
         JDBCLoginModule module = new JDBCLoginModule();
 
         Subject subject = new Subject();
-        module.initialize(subject, getCallbackHandler("abc", "xyz"), null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("abc", "xyz"), null, options);
 
         module.login();
         module.commit();
@@ -217,20 +212,5 @@ public class JdbcLoginModuleTest {
         assertTrue(engine.listRoles(new UserPrincipal("abc")).isEmpty());
         assertTrue(engine.listRoles(new GroupPrincipal("group1")).isEmpty());
         assertTrue(engine.listGroups(new UserPrincipal("abc")).isEmpty());
-    }
-
-    private CallbackHandler getCallbackHandler(final String user, final String password) {
-        return new CallbackHandler() {
-                @Override
-                public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                    for (Callback cb : callbacks) {
-                        if (cb instanceof NameCallback) {
-                            ((NameCallback) cb).setName(user);
-                        } else if (cb instanceof PasswordCallback) {
-                            ((PasswordCallback) cb).setPassword(password.toCharArray());
-                        }
-                    }
-                }
-            };
     }
 }

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/krb5/Krb5LoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/krb5/Krb5LoginModuleTest.java
@@ -52,6 +52,7 @@ import org.apache.directory.shared.kerberos.KerberosUtils;
 import org.apache.directory.shared.kerberos.codec.types.EncryptionType;
 import org.apache.directory.shared.kerberos.components.EncryptionKey;
 import org.apache.directory.shared.kerberos.crypto.checksum.ChecksumType;
+import org.apache.karaf.jaas.modules.NamePasswordCallbackHandler;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -59,11 +60,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.security.auth.Subject;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.PasswordCallback;
-import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.kerberos.KerberosPrincipal;
 import javax.security.auth.kerberos.KerberosTicket;
 import javax.security.auth.login.Configuration;
@@ -233,21 +229,10 @@ public class Krb5LoginModuleTest extends AbstractKerberosITest {
 
     @Test
     public void testLoginSuccess() throws Exception {
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("hnelson");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("secret".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
 
         Krb5LoginModule module = new Krb5LoginModule();
-        module.initialize(subject, cb, null, new HashMap<>());
+        module.initialize(subject, new NamePasswordCallbackHandler("hnelson", "secret"), null, new HashMap<>());
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
 
@@ -283,21 +268,10 @@ public class Krb5LoginModuleTest extends AbstractKerberosITest {
 
     @Test(expected = LoginException.class)
     public void testLoginUsernameFailure() throws Exception {
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("hnelson0");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("secret".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
 
         Krb5LoginModule module = new Krb5LoginModule();
-        module.initialize(subject, cb, null, new HashMap<>());
+        module.initialize(subject, new NamePasswordCallbackHandler("hnelson0", "secret"), null, new HashMap<>());
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
 
@@ -307,21 +281,10 @@ public class Krb5LoginModuleTest extends AbstractKerberosITest {
 
     @Test(expected = LoginException.class)
     public void testLoginPasswordFailure() throws Exception {
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("hnelson");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("secret0".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
 
         Krb5LoginModule module = new Krb5LoginModule();
-        module.initialize(subject, cb, null, new HashMap<>());
+        module.initialize(subject, new NamePasswordCallbackHandler("hnelson", "secret0"), null, new HashMap<>());
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
 

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/GSSAPILdapLoginModuleTest.java
@@ -47,17 +47,13 @@ import org.apache.directory.shared.kerberos.crypto.checksum.ChecksumType;
 import org.apache.felix.utils.properties.Properties;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
+import org.apache.karaf.jaas.modules.NamePasswordCallbackHandler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.security.auth.Subject;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.PasswordCallback;
-import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.kerberos.KerberosPrincipal;
 import javax.security.auth.kerberos.KerberosTicket;
 import javax.security.auth.login.LoginException;
@@ -199,19 +195,8 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
         Properties options = ldapLoginModuleOptions();
         GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
 
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("hnelson");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("secret".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("hnelson", "secret"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertTrue(module.login());
@@ -260,19 +245,8 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
         Properties options = ldapLoginModuleOptions();
         GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
 
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("hnelson0");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("secret".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("hnelson0", "secret"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertTrue(module.login()); // should throw LoginException
@@ -284,19 +258,8 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
         Properties options = ldapLoginModuleOptions();
         GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
 
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("hnelson");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("secret0".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("hnelson", "secret0"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertTrue(module.login());
@@ -308,19 +271,8 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
         Properties options = ldapLoginModuleOptions();
         GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
 
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("test");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("test".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("test", "test"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertFalse(module.login());
@@ -333,19 +285,8 @@ public class GSSAPILdapLoginModuleTest extends AbstractKerberosITest {
         options.remove(GSSAPILdapLoginModule.REALM_PROPERTY);
         GSSAPILdapLoginModule module = new GSSAPILdapLoginModule();
 
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("hnelson0");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("secret".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("hnelson0", "secret"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertTrue(module.login()); // should throw LoginException

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapCacheTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapCacheTest.java
@@ -21,11 +21,7 @@ import javax.naming.directory.BasicAttribute;
 import javax.naming.directory.BasicAttributes;
 import javax.naming.directory.DirContext;
 import javax.security.auth.Subject;
-import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.PasswordCallback;
-import javax.security.auth.callback.UnsupportedCallbackException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -43,6 +39,7 @@ import org.apache.directory.server.core.integ.FrameworkRunner;
 import org.apache.felix.utils.properties.Properties;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
+import org.apache.karaf.jaas.modules.NamePasswordCallbackHandler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -95,17 +92,7 @@ public class LdapCacheTest extends AbstractLdapTestUnit {
     public void testAdminLogin() throws Exception {
         Properties options = ldapLoginModuleOptions();
         LDAPLoginModule module = new LDAPLoginModule();
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("admin");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("admin123".toCharArray());
-                    }
-                }
-            }
-        };
+        CallbackHandler cb = new NamePasswordCallbackHandler("admin", "admin123");
         Subject subject = new Subject();
         module.initialize(subject, cb, null, options);
 

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapCaseInsensitiveDNTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapCaseInsensitiveDNTest.java
@@ -25,19 +25,8 @@ import java.io.IOException;
 import java.security.Principal;
 
 import javax.security.auth.Subject;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.PasswordCallback;
-import javax.security.auth.callback.UnsupportedCallbackException;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.directory.api.ldap.model.constants.SchemaConstants;
-import org.apache.directory.api.ldap.model.message.ModifyRequest;
-import org.apache.directory.api.ldap.model.message.ModifyRequestImpl;
-import org.apache.directory.api.ldap.model.name.Dn;
-import org.apache.directory.ldap.client.api.LdapConnection;
-import org.apache.directory.ldap.client.api.LdapNetworkConnection;
 import org.apache.directory.server.core.integ.FrameworkRunner;
 import org.apache.directory.server.annotations.CreateLdapServer;
 import org.apache.directory.server.annotations.CreateTransport;
@@ -47,7 +36,7 @@ import org.apache.directory.server.core.annotations.CreatePartition;
 import org.apache.felix.utils.properties.Properties;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
-import org.apache.karaf.jaas.modules.ldap.LdapLoginModuleTest;
+import org.apache.karaf.jaas.modules.NamePasswordCallbackHandler;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -92,19 +81,8 @@ public class LdapCaseInsensitiveDNTest extends LdapLoginModuleTest {
     public void testCaseInsensitiveDN() throws Exception {
         Properties options = ldapLoginModuleOptions();
         LDAPLoginModule module = new LDAPLoginModule();
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("admin");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("admin123".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("admin", "admin123"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertTrue(module.login());

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapLoginModuleTest.java
@@ -26,13 +26,13 @@ import org.apache.directory.server.core.annotations.CreatePartition;
 import org.apache.felix.utils.properties.Properties;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
+import org.apache.karaf.jaas.modules.NamePasswordCallbackHandler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.security.auth.Subject;
-import javax.security.auth.callback.*;
 import javax.security.auth.login.LoginException;
 
 import java.io.File;
@@ -93,19 +93,8 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
     public void testAdminLogin() throws Exception {
         Properties options = ldapLoginModuleOptions();
         LDAPLoginModule module = new LDAPLoginModule();
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("admin");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("admin123".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("admin", "admin123"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertTrue(module.login());
@@ -144,19 +133,8 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
     public void testNonAdminLogin() throws Exception {
         Properties options = ldapLoginModuleOptions();
         LDAPLoginModule module = new LDAPLoginModule();
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("cheese");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("foodie".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("cheese", "foodie"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertTrue(module.login());
@@ -188,19 +166,8 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
         Properties options = ldapLoginModuleOptions();
         options.put("usernames.trim", "true");
         LDAPLoginModule module = new LDAPLoginModule();
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("cheese   ");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("foodie".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("cheese   ", "foodie"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertTrue(module.login());
@@ -231,19 +198,8 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
     public void testBadPassword() throws Exception {
         Properties options = ldapLoginModuleOptions();
         LDAPLoginModule module = new LDAPLoginModule();
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("admin");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("blahblah".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("admin", "blahblah"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         try {
@@ -258,19 +214,8 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
     public void testUserNotFound() throws Exception {
         Properties options = ldapLoginModuleOptions();
         LDAPLoginModule module = new LDAPLoginModule();
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("imnothere");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("admin123".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("imnothere", "admin123"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertFalse(module.login());
@@ -280,19 +225,8 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
     public void testEmptyPassword() throws Exception {
         Properties options = ldapLoginModuleOptions();
         LDAPLoginModule module = new LDAPLoginModule();
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("imnothere");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("imnothere", ""), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         try {
@@ -308,20 +242,8 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
         Properties options = ldapLoginModuleOptions();
         options.put(LDAPOptions.ROLE_MAPPING, "admin=karaf");
         LDAPLoginModule module = new LDAPLoginModule();
-        CallbackHandler cb = new CallbackHandler() {
-            @Override
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("admin");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("admin123".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("admin", "admin123"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertTrue(module.login());
@@ -352,19 +274,8 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
         Properties options = ldapLoginModuleOptions();
         options.put(LDAPOptions.ROLE_MAPPING, "admin=karaf,test;admin=another");
         LDAPLoginModule module = new LDAPLoginModule();
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("admin");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("admin123".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("admin", "admin123"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertTrue(module.login());
@@ -398,19 +309,8 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
         Properties options = ldapLoginModuleOptions();
         options.put(LDAPOptions.ROLE_MAPPING, "admin = karaf, test; admin = another");
         LDAPLoginModule module = new LDAPLoginModule();
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("admin");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("admin123".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("admin", "admin123"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertTrue(module.login());
@@ -448,19 +348,8 @@ public class LdapLoginModuleTest extends AbstractLdapTestUnit {
         options.put(LDAPOptions.ROLE_FILTER, "(member=%fqdn)");
         options.put(LDAPOptions.ROLE_NAME_ATTRIBUTE, "description");
         LDAPLoginModule module = new LDAPLoginModule();
-        CallbackHandler cb = new CallbackHandler() {
-            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                for (Callback cb : callbacks) {
-                    if (cb instanceof NameCallback) {
-                        ((NameCallback) cb).setName("admin");
-                    } else if (cb instanceof PasswordCallback) {
-                        ((PasswordCallback) cb).setPassword("admin123".toCharArray());
-                    }
-                }
-            }
-        };
         Subject subject = new Subject();
-        module.initialize(subject, cb, null, options);
+        module.initialize(subject, new NamePasswordCallbackHandler("admin", "admin123"), null, options);
 
         assertEquals("Precondition", 0, subject.getPrincipals().size());
         assertTrue(module.login());

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/properties/PropertiesLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/properties/PropertiesLoginModuleTest.java
@@ -31,6 +31,7 @@ import org.apache.felix.utils.properties.Properties;
 import org.apache.karaf.jaas.boot.principal.GroupPrincipal;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
+import org.apache.karaf.jaas.modules.NamePasswordCallbackHandler;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -49,20 +50,8 @@ public class PropertiesLoginModuleTest {
             PropertiesLoginModule module = new PropertiesLoginModule();
             Map<String, String> options = new HashMap<>();
             options.put(PropertiesLoginModule.USER_FILE, f.getAbsolutePath());
-            CallbackHandler cb = new CallbackHandler() {
-                @Override
-                public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                    for (Callback cb : callbacks) {
-                        if (cb instanceof NameCallback) {
-                            ((NameCallback) cb).setName("abc");
-                        } else if (cb instanceof PasswordCallback) {
-                            ((PasswordCallback) cb).setPassword("xyz".toCharArray());
-                        }
-                    }
-                }
-            };
             Subject subject = new Subject();
-            module.initialize(subject, cb, null, options);
+            module.initialize(subject, new NamePasswordCallbackHandler("abc", "xyz"), null, options);
 
             Assert.assertEquals("Precondition", 0, subject.getPrincipals().size());
             Assert.assertTrue(module.login());
@@ -105,19 +94,7 @@ public class PropertiesLoginModuleTest {
             PropertiesLoginModule module = new PropertiesLoginModule();
             Map<String, String> options = new HashMap<>();
             options.put(PropertiesLoginModule.USER_FILE, f.getAbsolutePath());
-            CallbackHandler cb = new CallbackHandler() {
-                @Override
-                public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                    for (Callback cb : callbacks) {
-                        if (cb instanceof NameCallback) {
-                            ((NameCallback) cb).setName("abc");
-                        } else if (cb instanceof PasswordCallback) {
-                            ((PasswordCallback) cb).setPassword("abc".toCharArray());
-                        }
-                    }
-                }
-            };
-            module.initialize(new Subject(), cb, null, options);
+            module.initialize(new Subject(), new NamePasswordCallbackHandler("abc", "abc"), null, options);
             try {
                 module.login();
                 Assert.fail("The login should have failed as the passwords didn't match");
@@ -146,20 +123,8 @@ public class PropertiesLoginModuleTest {
             PropertiesLoginModule module = new PropertiesLoginModule();
             Map<String, String> options = new HashMap<>();
             options.put(PropertiesLoginModule.USER_FILE, f.getAbsolutePath());
-            CallbackHandler cb = new CallbackHandler() {
-                @Override
-                public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                    for (Callback cb : callbacks) {
-                        if (cb instanceof NameCallback) {
-                            ((NameCallback) cb).setName("pqr");
-                        } else if (cb instanceof PasswordCallback) {
-                            ((PasswordCallback) cb).setPassword("abc".toCharArray());
-                        }
-                    }
-                }
-            };
             Subject subject = new Subject();
-            module.initialize(subject, cb, null, options);
+            module.initialize(subject, new NamePasswordCallbackHandler("pqr", "abc"), null, options);
 
             Assert.assertEquals("Precondition", 0, subject.getPrincipals().size());
             Assert.assertTrue(module.login());
@@ -214,19 +179,7 @@ public class PropertiesLoginModuleTest {
             PropertiesLoginModule module = new PropertiesLoginModule();
             Map<String, String> options = new HashMap<>();
             options.put(PropertiesLoginModule.USER_FILE, f.getAbsolutePath());
-            CallbackHandler cb = new CallbackHandler() {
-                @Override
-                public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-                    for (Callback cb : callbacks) {
-                        if (cb instanceof NameCallback) {
-                            ((NameCallback) cb).setName(name);
-                        } else if (cb instanceof PasswordCallback) {
-                            ((PasswordCallback) cb).setPassword("group".toCharArray());
-                        }
-                    }
-                }
-            };
-            module.initialize(new Subject(), cb, null, options);
+            module.initialize(new Subject(), new NamePasswordCallbackHandler(name, "group"), null, options);
             try {
                 module.login();
                 Assert.fail("The login should have failed as you cannot log in under a group name directly");


### PR DESCRIPTION
A number of tests use an anonymous class implementing CallbackHandler
with the same pattern, username and password. This patch introduces
NamePasswordCallbackHandler and uses it where appropriate.

Signed-off-by: Stephen Kitt <skitt@redhat.com>