### PR TITLE
Typo: buffer -> session, cursor -> commandLine

### DIFF
--- a/manual/src/main/asciidoc/developer-guide/extending.adoc
+++ b/manual/src/main/asciidoc/developer-guide/extending.adoc
@@ -284,7 +284,7 @@ public class SimpleNameCompleter implements Completer {
         delegate.getStrings().add("Mike");
         delegate.getStrings().add("Eric");
         delegate.getStrings().add("Jenny");
-        return delegate.complete(buffer, cursor, candidates);
+        return delegate.complete(session, commandLine, candidates);
     }
 
 }


### PR DESCRIPTION
Both references `buffer` and `cursor` are undefined.
delegate.complete requires as first argument a Session reference, followed by a CommandLine reference, thus `session` and `commandLine`.
