### PR TITLE
Fix karaf scheduler interface abstraction leak on exceptions

### DIFF
--- a/scheduler/src/main/java/org/apache/karaf/scheduler/Scheduler.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/Scheduler.java
@@ -19,8 +19,6 @@ package org.apache.karaf.scheduler;
 import java.util.Date;
 import java.util.Map;
 
-import org.quartz.SchedulerException;
-
 /**
  * A scheduler to schedule time/cron based jobs.
  * A job is an object that is executed/fired by the scheduler. The object
@@ -73,7 +71,7 @@ public interface Scheduler {
      *
      * @param job The job to execute (either {@link Job} or {@link Runnable}).
      * @param options Required options defining how to schedule the job.
-     * @throws SchedulerException if the job can't be scheduled.
+     * @throws SchedulerError if the job can't be scheduled.
      * @throws IllegalArgumentException If the preconditions are not met.
      * @see #NOW()
      * @see #NOW(int, long)
@@ -81,7 +79,7 @@ public interface Scheduler {
      * @see #AT(Date, int, long)
      * @see #EXPR(String)
      */
-    void schedule(Object job, ScheduleOptions options) throws IllegalArgumentException, SchedulerException;
+    void schedule(Object job, ScheduleOptions options) throws IllegalArgumentException, SchedulerError;
 
     /**
      * Remove a scheduled job by name.
@@ -91,7 +89,7 @@ public interface Scheduler {
      */
     boolean unschedule(String jobName);
 
-    Map<Object, ScheduleOptions> getJobs() throws SchedulerException;
+    Map<Object, ScheduleOptions> getJobs() throws SchedulerError;
 
     /**
      * Create a schedule options to fire a job immediately and only once.

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/SchedulerError.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/SchedulerError.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.scheduler;
+
+public class SchedulerError extends Exception {
+
+    public SchedulerError() {
+    }
+
+    public SchedulerError(String msg) {
+        super(msg);
+    }
+
+    public SchedulerError(Throwable cause) {
+        super(cause);
+    }
+
+    public SchedulerError(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+}


### PR DESCRIPTION
Wrap quartz SchedulerException in SchedulerError instead of using the
private exception class in the scheduler API.

This fixes wiring errors in service clients when using the scheduler interface, since class `org.quartz.SchedulerException` is not exported by scheduler-core bundle.