### PR TITLE
Fix formatting in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <serp.bundle.version>1.14.1_1</serp.bundle.version>
         <servlet.spec.groupId>javax.servlet</servlet.spec.groupId>
 	<servlet.spec.artifactId>javax.servlet-api</servlet.spec.artifactId>
-	<servlet.spec.version>2.1.0</servlet.spec.version>
+	<servlet.spec.version>3.1.0</servlet.spec.version>
 
         <geronimo.jms-spec.version>1.1.1</geronimo.jms-spec.version>
         <geronimo.jpa-spec.version>1.1</geronimo.jpa-spec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -163,8 +163,8 @@
         <jolokia.version>1.3.3</jolokia.version>
         <serp.bundle.version>1.14.1_1</serp.bundle.version>
         <servlet.spec.groupId>javax.servlet</servlet.spec.groupId>
-	    <servlet.spec.artifactId>javax.servlet-api</servlet.spec.artifactId>
-	    <servlet.spec.version>3.1.0</servlet.spec.version>
+	<servlet.spec.artifactId>javax.servlet-api</servlet.spec.artifactId>
+	<servlet.spec.version>2.1.0</servlet.spec.version>
 
         <geronimo.jms-spec.version>1.1.1</geronimo.jms-spec.version>
         <geronimo.jpa-spec.version>1.1</geronimo.jpa-spec.version>


### PR DESCRIPTION
The karaf-core pom.xml had a few properties indented improperly.
This change realigns these anomalies appropriately.

Signed-off-by: Ryan Goulding <ryandgoulding@gmail.com>