### PR TITLE
Optimize GenerateDescriptorMojo

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 
@@ -456,6 +457,7 @@ public class GenerateDescriptorMojo extends MojoSupport {
         // TODO Initialise the repositories from the existing feature file if any
         Map<Dependency, Feature> otherFeatures = new HashMap<>();
         Map<Feature, String> featureRepositories = new HashMap<>();
+        FeaturesCache cache = new FeaturesCache();
         for (final LocalDependency entry : localDependencies) {
             Object artifact = entry.getArtifact();
 
@@ -463,9 +465,11 @@ public class GenerateDescriptorMojo extends MojoSupport {
                 continue;
             }
 
-            processFeatureArtifact(features, feature, otherFeatures, featureRepositories, artifact, entry.getParent(),
-                    true);
+            processFeatureArtifact(features, feature, otherFeatures, featureRepositories, cache, artifact,
+                    entry.getParent(), true);
         }
+        // Do not retain cache beyond this point
+        cache = null;
 
         // Second pass to look for bundles
         if (addBundlesToPrimaryFeature) {
@@ -557,7 +561,7 @@ public class GenerateDescriptorMojo extends MojoSupport {
     }
 
     private void processFeatureArtifact(Features features, Feature feature, Map<Dependency, Feature> otherFeatures,
-                                        Map<Feature, String> featureRepositories,
+                                        Map<Feature, String> featureRepositories, FeaturesCache cache,
                                         Object artifact, Object parent, boolean add)
             throws MojoExecutionException, XMLStreamException, JAXBException, IOException {
         if (this.dependencyHelper.isArtifactAFeature(artifact) && FEATURE_CLASSIFIER.equals(
@@ -567,9 +571,9 @@ public class GenerateDescriptorMojo extends MojoSupport {
                 throw new MojoExecutionException(
                         "Cannot locate file for feature: " + artifact + " at " + featuresFile);
             }
-            Features includedFeatures = readFeaturesFile(featuresFile);
+            Features includedFeatures = cache.get(featuresFile);
             for (String repository : includedFeatures.getRepository()) {
-                processFeatureArtifact(features, feature, otherFeatures, featureRepositories,
+                processFeatureArtifact(features, feature, otherFeatures, featureRepositories, cache,
                         new DefaultArtifact(MavenUtil.mvnToAether(repository)), parent, false);
             }
             for (Feature includedFeature : includedFeatures.getFeature()) {
@@ -921,4 +925,18 @@ public class GenerateDescriptorMojo extends MojoSupport {
         return "\tTree listing is saved here: " + treeListFile.getAbsolutePath() + "\n";
     }
 
+    private static final class FeaturesCache {
+        private final Map<File, Features> map = new WeakHashMap<>();
+
+        Features get(final File featuresFile) throws XMLStreamException, JAXBException, IOException {
+            final Features existing = map.get(featuresFile);
+            if (existing != null) {
+                return existing;
+            }
+
+            final Features computed = readFeaturesFile(featuresFile);
+            map.put(featuresFile, computed);
+            return computed;
+        }
+    }
 }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -483,8 +483,6 @@ public class GenerateDescriptorMojo extends MojoSupport {
 
                 if (!this.dependencyHelper.isArtifactAFeature(artifact)) {
                     String bundleName = this.dependencyHelper.artifactToMvn(artifact, getVersionOrRange(entry.getParent(), artifact));
-                    File bundleFile = this.dependencyHelper.resolve(artifact, getLog());
-                    Manifest manifest = getManifest(bundleFile);
 
                     for (ConfigFile cf : feature.getConfigfile()) {
                         if (bundleName.equals(cf.getLocation().replace('\n', ' ').trim())) {
@@ -493,7 +491,9 @@ public class GenerateDescriptorMojo extends MojoSupport {
                         }
                     }
 
-                    if (manifest == null || !ManifestUtils.isBundle(getManifest(bundleFile))) {
+                    File bundleFile = this.dependencyHelper.resolve(artifact, getLog());
+                    Manifest manifest = getManifest(bundleFile);
+                    if (manifest == null || !ManifestUtils.isBundle(manifest)) {
                         bundleName = "wrap:" + bundleName;
                         needWrap = true;
                     }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MojoSupport.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MojoSupport.java
@@ -18,11 +18,12 @@
 package org.apache.karaf.tooling.utils;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -350,11 +351,8 @@ public abstract class MojoSupport extends AbstractMojo {
         File targetDir = destFile.getParentFile();
         ensureDirExists(targetDir);
 
-        try {
-            try (
-                FileInputStream is = new FileInputStream(sourceFile);
-                FileOutputStream bos = new FileOutputStream(destFile)
-            ) {
+        try (InputStream is = Files.newInputStream(sourceFile.toPath())) {
+            try (OutputStream bos = Files.newOutputStream(destFile.toPath())) {
                 StreamUtils.copy(is, bos);
             }
         } catch (IOException e) {


### PR DESCRIPTION
OpenDaylight typically processes deeply nested feature.xmls, which takes significant time. This PR optimizes GenerateDescriptorMojo, reducing build time observed by a factor of 3.