### PR TITLE
[KARAF-5758] Upgrade Hibernate Validator to 6.0.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
         <hibernate42.version>4.2.15.Final</hibernate42.version>
         <hibernate43.version>4.3.6.Final</hibernate43.version>
         <hibernate.version>5.2.9.Final</hibernate.version>
-        <hibernate.validator.version>6.0.9.Final</hibernate.validator.version>
+        <hibernate.validator.version>6.0.10.Final</hibernate.validator.version>
         <jansi.version>1.17.1</jansi.version>
         <javassist.version>3.9.0.GA</javassist.version>
         <jetty.version>9.4.6.v20170531</jetty.version>


### PR DESCRIPTION
 * https://issues.apache.org/jira/browse/KARAF-5758

Simple upgrade, nothing fancy.