### PR TITLE
[KARAF-5569] Add CommandFactory to ssh server when sftp is disabled

### DIFF
--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/Activator.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/Activator.java
@@ -175,6 +175,8 @@ public class Activator extends BaseActivator implements ManagedService {
             server.setCommandFactory(new ScpCommandFactory.Builder().withDelegate(cmd -> new ShellCommand(sessionFactory, cmd)).build());
             server.setSubsystemFactories(Collections.singletonList(new SftpSubsystemFactory()));
             server.setFileSystemFactory(new VirtualFileSystemFactory(Paths.get(System.getProperty("karaf.base"))));
+        } else {
+            server.setCommandFactory(cmd -> new ShellCommand(sessionFactory, cmd));
         }
         server.setKeyPairProvider(keyPairProvider);
         server.setPasswordAuthenticator(authenticator);


### PR DESCRIPTION
Add a basic ShellCommand CommandFactory to the ssh server when not using ScpCommandFactory and sftp