### PR TITLE
[KARAF-5798] use a consistent way to get the Karaf process ID; write …

### DIFF
--- a/main/src/main/java/org/apache/karaf/main/Main.java
+++ b/main/src/main/java/org/apache/karaf/main/Main.java
@@ -239,7 +239,8 @@ public class Main {
         }
         String log4jConfigPath = System.getProperty("karaf.etc") + "/org.ops4j.pax.logging.cfg";
         BootstrapLogManager.setProperties(config.props, log4jConfigPath);
-        InstanceHelper.updateInstancePid(config.karafHome, config.karafBase, true);
+        /* KARAF-5798: write the PID whether or not the lock has been acquired */
+        InstanceHelper.writePid(config.pidFile);
         BootstrapLogManager.configureLogger(LOG);
 
         for (String provider : config.securityProviders) {
@@ -746,6 +747,8 @@ public class Main {
         @Override
         public void lockAcquired() {
             LOG.info("Lock acquired. Setting startlevel to " + config.defaultStartLevel);
+            /* KARAF-5798: instance PID should reflect the current running master */
+            InstanceHelper.updateInstancePid(config.karafHome, config.karafBase, true);
             shutdownThread = InstanceHelper.setupShutdown(config, framework);
             setStartLevel(config.defaultStartLevel);
         }

--- a/main/src/test/java/org/apache/karaf/main/MockLock.java
+++ b/main/src/test/java/org/apache/karaf/main/MockLock.java
@@ -31,6 +31,8 @@ public class MockLock implements Lock {
     private Object lockLock = new Object();
     
     public MockLock(Properties props) {
+        /* KARAF-5798: allow tests to simulate slave instances */
+        lock = Boolean.valueOf(System.getProperty("test.karaf.mocklock.initiallyLocked", "true"));
     }
     
     public boolean lock() throws Exception {


### PR DESCRIPTION
…the pid file when the process launches so that it contains an accurate value for either a master or slave instance; only update the instance PID for the current running master (i.e. once lock is acquired)