### PR TITLE
Update references for the SSH keysize from 4096 -> 2048

### DIFF
--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -292,9 +292,9 @@
 
             #
             # Self defined key size in 1024, 2048, 3072, or 4096
-            # If not set, this defaults to 4096.
+            # If not set, this defaults to 2048.
             #
-            # keySize = 4096
+            # keySize = 2048
 
             #
             # Specify host key algorithm, defaults to RSA

--- a/itests/src/test/filtered-resources/etc/feature.xml
+++ b/itests/src/test/filtered-resources/etc/feature.xml
@@ -197,9 +197,9 @@
 
             #
             # Self defined key size in 1024, 2048, 3072, or 4096
-            # If not set, this defaults to 4096.
+            # If not set, this defaults to 2048.
             #
-            # keySize = 4096
+            # keySize = 2048
 
             #
             # Specify host key algorithm, defaults to RSA

--- a/manual/src/main/asciidoc/user-guide/remote.adoc
+++ b/manual/src/main/asciidoc/user-guide/remote.adoc
@@ -94,9 +94,9 @@ sftpEnabled=true
 
 #
 # Self defined key size in 1024, 2048, 3072, or 4096
-# If not set, this defaults to 4096.
+# If not set, this defaults to 2048.
 #
-# keySize = 4096
+# keySize = 2048
 
 #
 # Specify host key algorithm, defaults to RSA

--- a/shell/ssh/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/shell/ssh/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -23,7 +23,7 @@
         <AD id="sshHost" type="String" default="0.0.0.0" name="%sshHost.name" description="%sshHost.description"/>
         <AD id="sshRealm" type="String" default="karaf" name="%sshRealm.name" description="%sshRealm.description"/>
         <AD id="hostKey" type="String" default="${karaf.etc}/host.key" name="%hostKey.name" description="%hostKey.description"/>
-        <AD id="keySize" type="Integer" default="4096" name="%keySize.name" description="%keySize.description"/>
+        <AD id="keySize" type="Integer" default="2048" name="%keySize.name" description="%keySize.description"/>
         <AD id="algorithm" type="String" default="RSA" name="%algorithm.name" description="%algorithm.description"/>
     </OCD>
     <Designate pid="org.apache.karaf.shell">


### PR DESCRIPTION
The configuration file "etc/org.apache.karaf.shell.cfg" states that the default key size is 4096. This is not correct:
openssl rsa -in host.key -text -noout | grep "Private-Key"
Private-Key: (2048 bit)
Instead we should update references to the keysize to be 2048 bits.