### PR TITLE
Capitalise JAAS GroupCreateCommand description

### DIFF
--- a/jaas/command/src/main/java/org/apache/karaf/jaas/command/GroupCreateCommand.java
+++ b/jaas/command/src/main/java/org/apache/karaf/jaas/command/GroupCreateCommand.java
@@ -20,7 +20,7 @@ import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 
-@Command(scope = "jaas", name = "group-create", description = "create a group in a realm")
+@Command(scope = "jaas", name = "group-create", description = "Create a group in a realm")
 @Service
 public class GroupCreateCommand extends JaasCommandSupport {
    


### PR DESCRIPTION
Bit of a trivial PR...the JAAS GroupCreateCommand description is the only description of the JAAS commands that starts with a lower-case letter - it looks a bit inconsistent in the console.