### PR TITLE
Speed up string splitting operations

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/model/Feature.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/model/Feature.java
@@ -128,9 +128,9 @@ public class Feature extends Content implements org.apache.karaf.features.Featur
 
     public static org.apache.karaf.features.Feature valueOf(String str) {
         if (str.contains(VERSION_SEPARATOR)) {
-            String strName = str.substring(0, str.indexOf(VERSION_SEPARATOR));
-            String strVersion = str.substring(str.indexOf(VERSION_SEPARATOR)
-                    + VERSION_SEPARATOR.length(), str.length());
+            int idx = str.indexOf(VERSION_SEPARATOR);
+            String strName = str.substring(0, idx);
+            String strVersion = str.substring(idx + VERSION_SEPARATOR.length(), str.length());
             return new Feature(strName, strVersion);
         } else {
             return new Feature(str);

--- a/features/core/src/main/java/org/apache/karaf/features/internal/region/Subsystem.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/region/Subsystem.java
@@ -227,7 +227,7 @@ public class Subsystem extends ResourceImpl {
     }
 
     public void require(String requirement) throws BundleException {
-        int idx = requirement.indexOf(":");
+        int idx = requirement.indexOf(':');
         String type, req;
         if (idx >= 0) {
             type = requirement.substring(0, idx);

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/FeaturesServiceImpl.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/FeaturesServiceImpl.java
@@ -892,13 +892,18 @@ public class FeaturesServiceImpl implements FeaturesService, Deployer.DeployCall
         }
     }
 
-    private String normalize(String feature) {
-        if (!feature.contains(VERSION_SEPARATOR)) {
-            feature += "/0.0.0";
+    private static String normalize(String feature) {
+        final int idx = feature.indexOf(VERSION_SEPARATOR);
+        final String name;
+        final String version;
+        if (idx == -1) {
+            name = feature;
+            version = "0.0.0";
+        } else {
+            name = feature.substring(0, idx);
+            version = feature.substring(idx + 1);
         }
-        int idx = feature.indexOf(VERSION_SEPARATOR);
-        String name = feature.substring(0, idx);
-        String version = feature.substring(idx + 1);
+
         return name + VERSION_SEPARATOR + VersionCleaner.clean(version);
     }
 


### PR DESCRIPTION
Instead of performing multiple String.indexOf(String) operations,
use String.indexOf(char) and cache its result.

Signed-off-by: Robert Varga <nite@hq.sk>