### PR TITLE
[KARAF-5190] Enhance realpath() function to better manage awk on Solaris

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/client
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/client
@@ -17,15 +17,25 @@
 #
 
 realpath() {
+  # Use in priority xpg4 awk or nawk on SunOS as standard awk is outdated
+  AWK=awk
+  if ${solaris}; then
+      if [ -x /usr/xpg4/bin/awk ]; then
+          AWK=/usr/xpg4/bin/awk
+      elif [ -x /usr/bin/nawk ]; then
+          AWK=/usr/bin/nawk
+      fi
+  fi
+
   READLINK_EXISTS=$(command -v readlink &> /dev/null)
-  if [ -z "${READLINK_EXISTS}" ]; then
+  if [ -z "$READLINK_EXISTS" ]; then
     OURPWD=${PWD}
     cd "$(dirname "${1}")" || exit 2
-    LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+    LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     while [ "${LINK}" ]; do
         echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
-        LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+        LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     done
     REALPATH="${PWD}/$(basename "${1}")"
     cd "${OURPWD}" || exit 2
@@ -35,7 +45,7 @@ realpath() {
     cd "$(dirname "${1}")" || exit 2
     LINK=$(readlink "$(basename "${1}")")
     while [ "${LINK}" ]; do
-	    echo "link: ${LINK}" >&2
+            echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
         LINK=$(readlink "$(basename "${1}")")
     done

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/inc
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/inc
@@ -218,17 +218,17 @@ detectJVM() {
 
 checkJvmVersion() {
     # Use in priority xpg4 awk or nawk on SunOS as standard awk is outdated 
+    AWK=awk
     if ${solaris}; then
         if [ -x /usr/xpg4/bin/awk ]; then
-            VERSION=$("${JAVA}" -version 2>&1 | /usr/xpg4/bin/awk -F '"' '/version/ {print $2}' | sed -e 's/_.*//g; s/^1\.//g; s/\..*//g; s/-.*//g;')
+            AWK=/usr/xpg4/bin/awk
         elif [ -x /usr/bin/nawk ]; then
-            VERSION=$("${JAVA}" -version 2>&1 | /usr/bin/nawk -F '"' '/version/ {print $2}' | sed -e 's/_.*//g; s/^1\.//g; s/\..*//g; s/-.*//g;')
-        else 
-            VERSION=$("${JAVA}" -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed -e 's/_.*//g; s/^1\.//g; s/\..*//g; s/-.*//g;')
+            AWK=/usr/bin/nawk
         fi
-    else    
-        VERSION=$("${JAVA}" -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed -e 's/_.*//g; s/^1\.//g; s/\..*//g; s/-.*//g;')
     fi
+    
+    VERSION=$("${JAVA}" -version 2>&1 | ${AWK} -F '"' '/version/ {print $2}' | sed -e 's/_.*//g; s/^1\.//g; s/\..*//g; s/-.*//g;')
+    
     # java must be at least version 8 
     if [ "${VERSION}" -lt "8" ]; then
         die "JVM must be greater than 1.8"

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/instance
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/instance
@@ -17,15 +17,25 @@
 #
 
 realpath() {
+  # Use in priority xpg4 awk or nawk on SunOS as standard awk is outdated
+  AWK=awk
+  if ${solaris}; then
+      if [ -x /usr/xpg4/bin/awk ]; then
+          AWK=/usr/xpg4/bin/awk
+      elif [ -x /usr/bin/nawk ]; then
+          AWK=/usr/bin/nawk
+      fi
+  fi
+
   READLINK_EXISTS=$(command -v readlink &> /dev/null)
-  if [ -z "${READLINK_EXISTS}" ]; then
+  if [ -z "$READLINK_EXISTS" ]; then
     OURPWD=${PWD}
     cd "$(dirname "${1}")" || exit 2
-    LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+    LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     while [ "${LINK}" ]; do
         echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
-        LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+        LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     done
     REALPATH="${PWD}/$(basename "${1}")"
     cd "${OURPWD}" || exit 2
@@ -35,7 +45,7 @@ realpath() {
     cd "$(dirname "${1}")" || exit 2
     LINK=$(readlink "$(basename "${1}")")
     while [ "${LINK}" ]; do
-	    echo "link: ${LINK}" >&2
+            echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
         LINK=$(readlink "$(basename "${1}")")
     done

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf
@@ -17,15 +17,25 @@
 #
 
 realpath() {
+  # Use in priority xpg4 awk or nawk on SunOS as standard awk is outdated
+  AWK=awk
+  if ${solaris}; then
+      if [ -x /usr/xpg4/bin/awk ]; then
+          AWK=/usr/xpg4/bin/awk
+      elif [ -x /usr/bin/nawk ]; then
+          AWK=/usr/bin/nawk
+      fi
+  fi
+
   READLINK_EXISTS=$(command -v readlink &> /dev/null)
   if [ -z "$READLINK_EXISTS" ]; then
     OURPWD=${PWD}
     cd "$(dirname "${1}")" || exit 2
-    LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+    LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     while [ "${LINK}" ]; do
         echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
-        LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+        LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     done
     REALPATH="${PWD}/$(basename "${1}")"
     cd "${OURPWD}" || exit 2

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/shell
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/shell
@@ -17,15 +17,25 @@
 #
 
 realpath() {
+  # Use in priority xpg4 awk or nawk on SunOS as standard awk is outdated
+  AWK=awk
+  if ${solaris}; then
+      if [ -x /usr/xpg4/bin/awk ]; then
+          AWK=/usr/xpg4/bin/awk
+      elif [ -x /usr/bin/nawk ]; then
+          AWK=/usr/bin/nawk
+      fi
+  fi
+
   READLINK_EXISTS=$(command -v readlink &> /dev/null)
-  if [ -z "${READLINK_EXISTS}" ]; then
+  if [ -z "$READLINK_EXISTS" ]; then
     OURPWD=${PWD}
     cd "$(dirname "${1}")" || exit 2
-    LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+    LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     while [ "${LINK}" ]; do
         echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
-        LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+        LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     done
     REALPATH="${PWD}/$(basename "${1}")"
     cd "${OURPWD}" || exit 2
@@ -35,7 +45,7 @@ realpath() {
     cd "$(dirname "${1}")" || exit 2
     LINK=$(readlink "$(basename "${1}")")
     while [ "${LINK}" ]; do
-	    echo "link: ${LINK}" >&2
+            echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
         LINK=$(readlink "$(basename "${1}")")
     done

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/start
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/start
@@ -17,15 +17,25 @@
 #
 
 realpath() {
+  # Use in priority xpg4 awk or nawk on SunOS as standard awk is outdated
+  AWK=awk
+  if ${solaris}; then
+      if [ -x /usr/xpg4/bin/awk ]; then
+          AWK=/usr/xpg4/bin/awk
+      elif [ -x /usr/bin/nawk ]; then
+          AWK=/usr/bin/nawk
+      fi
+  fi
+
   READLINK_EXISTS=$(command -v readlink &> /dev/null)
-  if [ -z "${READLINK_EXISTS}" ]; then
+  if [ -z "$READLINK_EXISTS" ]; then
     OURPWD=${PWD}
     cd "$(dirname "${1}")" || exit 2
-    LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+    LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     while [ "${LINK}" ]; do
         echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
-        LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+        LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     done
     REALPATH="${PWD}/$(basename "${1}")"
     cd "${OURPWD}" || exit 2
@@ -35,7 +45,7 @@ realpath() {
     cd "$(dirname "${1}")" || exit 2
     LINK=$(readlink "$(basename "${1}")")
     while [ "${LINK}" ]; do
-	    echo "link: ${LINK}" >&2
+            echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
         LINK=$(readlink "$(basename "${1}")")
     done

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/status
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/status
@@ -17,15 +17,25 @@
 #
 
 realpath() {
+  # Use in priority xpg4 awk or nawk on SunOS as standard awk is outdated
+  AWK=awk
+  if ${solaris}; then
+      if [ -x /usr/xpg4/bin/awk ]; then
+          AWK=/usr/xpg4/bin/awk
+      elif [ -x /usr/bin/nawk ]; then
+          AWK=/usr/bin/nawk
+      fi
+  fi
+
   READLINK_EXISTS=$(command -v readlink &> /dev/null)
-  if [ -z "${READLINK_EXISTS}" ]; then
+  if [ -z "$READLINK_EXISTS" ]; then
     OURPWD=${PWD}
     cd "$(dirname "${1}")" || exit 2
-    LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+    LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     while [ "${LINK}" ]; do
         echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
-        LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+        LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     done
     REALPATH="${PWD}/$(basename "${1}")"
     cd "${OURPWD}" || exit 2
@@ -35,7 +45,7 @@ realpath() {
     cd "$(dirname "${1}")" || exit 2
     LINK=$(readlink "$(basename "${1}")")
     while [ "${LINK}" ]; do
-	    echo "link: ${LINK}" >&2
+            echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
         LINK=$(readlink "$(basename "${1}")")
     done

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/stop
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/stop
@@ -17,15 +17,25 @@
 #
 
 realpath() {
+  # Use in priority xpg4 awk or nawk on SunOS as standard awk is outdated
+  AWK=awk
+  if ${solaris}; then
+      if [ -x /usr/xpg4/bin/awk ]; then
+          AWK=/usr/xpg4/bin/awk
+      elif [ -x /usr/bin/nawk ]; then
+          AWK=/usr/bin/nawk
+      fi
+  fi
+
   READLINK_EXISTS=$(command -v readlink &> /dev/null)
-  if [ -z "${READLINK_EXISTS}" ]; then
+  if [ -z "$READLINK_EXISTS" ]; then
     OURPWD=${PWD}
     cd "$(dirname "${1}")" || exit 2
-    LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+    LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     while [ "${LINK}" ]; do
         echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
-        LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+        LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     done
     REALPATH="${PWD}/$(basename "${1}")"
     cd "${OURPWD}" || exit 2
@@ -35,7 +45,7 @@ realpath() {
     cd "$(dirname "${1}")" || exit 2
     LINK=$(readlink "$(basename "${1}")")
     while [ "${LINK}" ]; do
-	    echo "link: ${LINK}" >&2
+            echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
         LINK=$(readlink "$(basename "${1}")")
     done


### PR DESCRIPTION
This PR aims to update and normalize the `realpath()` function included in Karaf shell scripts (karaf, shell, start, stop, status, instance, client) , making them compatible with Solaris platforms.

For exemple, until now, launching the `start` script on Solaris resulted in a loop caused by bad behavior of default Solaris awk command, which is not able to properly manage the `-F"-> "` delimiter.

It also cleans the `checkJvmVersion()` function to make the `awk` command configuration inside it identical to the one in newly updated `realpath()`.