### PR TITLE
[KARAF-5568] support return codes in karaf commands

### DIFF
--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/ConsoleSessionImpl.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/ConsoleSessionImpl.java
@@ -452,7 +452,7 @@ public class ConsoleSessionImpl implements Session {
     private void doExecute(CharSequence command) {
         try {
             Object result = session.execute(command);
-            if (result != null) {
+            if (result instanceof String) {
                 session.getConsole().println(session.format(result, Converter.INSPECT));
             }
         } catch (InterruptedException e) {

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/ShellCommand.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/ShellCommand.java
@@ -129,6 +129,11 @@ public class ShellCommand implements Command, SessionAware {
                 }
                 if (result != null)
                 {
+                	if(result instanceof Integer) {
+                		// if it is an integer it's interpreted as a return code
+                		exitStatus = (Integer) result;
+                	}
+
                     // TODO: print the result of the command ?
 //                    session.getConsole().println(session.format(result, Converter.INSPECT));
                 }


### PR DESCRIPTION
if the return code of an Action is an integer it is

 * no longer printed
 * used as return code for an SSH shell