### PR TITLE
[KARAF-5728] Upgrade to Pax Web 7.1.1-SNAPSHOT and Jetty 9.4.10.v20180503

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
         <hibernate.validator.version>6.0.10.Final</hibernate.validator.version>
         <jansi.version>1.17.1</jansi.version>
         <javassist.version>3.9.0.GA</javassist.version>
-        <jetty.version>9.4.6.v20170531</jetty.version>
+        <jetty.version>9.4.10.v20180503</jetty.version>
         <jline.version>3.7.0</jline.version>
         <junit.version>4.12</junit.version>
         <jsw.version>3.2.3</jsw.version>
@@ -277,7 +277,7 @@
         <pax.base.version>1.5.0</pax.base.version>
         <pax.swissbox.version>1.8.3</pax.swissbox.version>
         <pax.url.version>2.5.4</pax.url.version>
-        <pax.web.version>7.0.0</pax.web.version>
+        <pax.web.version>7.1.1</pax.web.version>
         <pax.tinybundle.version>3.0.0</pax.tinybundle.version>
         <pax.jdbc.version>1.3.0</pax.jdbc.version>
         <pax.jms.version>1.0.1</pax.jms.version>


### PR DESCRIPTION
It's a WIP waiting Pax Web 7.1.1 release.