### PR TITLE
Avoid NPE if ParsedLine is null

### DIFF
--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/ConsoleSessionImpl.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/ConsoleSessionImpl.java
@@ -355,7 +355,9 @@ public class ConsoleSessionImpl implements Session {
                     if (pl instanceof ParsedLineImpl) {
                         command = ((ParsedLineImpl) pl).program();
                     } else {
-                        command = pl.line();
+                        if (pl != null) {
+                            command = pl.line();
+                        }
                     }
                 } catch (EndOfFileException e) {
                     break;


### PR DESCRIPTION
I noticed this on a Karaf 4.1.5 instance. The fix has already been applied to master, but not 4.1.x.