### PR TITLE
Add karaf command scheduler:trigger

### DIFF
--- a/scheduler/src/main/java/org/apache/karaf/scheduler/Scheduler.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/Scheduler.java
@@ -92,6 +92,15 @@ public interface Scheduler {
     Map<Object, ScheduleOptions> getJobs() throws SchedulerError;
 
     /**
+     * Triggers a scheduled job.
+     *
+     * @param jobName The name of the job.
+     * @return <code>true</code> if the job was triggered, otherwise <code>false</code>
+     * @throws SchedulerError  if the job can't be triggered.
+     */
+    boolean trigger(String jobName) throws SchedulerError;
+
+    /**
      * Create a schedule options to fire a job immediately and only once.
      *
      * @return The corresponding {@link ScheduleOptions}.

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/command/Trigger.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/command/Trigger.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.scheduler.command;
+
+import org.apache.karaf.scheduler.command.support.TriggerJob;
+import org.apache.karaf.scheduler.Scheduler;
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+
+@Command(scope = "scheduler", name = "trigger", description = "Manually trigger a scheduled job")
+@Service
+public class Trigger implements Action {
+
+    @Argument(description = "Name of the job to trigger", required = true)
+    String name;
+
+    @Option(name = "-b", aliases = "background", description = "schedule the trigger in the background", required = false)
+    boolean background = false;
+
+    @Reference
+    Scheduler scheduler;
+
+    @Override
+    public Object execute() throws Exception {
+        if (background) {
+            System.out.println("Scheduling background trigger for job " + name);
+            scheduler.schedule(new TriggerJob(scheduler, name), scheduler.NOW());
+        } else {
+            System.out.println("Triggering job " + name);
+            if (!scheduler.trigger(name)) {
+                System.out.println("Could not find a scheduled job with name " + name);
+            }
+        }
+        return null;
+    }
+
+
+}

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/command/support/TriggerJob.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/command/support/TriggerJob.java
@@ -1,0 +1,36 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.apache.karaf.scheduler.command.support;
+
+import org.apache.karaf.scheduler.Scheduler;
+import org.apache.karaf.scheduler.SchedulerError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TriggerJob implements Runnable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TriggerJob.class);
+
+    private final Scheduler scheduler;
+    private final String name;
+
+    public TriggerJob(Scheduler scheduler, String name) {
+        this.scheduler = scheduler;
+        this.name = name;
+    }
+
+    @Override
+    public void run() {
+        try {
+            if (!scheduler.trigger(name)) {
+                LOGGER.warn("Could not find a scheduled job with name " + name);
+            }
+        } catch (SchedulerError ex) {
+            LOGGER.error("Failed to trigger job {}", name, ex);
+        }
+    }
+
+}

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/core/QuartzScheduler.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/core/QuartzScheduler.java
@@ -301,4 +301,22 @@ public class QuartzScheduler implements Scheduler {
         }
     }
 
+    @Override
+    public boolean trigger(String jobName) throws SchedulerError {
+        final org.quartz.Scheduler s = this.scheduler;
+        if (jobName != null && s != null) {
+            try {
+                final JobKey key = JobKey.jobKey(jobName);
+                final JobDetail jobdetail = s.getJobDetail(key);
+                if (jobdetail != null) {
+                    this.scheduler.triggerJob(key, jobdetail.getJobDataMap());
+                    return true;
+                }
+            } catch (SchedulerException ex) {
+                throw new SchedulerError(ex);
+            }
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
Allow console users to manually trigger jobs from the karaf scheduler list.

Example:

```
karaf@root()> scheduler:schedule --name test --period 60 { echo $(date) }
karaf@root()> Aug Sun 13 00:47:53 2017                                                                                                                                                         
scheduler:trigger test
Triggered job test                                                                                                                                                                             
karaf@root()> scheduler:trigger -b test                                                                                                                                                        
Scheduling background trigger for job test                                                                                                                                                     
Aug Sun 13 01:14:50 2017
```

The `scheduler:trigger` command works well with non-shell jobs, but triggering karaf scripts sometimes generates a conflict with Felix: 

```
2017-08-13 00:47:57,571 | WARN  | null_Worker-2    | ScriptJob                        | 52 - org.apache.karaf.scheduler.core - 4.2.0.SNAPSHOT | Error executing script
java.lang.IllegalStateException: A job is already in foreground
        at org.apache.felix.gogo.runtime.CommandSessionImpl$JobImpl.foreground(CommandSessionImpl.java:643) [42:org.apache.karaf.shell.core:4.2.0.SNAPSHOT]
        at org.apache.felix.gogo.runtime.CommandSessionImpl$JobImpl.start(CommandSessionImpl.java:760) [42:org.apache.karaf.shell.core:4.2.0.SNAPSHOT]
        at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:295) [42:org.apache.karaf.shell.core:4.2.0.SNAPSHOT]
        at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:168) [42:org.apache.karaf.shell.core:4.2.0.SNAPSHOT]
        at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:148) [42:org.apache.karaf.shell.core:4.2.0.SNAPSHOT]
        at org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand$VersatileFunction.execute(SecuredCommand.java:107) [42:org.apache.karaf.shell.core:4.2.0.SNAPSHOT]
        at org.apache.karaf.scheduler.command.support.ScriptJob.execute(ScriptJob.java:43) [52:org.apache.karaf.scheduler.core:4.2.0.SNAPSHOT]
        at org.apache.karaf.scheduler.core.QuartzJobExecutor.execute(QuartzJobExecutor.java:53) [52:org.apache.karaf.scheduler.core:4.2.0.SNAPSHOT]
        at org.quartz.core.JobRunShell.run(JobRunShell.java:202) [52:org.apache.karaf.scheduler.core:4.2.0.SNAPSHOT]
        at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573) [52:org.apache.karaf.scheduler.core:4.2.0.SNAPSHOT]
```

The `scheduler:trigger -b` command tries to avoid this by scheduling a job that in turns runs the trigger (hopefully) after the foreground console command has finished.