### PR TITLE
ENTESB-64: Shutting down Fuse ESB does not delete lock file

### DIFF
--- a/main/src/main/java/org/apache/karaf/main/lock/SimpleFileLock.java
+++ b/main/src/main/java/org/apache/karaf/main/lock/SimpleFileLock.java
@@ -78,6 +78,7 @@ public class SimpleFileLock implements Lock {
             lock.channel().close();
         }
         lock = null;
+        lockPath.deleteOnExit();
     }
  
     public synchronized boolean isAlive() throws Exception {


### PR DESCRIPTION
Updated SimpleFileLock class to delete the lock file after release method is called for releasing lock.