### PR TITLE
Clean up object duplication

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/region/SubsystemResolver.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/region/SubsystemResolver.java
@@ -232,7 +232,7 @@ public class SubsystemResolver {
         return wiring;
     }
 
-    private Object toJson(Map<Resource, List<Wire>> wiring) {
+    private static Object toJson(Map<Resource, List<Wire>> wiring) {
         Map<String, List<Map<String, Object>>> wires = new HashMap<>();
         for (Map.Entry<Resource, List<Wire>> reswiring : wiring.entrySet()) {
             Resource resource = reswiring.getKey();
@@ -251,25 +251,25 @@ public class SubsystemResolver {
         return wires;
     }
 
-    private String toString(Resource r) {
+    private static String toString(Resource r) {
         return toString(r.getCapabilities(IDENTITY_NAMESPACE).get(0));
     }
 
-    private String toString(Requirement r) {
+    private static String toString(Requirement r) {
         return BaseClause.toString(null, r.getNamespace(), r.getAttributes(), r.getDirectives());
     }
 
-    private String toString(Capability c) {
+    private static String toString(Capability c) {
         return BaseClause.toString(null, c.getNamespace(), c.getAttributes(), c.getDirectives());
     }
 
-    private Object toJson(Repository repository) {
+    private static Object toJson(Repository repository) {
         Requirement req = new RequirementImpl(
                 null,
                 IDENTITY_NAMESPACE,
                 Collections.emptyMap(),
                 Collections.emptyMap(),
-                new SimpleFilter(null, null, SimpleFilter.MATCH_ALL));
+                SimpleFilter.MATCH_ALL_FILTER);
         Collection<Capability> identities = repository.findProviders(Collections.singleton(req)).get(req);
         List<Object> resources = new ArrayList<>();
         for (Capability identity : identities) {
@@ -279,7 +279,7 @@ public class SubsystemResolver {
         return resources;
     }
 
-    private Object toJson(Resource resource) {
+    private static Object toJson(Resource resource) {
         Map<String, Object> obj = new HashMap<>();
         List<Object> caps = new ArrayList<>();
         List<Object> reqs = new ArrayList<>();
@@ -371,7 +371,7 @@ public class SubsystemResolver {
     }
 
     /**
-     * 
+     *
      * @return map of bundles and the region they are deployed in
      */
     public Map<Resource, String> getBundles() {
@@ -403,7 +403,7 @@ public class SubsystemResolver {
     }
 
     /**
-     * 
+     *
      * @param resourceFilter
      * @return map from resource to region name
      */
@@ -475,7 +475,7 @@ public class SubsystemResolver {
         return null;
     }
 
-    private Capability findMatchingCapability(SimpleFilter filter, Collection<Capability> caps) {
+    private static Capability findMatchingCapability(SimpleFilter filter, Collection<Capability> caps) {
         for (Capability cap : caps) {
             if (CapabilitySet.matches(cap, filter)) {
                 return cap;
@@ -484,7 +484,7 @@ public class SubsystemResolver {
         return null;
     }
 
-    private Wire findMatchingWire(SimpleFilter filter, Collection<Wire> wires) {
+    private static Wire findMatchingWire(SimpleFilter filter, Collection<Wire> wires) {
         for (Wire wire : wires) {
             Capability cap = wire.getCapability();
             if (CapabilitySet.matches(cap, filter)) {
@@ -494,7 +494,7 @@ public class SubsystemResolver {
         return null;
     }
 
-    private SimpleFilter createFilter(String... s) {
+    private static SimpleFilter createFilter(String... s) {
         Map<String, Object> attrs = new HashMap<>();
         for (int i = 0; i < s.length - 1; i += 2) {
             attrs.put(s[i], s[i + 1]);
@@ -516,13 +516,14 @@ public class SubsystemResolver {
         }
     }
 
-    private boolean isFlat(Subsystem subsystem) {
-        if (subsystem == null || subsystem.getFeature() == null)
+    private static boolean isFlat(Subsystem subsystem) {
+        if (subsystem == null || subsystem.getFeature() == null) {
             return false;
+        }
         return subsystem.getFeature() != null && subsystem.getFeature().getScoping() == null;
     }
 
-    private Subsystem getOrCreateChild(Subsystem ss, String name) {
+    private static Subsystem getOrCreateChild(Subsystem ss, String name) {
         Subsystem child = ss.getChild(name);
         return child != null ? child : ss.createSubsystem(name, true);
     }
@@ -539,7 +540,7 @@ public class SubsystemResolver {
         }
     }
 
-    private RegionFilterBuilder createRegionFilterBuilder(RegionDigraph digraph, Map<String, Set<String>> sharingPolicy) throws InvalidSyntaxException {
+    private static RegionFilterBuilder createRegionFilterBuilder(RegionDigraph digraph, Map<String, Set<String>> sharingPolicy) throws InvalidSyntaxException {
         RegionFilterBuilder result = digraph.createRegionFilterBuilder();
         for (Map.Entry<String, Set<String>> entry : sharingPolicy.entrySet()) {
             for (String filter : entry.getValue()) {

--- a/features/core/src/main/java/org/apache/karaf/features/internal/repository/BaseRepository.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/repository/BaseRepository.java
@@ -79,7 +79,7 @@ public class BaseRepository implements Repository {
                     String filter = requirement.getDirectives().get(Constants.FILTER_DIRECTIVE);
                     sf = (filter != null)
                             ? SimpleFilter.parse(filter)
-                            : new SimpleFilter(null, null, SimpleFilter.MATCH_ALL);
+                            : SimpleFilter.MATCH_ALL_FILTER;
                 }
                 result.put(requirement, set.match(sf, true));
             } else {

--- a/features/core/src/main/java/org/apache/karaf/features/internal/resolver/SimpleFilter.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/resolver/SimpleFilter.java
@@ -55,11 +55,13 @@ public class SimpleFilter {
         COMMON_STRINGS = s;
     }
 
+    public static final SimpleFilter MATCH_ALL_FILTER = new SimpleFilter(null, null, MATCH_ALL);
+
     private final String name;
     private final Object value;
     private final int op;
 
-    public SimpleFilter(String name, Object value, int op) {
+    SimpleFilter(String name, Object value, int op) {
         this.name = internIfCommon(name);
         this.value = value;
         this.op = op;
@@ -572,16 +574,13 @@ public class SimpleFilter {
             }
         }
 
-        SimpleFilter sf = null;
-
-        if (filters.size() == 1) {
-            sf = filters.get(0);
-        } else if (attrs.size() > 1) {
-            sf = new SimpleFilter(null, filters, SimpleFilter.AND);
-        } else if (filters.isEmpty()) {
-            sf = new SimpleFilter(null, null, SimpleFilter.MATCH_ALL);
+        switch (filters.size()) {
+            case 0:
+                return MATCH_ALL_FILTER;
+            case 1:
+                return filters.get(0);
+            default:
+                return new SimpleFilter(null, filters, SimpleFilter.AND);
         }
-
-        return sf;
     }
 }

--- a/features/core/src/main/java/org/apache/karaf/features/internal/resolver/SimpleFilter.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/resolver/SimpleFilter.java
@@ -19,10 +19,12 @@ package org.apache.karaf.features.internal.resolver;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.apache.felix.utils.version.VersionRange;
 
@@ -38,12 +40,27 @@ public class SimpleFilter {
     public static final int PRESENT = 8;
     public static final int APPROX = 9;
 
+    /**
+     * Strings which are commonly found in filter specification. We use this map as an interner.
+     */
+    private static final Set<String> COMMON_STRINGS;
+
+    static {
+        Set<String> s = new HashSet<>(8);
+        s.add("optional");
+        s.add("osgi.ee");
+        s.add("resolution");
+        s.add("uses");
+        s.add("version");
+        COMMON_STRINGS = s;
+    }
+
     private final String name;
     private final Object value;
     private final int op;
 
     public SimpleFilter(String name, Object value, int op) {
-        this.name = name;
+        this.name = internIfCommon(name);
         this.value = value;
         this.op = op;
     }
@@ -123,6 +140,10 @@ public class SimpleFilter {
             sb.append("(*)");
             break;
         }
+    }
+
+    private static String internIfCommon(String str) {
+        return str != null && COMMON_STRINGS.contains(str) ? str.intern() : str;
     }
 
     private static void toString(StringBuilder sb, List<?> list) {

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/RequirementSort.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/RequirementSort.java
@@ -79,7 +79,7 @@ public final class RequirementSort<T extends Resource> {
             String filter = requirement.getDirectives().get(Constants.FILTER_DIRECTIVE);
             SimpleFilter sf = (filter != null)
                     ? SimpleFilter.parse(filter)
-                    : new SimpleFilter(null, null, SimpleFilter.MATCH_ALL);
+                    : SimpleFilter.MATCH_ALL_FILTER;
             for (Capability cap : capSet.match(sf, true)) {
                 result.add((T) cap.getResource());
             }


### PR DESCRIPTION
This series of patches are attempts to improve resolver memory usage, which we have
observed to go up to ~2GB while performing a mass install of all OpenDaylight features.

A large-ish part of this are duplicated Strings and Maps.