### PR TITLE
[KARAF-5604] Speed up descriptor generation

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -471,7 +471,7 @@ public class GenerateDescriptorMojo extends MojoSupport {
         // TODO Initialise the repositories from the existing feature file if any
         Map<Dependency, Feature> otherFeatures = new HashMap<>();
         Map<Feature, String> featureRepositories = new HashMap<>();
-        FeaturesCache cache = new FeaturesCache(featuresCacheSize);
+        FeaturesCache cache = new FeaturesCache(featuresCacheSize, artifactCacheSize);
         for (final LocalDependency entry : localDependencies) {
             Object artifact = entry.getArtifact();
 
@@ -585,10 +585,10 @@ public class GenerateDescriptorMojo extends MojoSupport {
                 throw new MojoExecutionException(
                         "Cannot locate file for feature: " + artifact + " at " + featuresFile);
             }
-            Features includedFeatures = cache.get(featuresFile);
+            Features includedFeatures = cache.getFeature(featuresFile);
             for (String repository : includedFeatures.getRepository()) {
                 processFeatureArtifact(features, feature, otherFeatures, featureRepositories, cache,
-                        MavenUtil.mvnToArtifact(repository), parent, false);
+                        cache.getArtifact(repository), parent, false);
             }
             for (Feature includedFeature : includedFeatures.getFeature()) {
                 Dependency dependency = new Dependency(includedFeature.getName(), includedFeature.getVersion());
@@ -944,20 +944,27 @@ public class GenerateDescriptorMojo extends MojoSupport {
     }
 
     private static final class FeaturesCache {
-        private final SimpleLRUCache<File, Features> cache;
+        // Maven-to-Aether Artifact cache, as parsing strings is expensive
+        private final SimpleLRUCache<String, DefaultArtifact> artifactCache;
+        private final SimpleLRUCache<File, Features> featuresCache;
 
-        FeaturesCache(int featuresCacheSize) {
-            cache = new SimpleLRUCache<>(featuresCacheSize);
+        FeaturesCache(int featuresCacheSize, int artifactCacheSize) {
+            featuresCache = new SimpleLRUCache<>(featuresCacheSize);
+            artifactCache = new SimpleLRUCache<>(artifactCacheSize);
         }
 
-        Features get(final File featuresFile) throws XMLStreamException, JAXBException, IOException {
-            final Features existing = cache.get(featuresFile);
+        DefaultArtifact getArtifact(String mavenName) {
+            return artifactCache.computeIfAbsent(mavenName, MavenUtil::mvnToArtifact);
+        }
+
+        Features getFeature(final File featuresFile) throws XMLStreamException, JAXBException, IOException {
+            final Features existing = featuresCache.get(featuresFile);
             if (existing != null) {
                 return existing;
             }
 
             final Features computed = readFeaturesFile(featuresFile);
-            cache.put(featuresFile, computed);
+            featuresCache.put(featuresFile, computed);
             return computed;
         }
     }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -588,7 +588,7 @@ public class GenerateDescriptorMojo extends MojoSupport {
             Features includedFeatures = cache.get(featuresFile);
             for (String repository : includedFeatures.getRepository()) {
                 processFeatureArtifact(features, feature, otherFeatures, featureRepositories, cache,
-                        new DefaultArtifact(MavenUtil.mvnToAether(repository)), parent, false);
+                        MavenUtil.mvnToArtifact(repository), parent, false);
             }
             for (Feature includedFeature : includedFeatures.getFeature()) {
                 Dependency dependency = new Dependency(includedFeature.getName(), includedFeature.getVersion());

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/Dependency31Helper.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/Dependency31Helper.java
@@ -366,7 +366,7 @@ public class Dependency31Helper implements DependencyHelper {
 
         ArtifactResult result;
         try {
-            result = resolveArtifact(new DefaultArtifact(id));
+            result = resolveArtifact(MavenUtil.aetherToArtifact(id));
         } catch (ArtifactResolutionException e) {
             log.warn("Could not resolve " + id, e);
             throw new MojoFailureException(format("Couldn't resolve artifact %s", id), e);
@@ -421,8 +421,7 @@ public class Dependency31Helper implements DependencyHelper {
 
     @Override
     public org.apache.maven.artifact.Artifact mvnToArtifact(String name) throws MojoExecutionException {
-        name = MavenUtil.mvnToAether(name);
-        DefaultArtifact artifact = new DefaultArtifact(name);
+        DefaultArtifact artifact = MavenUtil.mvnToArtifact(name);
         org.apache.maven.artifact.Artifact mavenArtifact = toArtifact(artifact);
         return mavenArtifact;
     }
@@ -441,7 +440,7 @@ public class Dependency31Helper implements DependencyHelper {
 
     @Override
     public String pathFromAether(String name) throws MojoExecutionException {
-        DefaultArtifact artifact = new DefaultArtifact(name);
+        DefaultArtifact artifact = MavenUtil.aetherToArtifact(name);
         org.apache.maven.artifact.Artifact mavenArtifact = toArtifact(artifact);
         return MavenUtil.layout.pathOf(mavenArtifact);
     }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/Dependency31Helper.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/Dependency31Helper.java
@@ -328,7 +328,9 @@ public class Dependency31Helper implements DependencyHelper {
 
     @Override
     public File resolve(Object artifact, Log log) {
-        log.debug("Resolving artifact " + artifact + " from " + projectRepositories);
+        if (log.isDebugEnabled()) {
+            log.debug("Resolving artifact " + artifact + " from " + projectRepositories);
+        }
 
         ArtifactResult result;
         try {
@@ -338,7 +340,10 @@ public class Dependency31Helper implements DependencyHelper {
             return null;
         }
 
-        log.debug("Resolved artifact " + artifact + " to " + result.getArtifact().getFile() + " from " + result.getRepository());
+        if (log.isDebugEnabled()) {
+            log.debug("Resolved artifact " + artifact + " to " + result.getArtifact().getFile() + " from "
+                    + result.getRepository());
+        }
 
         return result.getArtifact().getFile();
     }
@@ -355,7 +360,9 @@ public class Dependency31Helper implements DependencyHelper {
         }
         id = MavenUtil.mvnToAether(id);
 
-        log.debug("Resolving artifact " + id + " from " + projectRepositories);
+        if (log.isDebugEnabled()) {
+            log.debug("Resolving artifact " + id + " from " + projectRepositories);
+        }
 
         ArtifactResult result;
         try {
@@ -365,7 +372,10 @@ public class Dependency31Helper implements DependencyHelper {
             throw new MojoFailureException(format("Couldn't resolve artifact %s", id), e);
         }
 
-        log.debug("Resolved artifact " + id + " to " + result.getArtifact().getFile() + " from " + result.getRepository());
+        if (log.isDebugEnabled()) {
+            log.debug("Resolved artifact " + id + " to " + result.getArtifact().getFile() + " from "
+                    + result.getRepository());
+        }
 
         return result.getArtifact().getFile();
     }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MavenUtil.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MavenUtil.java
@@ -34,6 +34,7 @@ import org.apache.maven.artifact.repository.metadata.Snapshot;
 import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.repository.RemoteRepository;
 
 /**
@@ -77,6 +78,58 @@ public class MavenUtil {
         }
         b.append(m.group(3));
         return b.toString();
+    }
+
+    /**
+     * Convert PAX URL mvn format to an aether Artifact.
+     * N.B. we do not handle repository-url in mvn urls.
+     * N.B. version is required in mvn urls.
+     *
+     * @param name PAX URL mvn format: mvn-uri := [ 'wrap:' ] 'mvn:' [ repository-url '!' ] group-id '/' artifact-id [ '/' [version] [ '/' [type] [ '/' classifier ] ] ] ]
+     * @return aether Artifact
+     */
+    public static DefaultArtifact mvnToArtifact(String name) {
+        Matcher m = mvnPattern.matcher(name);
+        if (!m.matches()) {
+            return new DefaultArtifact(name);
+        }
+
+        String groupId = m.group(1);
+        String artifactId = m.group(2);
+        String version = m.group(3);
+        String extension = m.group(5);
+        if (!present(extension)) {
+            extension = "jar";
+        }
+        String classifier = m.group(7);
+
+        return new DefaultArtifact(groupId, artifactId, present(classifier) ? classifier : "", extension, version);
+    }
+
+    /**
+     * Convert Aether coordinate format to an aether Artifact.
+     * N.B. we do not handle repository-url in mvn urls.
+     * N.B. version is required in mvn urls.
+     *
+     * @param name aether coordinate format: &lt;groupId&gt;:&lt;artifactId&gt;[:&lt;extension&gt;[:&lt;classifier&gt;]]:&lt;version&gt;
+     * @return aether Artifact
+     */
+    public static DefaultArtifact aetherToArtifact(String name) {
+        Matcher m = aetherPattern.matcher(name);
+        if (!m.matches()) {
+            return new DefaultArtifact(name);
+        }
+
+        String groupId = m.group(1);
+        String artifactId = m.group(2);
+        String version = m.group(7);
+        String extension = m.group(4);
+        if (!present(extension)) {
+            extension = "jar";
+        }
+        String classifier = m.group(6);
+
+        return new DefaultArtifact(groupId, artifactId, present(classifier) ? classifier : "", extension, version);
     }
 
     private static boolean present(String part) {


### PR DESCRIPTION
Profiling has turned out two more inefficiencies:
- calling log.debug() with a concatenated string -- we end up wasting time constructing the string, which is never logged
- aether's DefaultArtifact(String) is extremely slow due to Pattern.compile() it contains
