### PR TITLE
A fix to KARAF-5104 karaf:run should support a features set

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
@@ -75,6 +75,13 @@ public class RunMojo extends MojoSupport {
     private boolean deployProjectArtifact = true;
 
     /**
+     * A list of URLs referencing feature repositories that will be added
+     * to the karaf instance started by this goal.
+     */
+    @Parameter
+    private String[] featureRepositories = null;
+
+    /**
      * Comma-separated list of features to install.
      */
     @Parameter(defaultValue = "")
@@ -332,6 +339,12 @@ public class RunMojo extends MojoSupport {
             	Class serviceClass = featureService.getClass();
             	Method addRepositoryMethod = serviceClass.getMethod("addRepository", URI.class);
                 addRepositoryMethod.invoke(featureService, attachedFeatureFile.toURI());
+
+                if (featureRepositories != null) {
+                    for (String featureRepo : featureRepositories) {
+                    	addRepositoryMethod.invoke(featureService, URI.create(featureRepo));
+                    }
+                }
 
                 if (featuresToInstall != null) {
                     Method installFeatureMethod = serviceClass.getMethod("installFeature", String.class);

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
@@ -131,7 +131,7 @@ public class RunMojo extends MojoSupport {
         }
     }
 
-    private void deploy(BundleContext bundleContext) throws MojoExecutionException {
+    void deploy(BundleContext bundleContext) throws MojoExecutionException {
         if (deployProjectArtifact) {
             File artifact = project.getArtifact().getFile();
             if (artifact != null && artifact.exists()) {

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
@@ -201,6 +201,7 @@ public class RunMojo extends MojoSupport {
                 String[] features = featuresToInstall.split(" *, *");
                 for (String feature : features) {
                     installFeatureMethod.invoke(featureService, feature);
+                    Thread.sleep(1000L);
                 }
             } catch (Exception e) {
                 throw new MojoExecutionException("Failed to add features to karaf", e);

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
@@ -75,6 +75,12 @@ public class RunMojo extends MojoSupport {
     private boolean deployProjectArtifact = true;
 
     /**
+     * Comma-separated list of features to install.
+     */
+    @Parameter(defaultValue = "")
+    private String featuresToInstall = null;
+
+    /**
      * Define if the Karaf container keep running or stop just after the goal execution
      */
     @Parameter(defaultValue = "true")
@@ -326,6 +332,14 @@ public class RunMojo extends MojoSupport {
             	Class serviceClass = featureService.getClass();
             	Method addRepositoryMethod = serviceClass.getMethod("addRepository", URI.class);
                 addRepositoryMethod.invoke(featureService, attachedFeatureFile.toURI());
+
+                if (featuresToInstall != null) {
+                    Method installFeatureMethod = serviceClass.getMethod("installFeature", String.class);
+                    String[] features = featuresToInstall.split(" *, *");
+                    for (String feature : features) {
+                        installFeatureMethod.invoke(featureService, feature);
+                    }
+                }
             } catch (Exception e) {
                 throw new MojoExecutionException("Failed to register attachment as feature repository", e);
             }

--- a/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/RunMojoTest.java
+++ b/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/RunMojoTest.java
@@ -266,6 +266,8 @@ public class RunMojoTest extends EasyMockSupport {
             project.addAttachedArtifact(artifactFeaturesAttachment);
             setInheritedPrivateField(mojo, "project", project);
             setPrivateField(mojo, "featuresToInstall", "liquibase-core, ukelonn-db-derby-test, ukelonn");
+            String[] featureRepos = { "mvn:org.ops4j.pax.jdbc/pax-jdbc-features/LATEST/xml/features" };
+            setPrivateField(mojo, "featureRepositories", featureRepos);
             mojo.deploy(context);
             verify(context);
         } finally {

--- a/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/RunMojoTest.java
+++ b/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/RunMojoTest.java
@@ -1,0 +1,143 @@
+package org.apache.karaf.tooling;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import static org.easymock.EasyMock.*;
+import org.easymock.EasyMockSupport;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+
+public class RunMojoTest extends EasyMockSupport {
+
+    @Test
+    public void testDeployWithDeployProjectArtifactFalse() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, MojoExecutionException {
+        BundleContext context = mock(BundleContext.class);
+        RunMojo mojo = new RunMojo();
+        setPrivateField(mojo, "deployProjectArtifact", false);
+        mojo.deploy(context);
+    }
+
+    @Test
+    public void testDeployWithNullArtifact() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        BundleContext context = mock(BundleContext.class);
+        Artifact artifact = mock(Artifact.class);
+        RunMojo mojo = new RunMojo();
+        MavenProject project = new MavenProject();
+        project.setArtifact(artifact);
+        setInheritedPrivateField(mojo, "project", project);
+        try {
+            mojo.deploy(context);
+            fail("Expected MojoExecutionException");
+        } catch (MojoExecutionException e) {
+            assertEquals("Project artifact doesn't exist", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDeployWithNonExistingArtifact() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        BundleContext context = mock(BundleContext.class);
+        Artifact artifact = mock(Artifact.class);
+        File artifactFile = mock(File.class);
+        expect(artifact.getFile()).andReturn(artifactFile);
+        replay(artifact);
+        RunMojo mojo = new RunMojo();
+        MavenProject project = new MavenProject();
+        project.setArtifact(artifact);
+        setInheritedPrivateField(mojo, "project", project);
+        try {
+            mojo.deploy(context);
+            fail("Expected MojoExecutionException");
+        } catch (MojoExecutionException e) {
+            assertEquals("Project artifact doesn't exist", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDeployWithExistingArtifactButProjectNotBundle() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        BundleContext context = mock(BundleContext.class);
+        Artifact artifact = mock(Artifact.class);
+        File artifactFile = mock(File.class);
+        expect(artifactFile.exists()).andReturn(true);
+        replay(artifactFile);
+        expect(artifact.getFile()).andReturn(artifactFile);
+        replay(artifact);
+        RunMojo mojo = new RunMojo();
+        MavenProject project = new MavenProject();
+        project.setArtifact(artifact);
+        setInheritedPrivateField(mojo, "project", project);
+        try {
+            mojo.deploy(context);
+            fail("Expected MojoExecutionException");
+        } catch (MojoExecutionException e) {
+            assertEquals("Packaging jar is not supported", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDeployWithExistingArtifactFailsInInstall() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        BundleContext context = mock(BundleContext.class);
+        Artifact artifact = mock(Artifact.class);
+        File artifactFile = niceMock(File.class);
+        expect(artifactFile.exists()).andReturn(true);
+        replay(artifactFile);
+        expect(artifact.getFile()).andReturn(artifactFile);
+        replay(artifact);
+        RunMojo mojo = new RunMojo();
+        MavenProject project = new MavenProject();
+        project.setPackaging("bundle");
+        project.setArtifact(artifact);
+        setInheritedPrivateField(mojo, "project", project);
+        try {
+            mojo.deploy(context);
+            fail("Expected MojoExecutionException");
+        } catch (MojoExecutionException e) {
+            assertEquals("Can't deploy project artifact in container", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDeployWithExistingArtifact() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, IOException, BundleException, MojoExecutionException {
+        BundleContext context = niceMock(BundleContext.class);
+        Bundle bundle = niceMock(Bundle.class);
+        expect(context.installBundle(anyString())).andReturn(bundle);
+        replay(context);
+        Artifact artifact = mock(Artifact.class);
+        File artifactFile = File.createTempFile("fake-bundle", ".jar");
+        try {
+            expect(artifact.getFile()).andReturn(artifactFile);
+            replay(artifact);
+            RunMojo mojo = new RunMojo();
+            MavenProject project = new MavenProject();
+            project.setPackaging("bundle");
+            project.setArtifact(artifact);
+            setInheritedPrivateField(mojo, "project", project);
+            replay(bundle);
+            mojo.deploy(context);
+            verify(bundle);
+        } finally {
+            artifactFile.delete();
+        }
+    }
+
+    private void setPrivateField(Object obj, String fieldName, Object value) throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        Field field = obj.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(obj, value);
+    }
+
+    private void setInheritedPrivateField(Object obj, String fieldName, Object value) throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        Field field = obj.getClass().getSuperclass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(obj, value);
+    }
+
+}

--- a/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/RunMojoTest.java
+++ b/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/RunMojoTest.java
@@ -5,16 +5,21 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.net.URI;
 
+import org.apache.karaf.features.FeaturesService;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import static org.easymock.EasyMock.*;
+
+import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
+import org.osgi.framework.ServiceReference;
 
 public class RunMojoTest extends EasyMockSupport {
 
@@ -125,6 +130,112 @@ public class RunMojoTest extends EasyMockSupport {
             verify(bundle);
         } finally {
             artifactFile.delete();
+        }
+    }
+
+    @Test
+    public void testDeployWithPomArtifactAndAttachedFeatureXmlNoFeatureService() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, IOException, BundleException, MojoExecutionException {
+        File artifactFeaturesAttachmentFile = File.createTempFile("someproject-features", ".xml");
+        try {
+            BundleContext context = niceMock(BundleContext.class);
+            Bundle bundle = niceMock(Bundle.class);
+            expect(context.installBundle(anyString())).andReturn(bundle);
+            replay(context);
+            Artifact artifact = niceMock(Artifact.class);
+            replay(artifact);
+            Artifact artifactFeaturesAttachment = mock(Artifact.class);
+            expect(artifactFeaturesAttachment.getFile()).andReturn(artifactFeaturesAttachmentFile);
+            expect(artifactFeaturesAttachment.getClassifier()).andReturn("features");
+            expect(artifactFeaturesAttachment.getType()).andReturn("xml");
+            replay(artifactFeaturesAttachment);
+
+            RunMojo mojo = new RunMojo();
+            MavenProject project = new MavenProject();
+            project.setPackaging("pom");
+            project.setArtifact(artifact);
+            project.addAttachedArtifact(artifactFeaturesAttachment);
+            setInheritedPrivateField(mojo, "project", project);
+            replay(bundle);
+            try {
+                mojo.deploy(context);
+                fail("Expected MojoExecutionException");
+            } catch (MojoExecutionException e) {
+                assertEquals("Failed to find the FeatureService when adding a feature repository", e.getMessage());
+            }
+        } finally {
+            artifactFeaturesAttachmentFile.delete();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testDeployWithPomArtifactAndAttachedFeatureXmlRepoRegistrationFails() throws Exception {
+        File artifactFeaturesAttachmentFile = File.createTempFile("someproject-features", ".xml");
+        try {
+            FeaturesService featureService = niceMock(FeaturesService.class);
+            featureService.addRepository(anyObject(URI.class));
+            EasyMock.expectLastCall().andThrow(new Exception("Not a feature repository"));
+            replay(featureService);
+            ServiceReference<FeaturesService> ref = niceMock(ServiceReference.class);
+            BundleContext context = niceMock(BundleContext.class);
+            expect(context.getServiceReference(eq(FeaturesService.class))).andReturn(ref);
+            expect(context.getService(eq(ref))).andReturn(featureService);
+            replay(context);
+            Artifact artifact = niceMock(Artifact.class);
+            replay(artifact);
+            Artifact artifactFeaturesAttachment = mock(Artifact.class);
+            expect(artifactFeaturesAttachment.getFile()).andReturn(artifactFeaturesAttachmentFile);
+            expect(artifactFeaturesAttachment.getClassifier()).andReturn("features");
+            expect(artifactFeaturesAttachment.getType()).andReturn("xml");
+            replay(artifactFeaturesAttachment);
+
+            RunMojo mojo = new RunMojo();
+            MavenProject project = new MavenProject();
+            project.setPackaging("pom");
+            project.setArtifact(artifact);
+            project.addAttachedArtifact(artifactFeaturesAttachment);
+            setInheritedPrivateField(mojo, "project", project);
+            try {
+                mojo.deploy(context);
+                fail("Expected MojoExecutionException");
+            } catch (MojoExecutionException e) {
+                assertEquals("Failed to register attachment as feature repository", e.getMessage());
+            }
+        } finally {
+            artifactFeaturesAttachmentFile.delete();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testDeployWithPomArtifactAndAttachedFeatureXml() throws Exception {
+        File artifactFeaturesAttachmentFile = File.createTempFile("someproject-features", ".xml");
+        try {
+            FeaturesService featureService = niceMock(FeaturesService.class);
+            replay(featureService);
+            ServiceReference<FeaturesService> ref = niceMock(ServiceReference.class);
+            BundleContext context = niceMock(BundleContext.class);
+            expect(context.getServiceReference(eq(FeaturesService.class))).andReturn(ref);
+            expect(context.getService(eq(ref))).andReturn(featureService);
+            replay(context);
+            Artifact artifact = niceMock(Artifact.class);
+            replay(artifact);
+            Artifact artifactFeaturesAttachment = mock(Artifact.class);
+            expect(artifactFeaturesAttachment.getFile()).andReturn(artifactFeaturesAttachmentFile);
+            expect(artifactFeaturesAttachment.getClassifier()).andReturn("features");
+            expect(artifactFeaturesAttachment.getType()).andReturn("xml");
+            replay(artifactFeaturesAttachment);
+
+            RunMojo mojo = new RunMojo();
+            MavenProject project = new MavenProject();
+            project.setPackaging("pom");
+            project.setArtifact(artifact);
+            project.addAttachedArtifact(artifactFeaturesAttachment);
+            setInheritedPrivateField(mojo, "project", project);
+            mojo.deploy(context);
+            verify(context);
+        } finally {
+            artifactFeaturesAttachmentFile.delete();
         }
     }
 


### PR DESCRIPTION
This pull request is a fix to [KARAF-5104](https://issues.apache.org/jira/browse/KARAF-5104)

This change adds:

1. A parameter to set a list of URLs to feature repositories to add to the karaf started by karaf:run
2. A parameter containing a comma separated list of features to install in the karaf started by karaf:run
3. If karaf:run is set up to deploy the current project artifact and if the current project has packaging pom and an attached file with classifier "features" and type "xml", that attachment will be installed as a feature repository in the karaf started by the karaf:run goal

Even if you decide not to take this change, you might consider the first commit of this pull request, because that is just as-is unit tests of the RunMojo.deploy(BundleContext) method.