### PR TITLE
[KARAF-5099] set the log:list description and display Log levels like log:get

### DIFF
--- a/log/src/main/java/org/apache/karaf/log/command/GetListLogLevel.java
+++ b/log/src/main/java/org/apache/karaf/log/command/GetListLogLevel.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.karaf.log.command;
 
 import java.util.Map;
@@ -30,30 +31,27 @@ import org.apache.karaf.shell.support.table.ShellTable;
 /**
  * Get the log level
  */
-@Command(scope = "log", name = "get", description = "Shows the currently set log level.")
+@Command(scope = "log", name = "list", description = "Shows the currently set log level, alias for log:get ALL")
 @Service
-public class GetLogLevel implements Action {
+public class GetListLogLevel implements Action {
 
-    @Argument(index = 0, name = "logger", description = "The name of the logger or ALL (default)", required = false, multiValued = false)
-    String logger;
+	@Argument(index = 0, name = "logger", description = "The name of the logger or ALL (default)", required = false, multiValued = false)
+	String logger;
 
-    @Option(name = "--no-format", description = "Disable table rendered output", required = false, multiValued = false)
-    boolean noFormat;
+	@Option(name = "--no-format", description = "Disable table rendered output", required = false, multiValued = false)
+	boolean noFormat;
 
-    @Reference
-    LogService logService;
+	@Reference
+	LogService logService;
 
-    @Override
-    public Object execute() throws Exception {
-        if (logger == null || logger.equalsIgnoreCase("ALL")) {
-            Map<String, String> loggers = logService.getLevel("ALL");
-            ShellTable table = new ShellTable();
-            table.column("Logger");
-            table.column("Level");
-            loggers.forEach((n, l) -> table.addRow().addContent(n, l));
-            table.print(System.out, !noFormat);
-        }
-        return null;
-    }
-
+	@Override
+	public Object execute() throws Exception {
+		Map<String, String> loggers = logService.getLevel("ALL");
+		ShellTable table = new ShellTable();
+		table.column("Logger");
+		table.column("Level");
+		loggers.forEach((n, l) -> table.addRow().addContent(n, l));
+		table.print(System.out, !noFormat);
+		return null;
+	}
 }


### PR DESCRIPTION
Checking this doc,  https://karaf.apache.org/manual/latest/ it says, 

> log:list displays all loggers and level (alias to log:get ALL command)

log:list always seems to display 'null'. As the command is an Alias of log:get, there is some confusion on what is displays or how users are going to use this. Hence, there needs to be a separate description present on this command to properly guide users on what it does, and leave the log:get as it is.