### PR TITLE
Update karaf download URL in quick start guide

### DIFF
--- a/manual/src/main/asciidoc/quick-start.adoc
+++ b/manual/src/main/asciidoc/quick-start.adoc
@@ -20,7 +20,7 @@ These instructions should help you get Apache Karaf up and running in 5 to 15 mi
 
 Karaf requires a Java SE 8 or Java SE 9 environment to run. Refer to http://www.oracle.com/technetwork/java/javase/ for details on how to download and install Java SE 1.8 or greater.
 
-* Open a Web browser and access the following URL: http://karaf.apache.org/index/community/download.html
+* Open a Web browser and access the following URL: http://karaf.apache.org/download.html
 * Download the binary distribution that matches your system (zip for windows, tar.gz for unixes)
 * Extract the archive to a new folder on your hard drive; for example in c:\karaf - from now on this directory will be referenced as <KARAF_HOME>.
 


### PR DESCRIPTION
The existing download URL in the karaf quick start guide was broken.  Replacing it with an URL that works