### PR TITLE
Fix ChannelExec exit status handling

### DIFF
--- a/client/src/main/java/org/apache/karaf/client/Main.java
+++ b/client/src/main/java/org/apache/karaf/client/Main.java
@@ -197,6 +197,9 @@ public class Main {
                     channel.setErr(output);
                     channel.open().verify();
                     channel.waitFor(EnumSet.of(ClientChannelEvent.CLOSED), 0);
+                    if (channel.getExitStatus() != null) {
+                        exitStatus = channel.getExitStatus();
+                    }
                 } else {
                     ChannelShell channel = session.createShellChannel();
                     Attributes attributes = terminal.enterRawMode();


### PR DESCRIPTION
Currently only ChannelShell exit status is handled, so any non-zero error codes from ChannelExec will be just discarded. This PR adds ChannelExec exit status handling.