### PR TITLE
Turn Feature.VERSION_SEPARATOR into a char

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/model/Feature.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/model/Feature.java
@@ -78,7 +78,7 @@ import org.apache.felix.utils.version.VersionCleaner;
         })
 public class Feature extends Content implements org.apache.karaf.features.Feature {
 
-    public static final String VERSION_SEPARATOR = "/";
+    public static final char VERSION_SEPARATOR = '/';
     public static final String DEFAULT_VERSION = "0.0.0";
 
     @XmlElement(name = "details", namespace=org.apache.karaf.features.FeaturesNamespaces.URI_CURRENT)
@@ -130,7 +130,7 @@ public class Feature extends Content implements org.apache.karaf.features.Featur
         int idx = str.indexOf(VERSION_SEPARATOR);
         if (idx >= 0) {
             String strName = str.substring(0, idx);
-            String strVersion = str.substring(idx + VERSION_SEPARATOR.length(), str.length());
+            String strVersion = str.substring(idx + 1, str.length());
             return new Feature(strName, strVersion);
         } else {
             return new Feature(str);


### PR DESCRIPTION
String.indexOf(char) is faster than String.indexOf(String), so use
char for VERSION_SEPARATOR.

Signed-off-by: Robert Varga <nite@hq.sk>