### PR TITLE
shell.core instead of shell.console

### DIFF
--- a/manual/src/main/asciidoc/developer-guide/extending.adoc
+++ b/manual/src/main/asciidoc/developer-guide/extending.adoc
@@ -78,7 +78,7 @@ Alternatively, you can simply create the directory `shell-sample-commands` and c
   <dependencies>
     <dependency>
       <groupId>org.apache.karaf.shell</groupId>
-      <artifactId>org.apache.karaf.shell.console</artifactId>
+      <artifactId>org.apache.karaf.shell.core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
The @org.apache.karaf.shell.commands.Command from org.apache.karaf.shell.console is deprecated, so wouldn't it be better to document using the org.apache.karaf.shell.core which has org.apache.karaf.shell.api.action.Command ?