### PR TITLE
Updated Scheduler feature to support persistence

### DIFF
--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -64,11 +64,11 @@
                             org.apache.karaf.scheduler;version=${project.version};-noimport:=true
                         </Export-Package>
                         <Import-Package>
-                            !com.mchange.*,
-                            !oracle.*,
-                            !org.quartz.*,
+                            com.mchange.*;resolution:=optional,
+                            oracle.*;resolution:=optional,
+                            org.quartz.*,
                             !weblogic.*,
-                            !javax.transaction,
+                            javax.transaction,
                             javax.servlet*;resolution:=optional,
                             org.jboss.*;resolution:=optional,
                             *

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/ScheduleOptions.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/ScheduleOptions.java
@@ -25,7 +25,7 @@ import java.util.Map;
  *
  * @since 2.3
  */
-public interface ScheduleOptions {
+public interface ScheduleOptions extends Serializable {
 
     /**
      * Add optional configuration for the job.

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/Scheduler.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/Scheduler.java
@@ -98,7 +98,7 @@ public interface Scheduler {
      */
     boolean unschedule(String jobName);
 
-    Map<Object, ScheduleOptions> getJobs() throws SchedulerError;
+    Map<String, ScheduleOptions> getJobs() throws SchedulerError;
 
     /**
      * Triggers a scheduled job.

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/SchedulerStorage.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/SchedulerStorage.java
@@ -1,0 +1,15 @@
+package org.apache.karaf.scheduler;
+
+import java.io.Serializable;
+
+public interface SchedulerStorage {
+
+    public <T> T get(final Serializable key);
+
+    public void put(final Serializable key, final Object value);
+
+    public boolean contains(final Serializable key);
+
+    public void release(final Serializable key);
+
+}

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/command/List.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/command/List.java
@@ -38,9 +38,9 @@ public class List implements Action {
         ShellTable table = new ShellTable();
         table.column("Name");
         table.column("Schedule");
-        Map<Object, ScheduleOptions> jobs = scheduler.getJobs();
-        for (Map.Entry<Object, ScheduleOptions> entry : jobs.entrySet()) {
-            table.addRow().addContent(entry.getValue().name(), entry.getValue().schedule());
+        Map<String, ScheduleOptions> jobs = scheduler.getJobs();
+        for (Map.Entry<String, ScheduleOptions> entry : jobs.entrySet()) {
+            table.addRow().addContent(entry.getKey(), entry.getValue().schedule());
         }
         table.print(System.out);
         return null;

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/command/completers/JobNameCompleter.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/command/completers/JobNameCompleter.java
@@ -38,8 +38,8 @@ public class JobNameCompleter implements Completer {
     public int complete(Session session, CommandLine commandLine, List<String> candidates) {
         StringsCompleter delegate = new StringsCompleter();
         try {
-            Map<Object, ScheduleOptions> jobs = scheduler.getJobs();
-            for (Map.Entry<Object, ScheduleOptions> job : jobs.entrySet()) {
+            Map<String, ScheduleOptions> jobs = scheduler.getJobs();
+            for (Map.Entry<String, ScheduleOptions> job : jobs.entrySet()) {
                 String name = job.getValue().name();
                 delegate.getStrings().add(name);
             }

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/core/QuartzSchedulerStorage.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/core/QuartzSchedulerStorage.java
@@ -1,0 +1,32 @@
+package org.apache.karaf.scheduler.core;
+
+import org.apache.karaf.scheduler.SchedulerStorage;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+public class QuartzSchedulerStorage implements SchedulerStorage {
+
+    private final Map<Serializable, Object> store = new HashMap<>();
+
+    @Override
+    public <T> T get(final Serializable key) {
+        return (T) this.store.get(key);
+    }
+
+    @Override
+    public void put(final Serializable key, final Object value) {
+        this.store.put(key, value);
+    }
+
+    @Override
+    public boolean contains(final Serializable key) {
+        return this.store.containsKey(key);
+    }
+
+    @Override
+    public void release(final Serializable key) {
+        this.store.remove(key);
+    }
+}

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/core/SchedulerMBeanImpl.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/core/SchedulerMBeanImpl.java
@@ -45,11 +45,11 @@ public class SchedulerMBeanImpl extends StandardMBean implements SchedulerMBean 
             TabularType tableType = new TabularType("Jobs", "Tables of all jobs", jobType, new String[]{ "Job" });
             TabularData table = new TabularDataSupport(tableType);
 
-            Map<Object, ScheduleOptions> jobs = scheduler.getJobs();
-            for (Map.Entry<Object, ScheduleOptions> entry : jobs.entrySet()) {
+            Map<String, ScheduleOptions> jobs = scheduler.getJobs();
+            for (Map.Entry<String, ScheduleOptions> entry : jobs.entrySet()) {
                 CompositeData data = new CompositeDataSupport(jobType,
                         new String[]{ "Job", "Schedule" },
-                        new Object[]{ entry.getValue().name(), entry.getValue().schedule()});
+                        new Object[]{ entry.getKey(), entry.getValue().schedule()});
                 table.put(data);
             }
             return table;

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/core/StdOsgiScheduler.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/core/StdOsgiScheduler.java
@@ -1,0 +1,123 @@
+package org.apache.karaf.scheduler.core;
+
+import org.quartz.*;
+import org.quartz.core.QuartzScheduler;
+import org.quartz.impl.StdScheduler;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+public class StdOsgiScheduler extends StdScheduler {
+
+    private final QuartzSchedulerStorage storage;
+
+
+    /**
+     * <p>
+     * Construct a <code>StdScheduler</code> instance to proxy the given
+     * <code>QuartzScheduler</code> instance, and with the given <code>SchedulingContext</code>.
+     * </p>
+     *
+     * @param sched
+     */
+    public StdOsgiScheduler(final QuartzScheduler sched) {
+        super(sched);
+        this.storage = new QuartzSchedulerStorage();
+    }
+
+    public QuartzSchedulerStorage getStorage() {
+        return storage;
+    }
+
+    @Override
+    public Date scheduleJob(final JobDetail jobDetail, final Trigger trigger)
+            throws SchedulerException {
+
+        JobDataMap context = (JobDataMap) jobDetail.getJobDataMap().get(org.apache.karaf.scheduler.core.QuartzScheduler.DATA_MAP_CONTEXT);
+
+        String contextKey = UUID.randomUUID().toString();
+
+        context.put(org.apache.karaf.scheduler.core.QuartzScheduler.DATA_MAP_CONTEXT_KEY, contextKey);
+        jobDetail.getJobDataMap().put(org.apache.karaf.scheduler.core.QuartzScheduler.DATA_MAP_CONTEXT_KEY, contextKey);
+        storage.put(contextKey, context);
+
+        jobDetail.getJobDataMap().remove(org.apache.karaf.scheduler.core.QuartzScheduler.DATA_MAP_CONTEXT);
+
+        final Date result = super.scheduleJob(jobDetail, trigger);
+
+        return result;
+    }
+
+    @Override
+    public boolean deleteJob(JobKey jobKey) throws SchedulerException {
+        final JobDetail jobDetail = getJobDetail(jobKey);
+        final JobDataMap jobDataMap = jobDetail.getJobDataMap();
+
+        final String contextKey = (String) jobDataMap.get(org.apache.karaf.scheduler.core.QuartzScheduler.DATA_MAP_CONTEXT_KEY);
+        if (null != contextKey) {
+            storage.release(contextKey);
+        }
+
+        return super.deleteJob(jobKey);
+    }
+
+    @Override
+    public boolean deleteJobs(List<JobKey> jobKeys) throws SchedulerException {
+        if (null != jobKeys) {
+            final List<String> contextKeyList = new ArrayList<>();
+            for(JobKey jobKey : jobKeys) {
+                final JobDetail jobDetail = getJobDetail(jobKey);
+                final JobDataMap jobDataMap = jobDetail.getJobDataMap();
+
+                final String contextKey = (String) jobDataMap.get(org.apache.karaf.scheduler.core.QuartzScheduler.DATA_MAP_CONTEXT_KEY);
+                if (null != contextKey) {
+                    contextKeyList.add(contextKey);
+                }
+            }
+
+            for(String contextKey : contextKeyList) {
+                storage.release(contextKey);
+            }
+        }
+
+        return super.deleteJobs(jobKeys);
+    }
+
+    @Override
+    public boolean unscheduleJob(TriggerKey triggerKey) throws SchedulerException {
+        final Trigger trigger = getTrigger(triggerKey);
+        final JobDataMap jobDataMap = trigger.getJobDataMap();
+
+        final String contextKey = (String) jobDataMap.get(org.apache.karaf.scheduler.core.QuartzScheduler.DATA_MAP_CONTEXT_KEY);
+        if (null != contextKey) {
+            storage.release(contextKey);
+        }
+
+        return super.unscheduleJob(triggerKey);
+    }
+
+    @Override
+    public boolean unscheduleJobs(List<TriggerKey> triggerKeys) throws SchedulerException {
+        if (null != triggerKeys) {
+            final List<String> contextKeyList = new ArrayList<>();
+            for(TriggerKey triggerKey : triggerKeys) {
+                final Trigger trigger = getTrigger(triggerKey);
+                final JobDataMap jobDataMap = trigger.getJobDataMap();
+
+                final String contextKey = (String) jobDataMap.get(org.apache.karaf.scheduler.core.QuartzScheduler.DATA_MAP_CONTEXT_KEY);
+                if (null != contextKey) {
+                    contextKeyList.add(contextKey);
+                }
+            }
+
+            for(String contextKey : contextKeyList) {
+                storage.release(contextKey);
+            }
+        }
+
+        return super.unscheduleJobs(triggerKeys);
+    }
+
+}

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/core/StdOsgiSchedulerFactory.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/core/StdOsgiSchedulerFactory.java
@@ -1,0 +1,30 @@
+package org.apache.karaf.scheduler.core;
+
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.core.QuartzScheduler;
+import org.quartz.core.QuartzSchedulerResources;
+import org.quartz.impl.StdSchedulerFactory;
+
+import java.util.Properties;
+
+public class StdOsgiSchedulerFactory extends StdSchedulerFactory {
+
+    public StdOsgiSchedulerFactory() {
+        super();
+    }
+
+    public StdOsgiSchedulerFactory(final Properties props) throws SchedulerException {
+        super(props);
+    }
+
+    public StdOsgiSchedulerFactory(final String fileName) throws SchedulerException {
+        super(fileName);
+    }
+
+    protected Scheduler instantiate(final QuartzSchedulerResources rsrcs, final QuartzScheduler qs) {
+        final Scheduler scheduler = new StdOsgiScheduler(qs);
+        return scheduler;
+    }
+
+}


### PR DESCRIPTION
Updated Scheduler feature to support persistence ( Oracle JDBC, C3P0 JDBC pool, Serialization ).

- ScheduleOptions was made Serializable, with addition to move Trigger creation from InternalScheduleOptions's constructor to method compile().
- getJobs() method from Scheduler interface returns String names and not Objects
- Added custom StdScheduler and StdSchedulerFactory classes, to implemented changes
- Added SchedulerStorage as support for "backward compatibility" and "short lived" jobs. This is not good place to use it.
- Updated QuartzJobExecutor to remove non-serializable items from JobDataMap storage
- Updated Scheduler Shell commands to use changed Scheduler API ( job names are as keys )