### PR TITLE
[KARAF-5357] Fixes mistake in feature help info

### DIFF
--- a/features/command/src/main/java/org/apache/karaf/features/command/StopFeaturesCommand.java
+++ b/features/command/src/main/java/org/apache/karaf/features/command/StopFeaturesCommand.java
@@ -29,7 +29,7 @@ import org.apache.karaf.shell.api.action.Completion;
 import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 
-@Command(scope = "feature", name = "stop", description = "Start features with the specified name and version.")
+@Command(scope = "feature", name = "stop", description = "Stop features with the specified name and version.")
 @Service
 public class StopFeaturesCommand extends FeaturesCommandSupport {
 


### PR DESCRIPTION
This PR simply fixes a typo in the text that is displayed when someone looks up info on the 'feature' command in the karaf client console.