### PR TITLE
[KARAF-5781] Properties edit doesn't conserve the existing ones. (On karaf-4.1.x)

### DIFF
--- a/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
+++ b/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
@@ -609,15 +609,6 @@ public class Builder {
             Files.write(configFile, config.getValue());
         }
 
-        // 'improve' configuration files.
-        if (propertyEdits != null) {
-            KarafPropertiesEditor editor = new KarafPropertiesEditor();
-            editor.setInputEtc(etcDirectory.toFile())
-                    .setOutputEtc(etcDirectory.toFile())
-                    .setEdits(propertyEdits);
-            editor.run();
-        }
-
         //
         // Handle overrides
         //
@@ -669,6 +660,13 @@ public class Builder {
         // Installed stage
         //
         installStage(installedProfile, allBootFeatures);
+
+        // 'improve' configuration files.
+        if (propertyEdits != null) {
+          KarafPropertiesEditor editor = new KarafPropertiesEditor();
+          editor.setInputEtc(etcDirectory.toFile()).setOutputEtc(etcDirectory.toFile()).setEdits(propertyEdits);
+          editor.run();
+        }
     }
 
     private void reformatClauses(Properties config, String key) {


### PR DESCRIPTION
Now it use the existing file and performs the specified changes.

Signed-off-by: van Sabben <4246302+vanSabben@users.noreply.github.com>