### PR TITLE
[KARAF-5380] Fix typo in JDBC lock implementation

### DIFF
--- a/main/src/main/java/org/apache/karaf/main/Main.java
+++ b/main/src/main/java/org/apache/karaf/main/Main.java
@@ -380,7 +380,7 @@ public class Main {
         File dataDir = new File(System.getProperty(ConfigProperties.PROP_KARAF_DATA));
         while (!exiting) {
             if (lock.lock()) {
-                lockCallback.lockAquired();
+                lockCallback.lockAcquired();
                 for (;;) {
                     if (!dataDir.isDirectory()) {
                         LOG.info("Data directory does not exist anymore, halting");
@@ -736,7 +736,7 @@ public class Main {
         }
 
         @Override
-        public void lockAquired() {
+        public void lockAcquired() {
             LOG.info("Lock acquired. Setting startlevel to " + config.defaultStartLevel);
             shutdownThread = InstanceHelper.setupShutdown(config, framework);
             setStartLevel(config.defaultStartLevel);

--- a/main/src/main/java/org/apache/karaf/main/lock/DefaultJDBCLock.java
+++ b/main/src/main/java/org/apache/karaf/main/lock/DefaultJDBCLock.java
@@ -185,7 +185,7 @@ public class DefaultJDBCLock implements Lock {
         String lockCreateStatement = statements.getLockCreateStatement();
         PreparedStatement preparedStatement = null;
         boolean lockAcquired = false;
-        
+
         try {
             preparedStatement = getConnection().prepareStatement(lockCreateStatement);
             preparedStatement.setQueryTimeout(timeout);
@@ -196,7 +196,7 @@ public class DefaultJDBCLock implements Lock {
         } finally {
             closeSafely(preparedStatement);
         }
-        
+
         return lockAcquired;
     }
 

--- a/main/src/main/java/org/apache/karaf/main/lock/DefaultJDBCLock.java
+++ b/main/src/main/java/org/apache/karaf/main/lock/DefaultJDBCLock.java
@@ -172,7 +172,7 @@ public class DefaultJDBCLock implements Lock {
      * @see org.apache.karaf.main.Lock#lock()
      */
     public boolean lock() {
-        boolean result = aquireLock();
+        boolean result = acquireLock();
         
         if (result) {
             result = updateLock();
@@ -181,15 +181,15 @@ public class DefaultJDBCLock implements Lock {
         return result;
     }
     
-    boolean aquireLock() {
+    boolean acquireLock() {
         String lockCreateStatement = statements.getLockCreateStatement();
         PreparedStatement preparedStatement = null;
-        boolean lockAquired = false;
+        boolean lockAcquired = false;
         
         try {
             preparedStatement = getConnection().prepareStatement(lockCreateStatement);
             preparedStatement.setQueryTimeout(timeout);
-            lockAquired = preparedStatement.execute();
+            lockAcquired = preparedStatement.execute();
         } catch (Exception e) {
             // Do we want to display this message everytime???
             log(Level.WARNING, "Failed to acquire database lock", e);
@@ -197,7 +197,7 @@ public class DefaultJDBCLock implements Lock {
             closeSafely(preparedStatement);
         }
         
-        return lockAquired;
+        return lockAcquired;
     }
 
     boolean updateLock() {

--- a/main/src/main/java/org/apache/karaf/main/lock/GenericJDBCLock.java
+++ b/main/src/main/java/org/apache/karaf/main/lock/GenericJDBCLock.java
@@ -343,9 +343,9 @@ public class GenericJDBCLock implements Lock {
     public boolean lock() throws Exception {
         try (Connection connection = getConnection()) {
             // Try to acquire/update the lock state
-            boolean lockAquired = acquireLock(connection, statements.getLockUpdateIdStatement(uniqueId, ++state, lock_delay, uniqueId));
+            boolean lockAcquired = acquireLock(connection, statements.getLockUpdateIdStatement(uniqueId, ++state, lock_delay, uniqueId));
 
-            if (!lockAquired) {
+            if (!lockAcquired) {
 
                 String lockSelectStatement = statements.getLockSelectStatement();
 
@@ -364,7 +364,7 @@ public class GenericJDBCLock implements Lock {
                                     if ((this.currentStateTime + this.currentLockDelay + this.currentLockDelay) < System.currentTimeMillis()) {
                                         // The state was not been updated for more than twice the lock_delay value of the current master...
                                         // Try to steal the lock....
-                                        lockAquired = acquireLock(connection, statements.getLockUpdateIdStatementToStealLock(uniqueId, state, lock_delay, currentId, currentState));
+                                        lockAcquired = acquireLock(connection, statements.getLockUpdateIdStatementToStealLock(uniqueId, state, lock_delay, currentId, currentState));
                                     }
                                 } else {
                                     // Set the current time to be used to determine if we can
@@ -390,7 +390,7 @@ public class GenericJDBCLock implements Lock {
                 }
             }
 
-            return lockAquired;
+            return lockAcquired;
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Error while trying to obtain the lock", e);
             return false;

--- a/main/src/main/java/org/apache/karaf/main/lock/Lock.java
+++ b/main/src/main/java/org/apache/karaf/main/lock/Lock.java
@@ -21,9 +21,9 @@ package org.apache.karaf.main.lock;
 public interface Lock {
 
     /**
-     * A KeepAlive function to maintain the lock. 
+     * A KeepAlive function to maintain the lock.
      * Indicates whether or not the lock could be acquired.
-     * 
+     *
      * @return True if connection lock retained, false otherwise.
      * @throws Exception If the lock can't be acquired.
      */
@@ -31,14 +31,14 @@ public interface Lock {
 
     /**
      * Terminate the lock connection safely.
-     * 
+     *
      * @throws Exception If the lock can't be released.
      */
     void release() throws Exception;
 
     /**
      * Indicate whether or not the lock still exists.
-     * 
+     *
      * @return True, if the lock still exists, otherwise false.
      * @throws Exception If an error occurs while checking if the lock is alive.
      */

--- a/main/src/main/java/org/apache/karaf/main/lock/Lock.java
+++ b/main/src/main/java/org/apache/karaf/main/lock/Lock.java
@@ -22,7 +22,7 @@ public interface Lock {
 
     /**
      * A KeepAlive function to maintain the lock. 
-     * Indicates whether or not the lock could be aquired.
+     * Indicates whether or not the lock could be acquired.
      * 
      * @return True if connection lock retained, false otherwise.
      * @throws Exception If the lock can't be acquired.

--- a/main/src/main/java/org/apache/karaf/main/lock/LockCallBack.java
+++ b/main/src/main/java/org/apache/karaf/main/lock/LockCallBack.java
@@ -23,7 +23,7 @@ package org.apache.karaf.main.lock;
  */
 public interface LockCallBack {
 
-    void lockAquired();
+    void lockAcquired();
 
     void lockLost();
 

--- a/main/src/main/java/org/apache/karaf/main/lock/OracleJDBCLock.java
+++ b/main/src/main/java/org/apache/karaf/main/lock/OracleJDBCLock.java
@@ -53,7 +53,7 @@ public class OracleJDBCLock extends DefaultJDBCLock {
      */
     @Override
     public boolean lock() {
-        return aquireLock();
+        return acquireLock();
     }
     
     /**
@@ -65,31 +65,31 @@ public class OracleJDBCLock extends DefaultJDBCLock {
      */
     @Override
     boolean updateLock() {
-        return aquireLock();
+        return acquireLock();
     }
     
     /**
      * A SELECT FOR UPDATE does not create a database lock when the SELECT FOR UPDATE is performed
-     * on an empty selection. So a succesfull call to {@link DefaultJDBCLock#aquireLock()} is not sufficient to 
+     * on an empty selection. So a succesfull call to {@link DefaultJDBCLock#acquireLock()} is not sufficient to 
      * ensure that we are the only one who have acquired the lock.
      */
     @Override
-    boolean aquireLock() {
-    	return super.aquireLock() && lockAcquiredOnNonEmptySelection();
+    boolean acquireLock() {
+    	return super.acquireLock() && lockAcquiredOnNonEmptySelection();
     }
     
     //Verify that we have a non empty record set.
     private boolean lockAcquiredOnNonEmptySelection() {
         String verifySelectionNotEmpytStatement = statements.getLockVerifySelectionNotEmptyStatement();
         PreparedStatement preparedStatement = null;
-        boolean lockAquired = false;
+        boolean lockAcquired = false;
         
         try {
             preparedStatement = getConnection().prepareStatement(verifySelectionNotEmpytStatement);
             preparedStatement.setQueryTimeout(timeout);
             ResultSet rs = preparedStatement.executeQuery();
             if (rs.next()) {
-            	lockAquired = rs.getInt(1) > 0;
+               lockAcquired = rs.getInt(1) > 0;
             } else {
             	LOG.warning("Failed to acquire database lock. Missing database lock record.");
             }
@@ -98,6 +98,6 @@ public class OracleJDBCLock extends DefaultJDBCLock {
         }finally {
             closeSafely(preparedStatement);
         }        
-        return lockAquired;
+        return lockAcquired;
     }
 }

--- a/main/src/main/java/org/apache/karaf/main/lock/OracleJDBCLock.java
+++ b/main/src/main/java/org/apache/karaf/main/lock/OracleJDBCLock.java
@@ -28,7 +28,7 @@ import org.apache.felix.utils.properties.Properties;
  * to become master.
  */
 public class OracleJDBCLock extends DefaultJDBCLock {
-    
+
     private static final String MOMENT_COLUMN_DATA_TYPE = "NUMBER(20)";
 
     public OracleJDBCLock(Properties props) {
@@ -43,61 +43,61 @@ public class OracleJDBCLock extends DefaultJDBCLock {
         statements.setMomentColumnDataType(MOMENT_COLUMN_DATA_TYPE);
         return statements;
     }
-    
+
     /**
      * When we perform an update on a long lived locked table, Oracle will save
      * a copy of the transaction in it's UNDO table space. Eventually this can
      * cause the UNDO table to become full, disrupting all locks in the DB instance.
      * A select query just touches the table, ensuring we can still read the DB but
-     * doesn't add to the UNDO. 
+     * doesn't add to the UNDO.
      */
     @Override
     public boolean lock() {
         return acquireLock();
     }
-    
+
     /**
      * When we perform an update on a long lived locked table, Oracle will save
      * a copy of the transaction in it's UNDO table space. Eventually this can
      * cause the UNDO table to become full, disrupting all locks in the DB instance.
      * A select query just touches the table, ensuring we can still read the DB but
-     * doesn't add to the UNDO. 
+     * doesn't add to the UNDO.
      */
     @Override
     boolean updateLock() {
         return acquireLock();
     }
-    
+
     /**
      * A SELECT FOR UPDATE does not create a database lock when the SELECT FOR UPDATE is performed
-     * on an empty selection. So a succesfull call to {@link DefaultJDBCLock#acquireLock()} is not sufficient to 
+     * on an empty selection. So a succesfull call to {@link DefaultJDBCLock#acquireLock()} is not sufficient to
      * ensure that we are the only one who have acquired the lock.
      */
     @Override
     boolean acquireLock() {
-    	return super.acquireLock() && lockAcquiredOnNonEmptySelection();
+        return super.acquireLock() && lockAcquiredOnNonEmptySelection();
     }
-    
+
     //Verify that we have a non empty record set.
     private boolean lockAcquiredOnNonEmptySelection() {
         String verifySelectionNotEmpytStatement = statements.getLockVerifySelectionNotEmptyStatement();
         PreparedStatement preparedStatement = null;
         boolean lockAcquired = false;
-        
+
         try {
             preparedStatement = getConnection().prepareStatement(verifySelectionNotEmpytStatement);
             preparedStatement.setQueryTimeout(timeout);
             ResultSet rs = preparedStatement.executeQuery();
             if (rs.next()) {
-               lockAcquired = rs.getInt(1) > 0;
+                lockAcquired = rs.getInt(1) > 0;
             } else {
-            	LOG.warning("Failed to acquire database lock. Missing database lock record.");
+                LOG.warning("Failed to acquire database lock. Missing database lock record.");
             }
         } catch (Exception e) {
             LOG.warning("Failed to acquire database lock: " + e);
-        }finally {
+        } finally {
             closeSafely(preparedStatement);
-        }        
+        }
         return lockAcquired;
     }
 }

--- a/main/src/main/java/org/apache/karaf/main/lock/PostgreSQLJDBCLock.java
+++ b/main/src/main/java/org/apache/karaf/main/lock/PostgreSQLJDBCLock.java
@@ -32,9 +32,9 @@ public class PostgreSQLJDBCLock extends DefaultJDBCLock {
     }
 
     @Override
-    boolean aquireLock() {
+    boolean acquireLock() {
         this.timeout = 0;
 
-        return super.aquireLock();
+        return super.acquireLock();
     }
 }

--- a/main/src/test/java/org/apache/karaf/main/lock/BaseJDBCLockTest.java
+++ b/main/src/test/java/org/apache/karaf/main/lock/BaseJDBCLockTest.java
@@ -37,7 +37,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public abstract class BaseJDBCLockTest {
-    
+
     DefaultJDBCLock lock;
     Properties props;
     String user = "root";
@@ -50,22 +50,22 @@ public abstract class BaseJDBCLockTest {
     String momentDatatype = "BIGINT";
     String nodeDatatype = "VARCHAR(20)";
     String createTableStmtSuffix = "";
-    
+
     Connection connection;
     DatabaseMetaData metaData;
     ResultSet resultSet;
     PreparedStatement preparedStatement;
     Statement statement;
-    
+
     abstract DefaultJDBCLock createLock(Properties props);
-    
+
     @BeforeClass
     public static void setUpTestSuite() {
         Properties properties = new Properties();
         properties.put("karaf.bootstrap.log", "target/karaf.log");
         BootstrapLogManager.setProperties(properties);
     }
-    
+
     @Before
     public void setUp() throws Exception {
         connection = EasyMock.createNiceMock(Connection.class);
@@ -73,7 +73,7 @@ public abstract class BaseJDBCLockTest {
         resultSet = EasyMock.createMock(ResultSet.class);
         preparedStatement = EasyMock.createMock(PreparedStatement.class);
         statement = EasyMock.createMock(Statement.class);
-        
+
         props = new Properties();
         props.put("karaf.lock.jdbc.url", url);
         props.put("karaf.lock.jdbc.driver", driver);
@@ -83,7 +83,7 @@ public abstract class BaseJDBCLockTest {
         props.put("karaf.lock.jdbc.clustername", clustername);
         props.put("karaf.lock.jdbc.timeout", Integer.toString(timeout));
     }
-    
+
     @Test
     public void initShouldCreateTheSchemaIfItNotExists() throws Exception {
         expect(connection.isClosed()).andReturn(false);
@@ -99,14 +99,14 @@ public abstract class BaseJDBCLockTest {
         expect(statement.execute("INSERT INTO " + tableName + " (MOMENT, NODE) VALUES (1, '" + clustername + "')")).andReturn(false);
         statement.close();
         connection.commit();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         lock = createLock(props);
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
     }
-    
+
     @Test
     public void initShouldNotCreateTheSchemaIfItAlreadyExists() throws Exception {
         connection.setAutoCommit(false);
@@ -116,17 +116,17 @@ public abstract class BaseJDBCLockTest {
         resultSet.close();
         expectLastCall().atLeastOnce();
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         lock = createLock(props);
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
     }
-    
+
     @Test
     public void lockShouldReturnTrueItTheTableIsNotLocked() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(false);
         expect(connection.prepareStatement("SELECT * FROM " + tableName + " FOR UPDATE")).andReturn(preparedStatement);
         preparedStatement.setQueryTimeout(10);
@@ -137,20 +137,20 @@ public abstract class BaseJDBCLockTest {
         preparedStatement.setQueryTimeout(10);
         expect(preparedStatement.executeUpdate()).andReturn(1);
         preparedStatement.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean lockAcquired = lock.lock();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertTrue(lockAcquired);
     }
-    
+
     @Test
     public void lockShouldReturnFalseIfAnotherRowIsLocked() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(false);
         expect(connection.prepareStatement("SELECT * FROM " + tableName + " FOR UPDATE")).andReturn(preparedStatement);
         preparedStatement.setQueryTimeout(10);
@@ -161,20 +161,20 @@ public abstract class BaseJDBCLockTest {
         preparedStatement.setQueryTimeout(10);
         expect(preparedStatement.executeUpdate()).andThrow(new SQLException());
         preparedStatement.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean lockAcquired = lock.lock();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertFalse(lockAcquired);
     }
-    
+
     @Test
     public void lockShouldReturnFalseIfTheRowIsAlreadyLocked() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(false);
         expect(connection.prepareStatement("SELECT * FROM " + tableName + " FOR UPDATE")).andReturn(preparedStatement);
         preparedStatement.setQueryTimeout(10);
@@ -185,136 +185,136 @@ public abstract class BaseJDBCLockTest {
         preparedStatement.setQueryTimeout(10);
         expect(preparedStatement.executeUpdate()).andThrow(new SQLException());
         preparedStatement.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean lockAcquired = lock.lock();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertFalse(lockAcquired);
     }
-    
+
     @Test
     public void release() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(false);
         expect(connection.isClosed()).andReturn(false);
         expect(connection.isClosed()).andReturn(false);
         connection.rollback();
         connection.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         lock.release();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
     }
-    
+
     @Test
     public void releaseShouldSucceedForAnAlreadyClosedConnection() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(true);
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         lock.release();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
     }
-    
+
     @Test
     public void releaseShouldSucceedForANullConnectionReference() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         lock.lockConnection = null;
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         lock.release();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
     }
-    
+
     @Test
     public void isAliveShouldReturnTrueIfItHoldsTheLock() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(false);
         expect(connection.isClosed()).andReturn(false);
         expect(connection.prepareStatement("UPDATE " + tableName + " SET MOMENT = 1")).andReturn(preparedStatement);
         preparedStatement.setQueryTimeout(10);
         expect(preparedStatement.executeUpdate()).andReturn(1);
         preparedStatement.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean alive = lock.isAlive();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertTrue(alive);
     }
-    
+
     @Test
     public void isAliveShouldReturnFalseIfTheConnectionIsClosed() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(true);
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean alive = lock.isAlive();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertFalse(alive);
     }
-    
+
     @Test
     public void isAliveShouldReturnFalseIfTheConnectionIsNull() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         lock.lockConnection = null;
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean alive = lock.isAlive();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertFalse(alive);
     }
-    
+
     @Test
     public void isAliveShouldReturnFalseIfItNotHoldsTheLock() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(false);
         expect(connection.isClosed()).andReturn(false);
         expect(connection.prepareStatement("UPDATE " + tableName + " SET MOMENT = 1")).andReturn(preparedStatement);
         preparedStatement.setQueryTimeout(10);
         expect(preparedStatement.executeUpdate()).andThrow(new SQLException());
         preparedStatement.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean alive = lock.isAlive();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertFalse(alive);
     }
-    
+
     @Test
     public void lockShouldReturnFalseIfTableIsEmpty() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(false);
         expect(connection.prepareStatement("SELECT * FROM " + tableName + " FOR UPDATE")).andReturn(preparedStatement);
         preparedStatement.setQueryTimeout(10);
@@ -325,11 +325,11 @@ public abstract class BaseJDBCLockTest {
         preparedStatement.setQueryTimeout(10);
         expect(preparedStatement.executeUpdate()).andReturn(0);
         preparedStatement.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean lockAcquired = lock.lock();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertFalse(lockAcquired);
     }

--- a/main/src/test/java/org/apache/karaf/main/lock/BaseJDBCLockTest.java
+++ b/main/src/test/java/org/apache/karaf/main/lock/BaseJDBCLockTest.java
@@ -140,10 +140,10 @@ public abstract class BaseJDBCLockTest {
         
         replay(connection, metaData, statement, preparedStatement, resultSet);
         
-        boolean lockAquired = lock.lock();
+        boolean lockAcquired = lock.lock();
         
         verify(connection, metaData, statement, preparedStatement, resultSet);
-        assertTrue(lockAquired);
+        assertTrue(lockAcquired);
     }
     
     @Test
@@ -164,10 +164,10 @@ public abstract class BaseJDBCLockTest {
         
         replay(connection, metaData, statement, preparedStatement, resultSet);
         
-        boolean lockAquired = lock.lock();
+        boolean lockAcquired = lock.lock();
         
         verify(connection, metaData, statement, preparedStatement, resultSet);
-        assertFalse(lockAquired);
+        assertFalse(lockAcquired);
     }
     
     @Test
@@ -188,10 +188,10 @@ public abstract class BaseJDBCLockTest {
         
         replay(connection, metaData, statement, preparedStatement, resultSet);
         
-        boolean lockAquired = lock.lock();
+        boolean lockAcquired = lock.lock();
         
         verify(connection, metaData, statement, preparedStatement, resultSet);
-        assertFalse(lockAquired);
+        assertFalse(lockAcquired);
     }
     
     @Test
@@ -328,9 +328,9 @@ public abstract class BaseJDBCLockTest {
         
         replay(connection, metaData, statement, preparedStatement, resultSet);
         
-        boolean lockAquired = lock.lock();
+        boolean lockAcquired = lock.lock();
         
         verify(connection, metaData, statement, preparedStatement, resultSet);
-        assertFalse(lockAquired);
+        assertFalse(lockAcquired);
     }
 }

--- a/main/src/test/java/org/apache/karaf/main/lock/OracleJDBCLockTest.java
+++ b/main/src/test/java/org/apache/karaf/main/lock/OracleJDBCLockTest.java
@@ -91,10 +91,10 @@ public class OracleJDBCLockTest extends BaseJDBCLockTest {
         
         replay(connection, metaData, statement, preparedStatement, resultSet);
         
-        boolean lockAquired = lock.lock();
+        boolean lockAcquired = lock.lock();
         
         verify(connection, metaData, statement, preparedStatement, resultSet);
-        assertTrue(lockAquired);
+        assertTrue(lockAcquired);
     }
     
     @Test
@@ -111,10 +111,10 @@ public class OracleJDBCLockTest extends BaseJDBCLockTest {
         
         replay(connection, metaData, statement, preparedStatement, resultSet);
         
-        boolean lockAquired = lock.lock();
+        boolean lockAcquired = lock.lock();
         
         verify(connection, metaData, statement, preparedStatement, resultSet);
-        assertFalse(lockAquired);
+        assertFalse(lockAcquired);
     }
     
     @Test
@@ -131,10 +131,10 @@ public class OracleJDBCLockTest extends BaseJDBCLockTest {
         
         replay(connection, metaData, statement, preparedStatement, resultSet);
         
-        boolean lockAquired = lock.lock();
+        boolean lockAcquired = lock.lock();
         
         verify(connection, metaData, statement, preparedStatement, resultSet);
-        assertFalse(lockAquired);
+        assertFalse(lockAcquired);
     }
     
     @Test
@@ -204,9 +204,9 @@ public class OracleJDBCLockTest extends BaseJDBCLockTest {
         
         replay(connection, metaData, statement, preparedStatement, resultSet);
         
-        boolean lockAquired = lock.lock();
+        boolean lockAcquired = lock.lock();
         
         verify(connection, metaData, statement, preparedStatement, resultSet);
-        assertFalse(lockAquired);
+        assertFalse(lockAcquired);
     }
 }

--- a/main/src/test/java/org/apache/karaf/main/lock/OracleJDBCLockTest.java
+++ b/main/src/test/java/org/apache/karaf/main/lock/OracleJDBCLockTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 
 
 public class OracleJDBCLockTest extends BaseJDBCLockTest {
-    
+
     @Before
     @Override
     public void setUp() throws Exception {
@@ -43,10 +43,10 @@ public class OracleJDBCLockTest extends BaseJDBCLockTest {
         driver = "oracle.jdbc.driver.OracleDriver";
         url = "jdbc:oracle:thin:@172.16.16.132:1521:XE";
         momentDatatype = "NUMBER(20)";
-        
+
         super.setUp();
     }
-    
+
     OracleJDBCLock createLock(Properties props) {
         return new OracleJDBCLock(props) {
             @Override
@@ -62,14 +62,14 @@ public class OracleJDBCLockTest extends BaseJDBCLockTest {
             long getCurrentTimeMillis() {
                 return 1;
             }
-            
+
             @Override
             public void log(Level level, String msg, Exception e) {
                 // Suppress log
             }
         };
     }
-    
+
     @Test
     @Override
     public void lockShouldReturnTrueItTheTableIsNotLocked() throws Exception {
@@ -88,60 +88,60 @@ public class OracleJDBCLockTest extends BaseJDBCLockTest {
         expect(resultSet.next()).andReturn(Boolean.TRUE);
         expect(resultSet.getInt(1)).andReturn(1);
         preparedStatement.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean lockAcquired = lock.lock();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertTrue(lockAcquired);
     }
-    
+
     @Test
     @Override
     public void lockShouldReturnFalseIfAnotherRowIsLocked() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(false);
         expect(connection.prepareStatement("SELECT * FROM " + tableName + " FOR UPDATE")).andReturn(preparedStatement);
         preparedStatement.setQueryTimeout(10);
         expect(preparedStatement.execute()).andThrow(new SQLException());
         preparedStatement.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean lockAcquired = lock.lock();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertFalse(lockAcquired);
     }
-    
+
     @Test
     @Override
     public void lockShouldReturnFalseIfTheRowIsAlreadyLocked() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(false);
         expect(connection.prepareStatement("SELECT * FROM " + tableName + " FOR UPDATE")).andReturn(preparedStatement);
         preparedStatement.setQueryTimeout(10);
         expect(preparedStatement.execute()).andThrow(new SQLException());
         preparedStatement.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean lockAcquired = lock.lock();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertFalse(lockAcquired);
     }
-    
+
     @Test
     public void isAliveShouldReturnTrueIfItHoldsTheLock() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(false);
         expect(connection.isClosed()).andReturn(false);
         expect(connection.prepareStatement("SELECT * FROM " + tableName + " FOR UPDATE")).andReturn(preparedStatement);
@@ -155,40 +155,40 @@ public class OracleJDBCLockTest extends BaseJDBCLockTest {
         expect(resultSet.next()).andReturn(Boolean.TRUE);
         expect(resultSet.getInt(1)).andReturn(1);
         preparedStatement.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean alive = lock.isAlive();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertTrue(alive);
     }
-    
+
     @Test
     public void isAliveShouldReturnFalseIfItNotHoldsTheLock() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(false);
         expect(connection.isClosed()).andReturn(false);
         expect(connection.prepareStatement("SELECT * FROM " + tableName + " FOR UPDATE")).andReturn(preparedStatement);
         preparedStatement.setQueryTimeout(10);
         expect(preparedStatement.execute()).andThrow(new SQLException());
         preparedStatement.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean alive = lock.isAlive();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertFalse(alive);
     }
-    
+
     @Test
     public void lockShouldReturnFalseIfTableIsEmpty() throws Exception {
         initShouldNotCreateTheSchemaIfItAlreadyExists();
         reset(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         expect(connection.isClosed()).andReturn(false);
         expect(connection.prepareStatement("SELECT * FROM " + tableName + " FOR UPDATE")).andReturn(preparedStatement);
         preparedStatement.setQueryTimeout(10);
@@ -201,11 +201,11 @@ public class OracleJDBCLockTest extends BaseJDBCLockTest {
         expect(resultSet.next()).andReturn(Boolean.TRUE);
         expect(resultSet.getInt(1)).andReturn(0);
         preparedStatement.close();
-        
+
         replay(connection, metaData, statement, preparedStatement, resultSet);
-        
+
         boolean lockAcquired = lock.lock();
-        
+
         verify(connection, metaData, statement, preparedStatement, resultSet);
         assertFalse(lockAcquired);
     }

--- a/main/src/test/java/org/apache/karaf/main/lock/PostgreSQLJDBCLockTest.java
+++ b/main/src/test/java/org/apache/karaf/main/lock/PostgreSQLJDBCLockTest.java
@@ -113,10 +113,10 @@ public class PostgreSQLJDBCLockTest extends BaseJDBCLockTest {
 
         replay(connection, metaData, statement, preparedStatement, resultSet);
 
-        boolean lockAquired = lock.lock();
+        boolean lockAcquired = lock.lock();
 
         verify(connection, metaData, statement, preparedStatement, resultSet);
-        assertTrue(lockAquired);
+        assertTrue(lockAcquired);
     }
 
     @Test
@@ -138,10 +138,10 @@ public class PostgreSQLJDBCLockTest extends BaseJDBCLockTest {
 
         replay(connection, metaData, statement, preparedStatement, resultSet);
 
-        boolean lockAquired = lock.lock();
+        boolean lockAcquired = lock.lock();
 
         verify(connection, metaData, statement, preparedStatement, resultSet);
-        assertFalse(lockAquired);
+        assertFalse(lockAcquired);
     }
 
     @Test
@@ -163,10 +163,10 @@ public class PostgreSQLJDBCLockTest extends BaseJDBCLockTest {
 
         replay(connection, metaData, statement, preparedStatement, resultSet);
 
-        boolean lockAquired = lock.lock();
+        boolean lockAcquired = lock.lock();
 
         verify(connection, metaData, statement, preparedStatement, resultSet);
-        assertFalse(lockAquired);
+        assertFalse(lockAcquired);
     }
 
     @Test
@@ -188,9 +188,9 @@ public class PostgreSQLJDBCLockTest extends BaseJDBCLockTest {
 
         replay(connection, metaData, statement, preparedStatement, resultSet);
 
-        boolean lockAquired = lock.lock();
+        boolean lockAcquired = lock.lock();
 
         verify(connection, metaData, statement, preparedStatement, resultSet);
-        assertFalse(lockAquired);
+        assertFalse(lockAcquired);
     }
 }

--- a/main/src/test/java/org/apache/karaf/main/lock/PostgreSQLJDBCLockTest.java
+++ b/main/src/test/java/org/apache/karaf/main/lock/PostgreSQLJDBCLockTest.java
@@ -34,17 +34,17 @@ import static org.junit.Assert.assertTrue;
 
 
 public class PostgreSQLJDBCLockTest extends BaseJDBCLockTest {
-    
+
     @Before
     @Override
     public void setUp() throws Exception {
         password = "secret";
         driver = "org.postgresql.Driver";
         url = "jdbc:postgresql://127.0.0.1:5432/test";
-        
+
         super.setUp();
     }
-    
+
     DefaultJDBCLock createLock(Properties props) {
         return new PostgreSQLJDBCLock(props) {
             @Override
@@ -60,24 +60,24 @@ public class PostgreSQLJDBCLockTest extends BaseJDBCLockTest {
             long getCurrentTimeMillis() {
                 return 1;
             }
-            
+
             @Override
             public void log(Level level, String msg, Exception e) {
                 // Suppress log
             }
         };
     }
-    
+
     @Test
     public void createConnectionShouldConcatinateOptionsCorrect() {
         props.put("karaf.lock.jdbc.url", this.url + ";dataEncryption=false");
-        
+
         lock = new PostgreSQLJDBCLock(props) {
             @Override
             boolean schemaExists() {
                 return true;
             }
-            
+
             @Override
             Connection doCreateConnection(String driver, String url, String username, String password) {
                 assertEquals(this.driver, driver);


### PR DESCRIPTION
Replace `aquire` with `acquire` in method names, variables, and comments. Also remove trailing whitespace and apply consistent indentation in touched files.