### PR TITLE
[KARAF-2688] Adding information about memory pools.

### DIFF
--- a/shell/commands/src/main/java/org/apache/karaf/shell/commands/impl/InfoAction.java
+++ b/shell/commands/src/main/java/org/apache/karaf/shell/commands/impl/InfoAction.java
@@ -153,18 +153,18 @@ public class InfoAction implements Action {
                     System.out.println(spaces4 + spaces4 + "Peak Usage");
                     printValue(spaces4 + spaces4 + spaces4 + "init", maxNameLen, printLong(init));
                     printValue(spaces4 + spaces4 + spaces4 + "used", maxNameLen, printLong(used));
-                    printValue(spaces4 + spaces4 + spaces4 + "committed:", maxNameLen, printLong(committed));
-                    printValue(spaces4 + spaces4 + spaces4 + "max:", maxNameLen, printLong(max));
+                    printValue(spaces4 + spaces4 + spaces4 + "committed", maxNameLen, printLong(committed));
+                    printValue(spaces4 + spaces4 + spaces4 + "max", maxNameLen, printLong(max));
 
                     init = usage.getInit();
                     used = usage.getUsed();
                     committed = usage.getCommitted();
                     max = usage.getMax();
                     System.out.println(spaces4 + spaces4 + "Current Usage");
-                    printValue(spaces4 + spaces4 + spaces4 + "init:", maxNameLen, printLong(init));
-                    printValue(spaces4 + spaces4 + spaces4 + "used:", maxNameLen, printLong(used));
-                    printValue(spaces4 + spaces4 + spaces4 + "committed:", maxNameLen, printLong(committed));
-                    printValue(spaces4 + spaces4 + spaces4 + "max:", maxNameLen, printLong(max));
+                    printValue(spaces4 + spaces4 + spaces4 + "init", maxNameLen, printLong(init));
+                    printValue(spaces4 + spaces4 + spaces4 + "used", maxNameLen, printLong(used));
+                    printValue(spaces4 + spaces4 + spaces4 + "committed", maxNameLen, printLong(committed));
+                    printValue(spaces4 + spaces4 + spaces4 + "max", maxNameLen, printLong(max));
                 }
             }
         }

--- a/shell/commands/src/main/java/org/apache/karaf/shell/commands/impl/InfoAction.java
+++ b/shell/commands/src/main/java/org/apache/karaf/shell/commands/impl/InfoAction.java
@@ -20,6 +20,9 @@ import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
@@ -40,6 +43,7 @@ import java.util.concurrent.Callable;
 import org.apache.karaf.shell.commands.info.InfoProvider;
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.apache.karaf.shell.support.ansi.SimpleAnsi;
 import org.osgi.framework.Bundle;
@@ -51,17 +55,26 @@ import org.osgi.framework.FrameworkUtil;
 public class InfoAction implements Action {
 
     private NumberFormat fmtI = new DecimalFormat("###,###", new DecimalFormatSymbols(Locale.ENGLISH));
+    private NumberFormat fmtDec = new DecimalFormat("###,###.##", new DecimalFormatSymbols(Locale.ENGLISH));
     private NumberFormat fmtD = new DecimalFormat("###,##0.000", new DecimalFormatSymbols(Locale.ENGLISH));
+
+    private OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
+
+    @Option(name="--memory-pools", aliases= {"-mp"}, description="Includes detailed information about memory pools")
+    protected boolean showMemoryPools;
 
 //    @Reference
     List<InfoProvider> infoProviders;
+
+    public InfoAction() {
+        fmtDec.setMinimumFractionDigits(2);
+    }
 
     @Override
     public Object execute() throws Exception {
         int maxNameLen;
 
         RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
-        OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
         ThreadMXBean threads = ManagementFactory.getThreadMXBean();
         MemoryMXBean mem = ManagementFactory.getMemoryMXBean();
         ClassLoadingMXBean cl = ManagementFactory.getClassLoadingMXBean();
@@ -87,7 +100,16 @@ public class InfoAction implements Action {
         printValue("Pid", maxNameLen, getPid());
         printValue("Uptime", maxNameLen, printDuration(runtime.getUptime()));
         try {
-            printValue("Process CPU time", maxNameLen, printDuration(getSunOsValueAsLong(os, "getProcessCpuTime") / 1000000));
+            Class< ? > sunOS = Class.forName("com.sun.management.OperatingSystemMXBean");
+            printValue("Process CPU time", maxNameLen, printDuration(getValueAsLong(sunOS, "getProcessCpuTime") / 1000000));
+            printValue("Process CPU load", maxNameLen, fmtDec.format(getValueAsDouble(sunOS, "getProcessCpuLoad")));
+            printValue("System CPU load", maxNameLen, fmtDec.format(getValueAsDouble(sunOS, "getSystemCpuLoad")));
+        } catch (Throwable t) {
+        }
+        try {
+            Class<?> unixOS = Class.forName("com.sun.management.UnixOperatingSystemMXBean");
+            printValue("Open file descriptors", maxNameLen, printLong(getValueAsLong(unixOS, "getOpenFileDescriptorCount")));
+            printValue("Max file descriptors", maxNameLen, printLong(getValueAsLong(unixOS, "getMaxFileDescriptorCount")));
         } catch (Throwable t) {
         }
         printValue("Total compile time", maxNameLen, printDuration(ManagementFactory.getCompilationMXBean().getTotalCompilationTime()));
@@ -106,6 +128,45 @@ public class InfoAction implements Action {
         for (GarbageCollectorMXBean gc : ManagementFactory.getGarbageCollectorMXBeans()) {
             String val = "Name = '" + gc.getName() + "', Collections = " + gc.getCollectionCount() + ", Time = " + printDuration(gc.getCollectionTime());
             printValue("Garbage collector", maxNameLen, val);
+        }
+
+        if (showMemoryPools) {
+            List<MemoryPoolMXBean> memoryPools = ManagementFactory.getMemoryPoolMXBeans();
+            System.out.println("Memory Pools");
+            printValue("Total Memory Pools", maxNameLen, printLong(memoryPools.size()));
+            String spaces4 = "   ";
+            for (MemoryPoolMXBean pool : memoryPools)
+            {
+                String name = pool.getName();
+                MemoryType type = pool.getType();
+                printValue(spaces4 + "Pool (" + type + ")", maxNameLen, name);
+
+                // PeakUsage/CurrentUsage
+                MemoryUsage peakUsage = pool.getPeakUsage();
+                MemoryUsage usage = pool.getUsage();
+
+                if (usage != null && peakUsage != null) {
+                    long init = peakUsage.getInit();
+                    long used = peakUsage.getUsed();
+                    long committed = peakUsage.getCommitted();
+                    long max = peakUsage.getMax();
+                    System.out.println(spaces4 + spaces4 + "Peak Usage");
+                    printValue(spaces4 + spaces4 + spaces4 + "init", maxNameLen, printLong(init));
+                    printValue(spaces4 + spaces4 + spaces4 + "used", maxNameLen, printLong(used));
+                    printValue(spaces4 + spaces4 + spaces4 + "committed:", maxNameLen, printLong(committed));
+                    printValue(spaces4 + spaces4 + spaces4 + "max:", maxNameLen, printLong(max));
+
+                    init = usage.getInit();
+                    used = usage.getUsed();
+                    committed = usage.getCommitted();
+                    max = usage.getMax();
+                    System.out.println(spaces4 + spaces4 + "Current Usage");
+                    printValue(spaces4 + spaces4 + spaces4 + "init:", maxNameLen, printLong(init));
+                    printValue(spaces4 + spaces4 + spaces4 + "used:", maxNameLen, printLong(used));
+                    printValue(spaces4 + spaces4 + spaces4 + "committed:", maxNameLen, printLong(committed));
+                    printValue(spaces4 + spaces4 + spaces4 + "max:", maxNameLen, printLong(max));
+                }
+            }
         }
 
         System.out.println("Classes");
@@ -156,14 +217,33 @@ public class InfoAction implements Action {
     }
 
     private String getPid() {
-    	String name = ManagementFactory.getRuntimeMXBean().getName();
-    	String[] parts = name.split("@");
-		return parts[0];
-	}
+        // In Java 9 the new process API can be used:
+        // long pid = ProcessHandle.current().getPid();
+        String name = ManagementFactory.getRuntimeMXBean().getName();
+        String[] parts = name.split("@");
+        return parts[0];
+    }
 
-	private long getSunOsValueAsLong(OperatingSystemMXBean os, String name) throws Exception {
+    private long getSunOsValueAsLong(OperatingSystemMXBean os, String name) throws Exception {
         Method mth = os.getClass().getMethod(name);
         return (Long) mth.invoke(os);
+    }
+
+    private long getValueAsLong(Class<?> osImpl, String name) throws Exception {
+        if (osImpl.isInstance(os))
+        {
+            Method mth = osImpl.getMethod(name);
+            return (Long) mth.invoke(os);
+        }
+        return -1;
+    }
+
+    private double getValueAsDouble(Class<?> osImpl, String name) throws Exception {
+        if (osImpl.isInstance(os)) {
+            Method mth = osImpl.getMethod(name);
+            return (Double) mth.invoke(os);
+        }
+        return -1;
     }
 
     private String printLong(long i) {


### PR DESCRIPTION
This commit not only adds info on perm-gen as requested in KARAF-2688, but generally prints info on the memory-pools, which might include perm-gen for the appropriate VM or e.g. MetaSpace for Oracle-Java8.

Since info is quite detailed, I made its output optional via **--memory-pools**.

Also added file descriptor info when on Unix.

Example output, running with Oracle-Java8 and G1-GC (unchanged, unrelated ouput omitted via (...)):
```
info --memory-pools
Karaf
  (...)

JVM
  (...)
  Process CPU load            0.05
  System CPU load             0.66
  Open file descriptors       663
  Max file descriptors        1,048,576
  Total compile time          1 minute
Threads
  (...)
Memory
  Current heap size           427,008 kbytes
  Maximum heap size           1,048,576 kbytes
  Committed heap size         589,824 kbytes
  Pending objects             0
  Garbage collector           Name = 'G1 Young Generation', Collections = 33, Time = 1.447 seconds
  Garbage collector           Name = 'G1 Old Generation', Collections = 0, Time = 0.000 seconds
Memory Pools
  Total Memory Pools          6
     Pool (Non-heap memory)   Code Cache
      Peak Usage
           init               2,555,904
           used               38,015,040
           committed         38,338,560
           max               251,658,240
      Current Usage
           init              2,555,904
           used              37,968,576
           committed         38,338,560
           max               251,658,240
     Pool (Non-heap memory)   Metaspace
      Peak Usage
           init               0
           used               96,152,744
           committed         110,964,736
           max               1,073,741,824
      Current Usage
           init              0
           used              96,152,744
           committed         110,964,736
           max               1,073,741,824
     Pool (Non-heap memory)   Compressed Class Space
      Peak Usage
           init               0
           used               11,900,544
           committed          16,068,608
           max                1,073,741,824
      Current Usage
           init              0
           use               11,900,544
           committed         16,068,608
           max               1,073,741,824
     Pool (Heap memory)       G1 Eden Space
      Peak Usage
           init               27,262,976
           used               357,564,416
           committed          378,535,936
           max               -1
      Current Usage
           init              27,262,976
           used              284,164,096
           committed         378,535,936
           max               -1
     Pool (Heap memory)       G1 Survivor Space
      Peak Usage
           init               0
           used               46,137,344
           committed          46,137,344
           max               -1
      Current Usage
           init              0
           used              2,097,152
           committed         2,097,152
           max               -1
     Pool (Heap memory)       G1 Old Gen
      Peak Usage
           init               106,954,752
           used               153,092,600
           committed          572,522,496
           max                1,073,741,824
      Current Usage
           init              106,954,752
           used              150,994,944
           committed         223,346,688
           max               1,073,741,824
Classes
  (...)
Operating system
  (...)
```