### PR TITLE
Enable karaf-assembly packaging to work with custom deployers

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/InstallKarsMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/InstallKarsMojo.java
@@ -562,6 +562,11 @@ public class InstallKarsMojo extends MojoSupport {
             if (bundleLocation.startsWith("war:")) {
                 bundleLocation = bundleLocation.substring("war:".length());
             }
+            // checked all known prefixes, clean a possible custom one wrapping mvn:
+            int mvnIndex = bundleLocation.indexOf("mvn:");
+            if (mvnIndex > 0) {
+                bundleLocation = bundleLocation.substring(mvnIndex);
+            }
             File bundleFile;
             if (bundleLocation.startsWith("mvn:")) {
                 if (bundleLocation.endsWith("/")) {


### PR DESCRIPTION
Allow the use of the karaf-assembly packaging when using the maven-karaf-plugin to properly add bundles with custom deployers to the repo.

A bundle defined as follows for example will be correctly added to the system folder:

```<bundle>my-deployer:mvn:org.webjars.bower/angular/1.5.8</bundle>```

Please let me know if this causes any issues that I might not be aware of.