### PR TITLE
KARAF-5877 log4j2 appending error when using log4j2 XML configuration

### DIFF
--- a/log/src/main/java/org/apache/karaf/log/core/internal/LogServiceLog4j2XmlImpl.java
+++ b/log/src/main/java/org/apache/karaf/log/core/internal/LogServiceLog4j2XmlImpl.java
@@ -136,8 +136,7 @@ public class LogServiceLog4j2XmlImpl implements LogServiceInternal {
      * indenting it as needed.
      */
     static void insertIndented(Element loggers, Element element, boolean atBeginning) {
-        NodeList loggerElements = loggers.getElementsByTagName("*");
-        if (atBeginning && loggerElements.getLength() > 0) {
+        if (atBeginning && loggers.hasChildNodes()) {
             Node insertBefore = loggers.getFirstChild();
             if (insertBefore != null) {
                 if (insertBefore.getNodeType() == Node.TEXT_NODE) {
@@ -150,7 +149,7 @@ public class LogServiceLog4j2XmlImpl implements LogServiceInternal {
                 loggers.appendChild(element);
             }
         } else {
-            Node insertAfter = loggerElements.getLength() > 0 ? loggerElements.item(loggerElements.getLength() - 1) : null;
+            Node insertAfter = loggers.getLastChild().getPreviousSibling();
             if (insertAfter != null) {
                 if (insertAfter.getPreviousSibling() != null && insertAfter.getPreviousSibling().getNodeType() == Node.TEXT_NODE) {
                     String indent = insertAfter.getPreviousSibling().getTextContent();


### PR DESCRIPTION
See [this JIRA ticket|https://issues.apache.org/jira/browse/KARAF-5877] for more background information.

In short, `LogServiceLog4j2XmlImpl` will throw an `org.w3c.dom.DOMException: NOT_FOUND_ERR` when the corresponding `log4j2` configuration file has an element with children as the last element in the `<Loggers>` element. This causes the `log:tail` command to display the logs and error out immediately.