### PR TITLE
Updated Scheduler feature to support persistence

### DIFF
--- a/examples/karaf-scheduler-example/README.md
+++ b/examples/karaf-scheduler-example/README.md
@@ -46,7 +46,7 @@ mvn clean install
 On a running Karaf instance, register the features repository using:
 
 ```
-karaf@root()> feature:repo-add mvn:org.apache.karaf.examples/karaf-scheduler-example-features/4.2.1-SNAPSHOT/xml
+karaf@root()> feature:repo-add mvn:org.apache.karaf.examples/karaf-scheduler-example-features/4.2.2-SNAPSHOT/xml
 ```
 
 Then, you can install the runnable service feature:

--- a/examples/karaf-scheduler-example/karaf-scheduler-example-runnable/src/main/java/org/apache/karaf/examples/scheduler/RunnableService.java
+++ b/examples/karaf-scheduler-example/karaf-scheduler-example-runnable/src/main/java/org/apache/karaf/examples/scheduler/RunnableService.java
@@ -28,6 +28,10 @@ import org.osgi.service.component.annotations.Component;
 )
 public class RunnableService implements Runnable {
 
+    public RunnableService() {
+        super();
+    }
+
     @Override
     public void run() {
         System.out.print("Hello Karaf user !");

--- a/examples/karaf-scheduler-example/karaf-scheduler-example-runnable/src/main/java/org/apache/karaf/examples/scheduler/RunnableService.java
+++ b/examples/karaf-scheduler-example/karaf-scheduler-example-runnable/src/main/java/org/apache/karaf/examples/scheduler/RunnableService.java
@@ -22,6 +22,7 @@ import org.osgi.service.component.annotations.Component;
         property = {
                 "scheduler.name=example",
                 "scheduler.period:Long=10",
+                "scheduler.times:Integer=5",
                 "scheduler.concurrent:Boolean=false"
         }
 )

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -64,11 +64,11 @@
                             org.apache.karaf.scheduler;version=${project.version};-noimport:=true
                         </Export-Package>
                         <Import-Package>
-                            !com.mchange.*,
-                            !oracle.*,
-                            !org.quartz.*,
+                            com.mchange.*;resolution:=optional,
+                            oracle.*;resolution:=optional,
+                            org.quartz.*;resolution:=optional,
                             !weblogic.*,
-                            !javax.transaction,
+                            javax.transaction;resolution:=optional,
                             javax.servlet*;resolution:=optional,
                             org.jboss.*;resolution:=optional,
                             *

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/ScheduleOptions.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/ScheduleOptions.java
@@ -25,7 +25,7 @@ import java.util.Map;
  *
  * @since 2.3
  */
-public interface ScheduleOptions {
+public interface ScheduleOptions extends Serializable {
 
     /**
      * Add optional configuration for the job.

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/Scheduler.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/Scheduler.java
@@ -105,7 +105,7 @@ public interface Scheduler {
      */
     boolean unschedule(String jobName);
 
-    Map<Object, ScheduleOptions> getJobs() throws SchedulerError;
+    Map<String, ScheduleOptions> getJobs() throws SchedulerError;
 
     /**
      * Triggers a scheduled job.

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/Scheduler.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/Scheduler.java
@@ -44,6 +44,13 @@ public interface Scheduler {
     String PROPERTY_SCHEDULER_PERIOD = "scheduler.period";
 
     /**
+     * Name of the configuration property to defined the number of iterations for a job.
+     * The times is expressed in iterations.
+     * This property needs to be of numeric type.
+     */
+    String PROPERTY_SCHEDULER_TIMES = "scheduler.times";
+
+    /**
      * Name of the configuration property to define if a periodically job should be scheduled immediate.
      * Default is to not startup immediate, the job is started the first time after the period has expired.
      * This property needs to be of type Boolean.

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/SchedulerError.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/SchedulerError.java
@@ -15,9 +15,10 @@
  */
 package org.apache.karaf.scheduler;
 
-public class SchedulerError extends Exception {
+public class SchedulerError extends RuntimeException {
 
     public SchedulerError() {
+        super();
     }
 
     public SchedulerError(String msg) {

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/SchedulerStorage.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/SchedulerStorage.java
@@ -1,0 +1,15 @@
+package org.apache.karaf.scheduler;
+
+import java.io.Serializable;
+
+public interface SchedulerStorage {
+
+    <T> T get(final Serializable key);
+
+    void put(final Serializable key, final Object value);
+
+    boolean contains(final Serializable key);
+
+    void release(final Serializable key);
+
+}

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/command/List.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/command/List.java
@@ -38,9 +38,9 @@ public class List implements Action {
         ShellTable table = new ShellTable();
         table.column("Name");
         table.column("Schedule");
-        Map<Object, ScheduleOptions> jobs = scheduler.getJobs();
-        for (Map.Entry<Object, ScheduleOptions> entry : jobs.entrySet()) {
-            table.addRow().addContent(entry.getValue().name(), entry.getValue().schedule());
+        Map<String, ScheduleOptions> jobs = scheduler.getJobs();
+        for (Map.Entry<String, ScheduleOptions> entry : jobs.entrySet()) {
+            table.addRow().addContent(entry.getKey(), entry.getValue().schedule());
         }
         table.print(System.out);
         return null;

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/command/completers/JobNameCompleter.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/command/completers/JobNameCompleter.java
@@ -38,9 +38,9 @@ public class JobNameCompleter implements Completer {
     public int complete(Session session, CommandLine commandLine, List<String> candidates) {
         StringsCompleter delegate = new StringsCompleter();
         try {
-            Map<Object, ScheduleOptions> jobs = scheduler.getJobs();
-            for (Map.Entry<Object, ScheduleOptions> job : jobs.entrySet()) {
-                String name = job.getValue().name();
+            Map<String, ScheduleOptions> jobs = scheduler.getJobs();
+            for (Map.Entry<String, ScheduleOptions> job : jobs.entrySet()) {
+                String name = job.getKey();
                 delegate.getStrings().add(name);
             }
         } catch (Exception e) {

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/core/QuartzScheduler.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/core/QuartzScheduler.java
@@ -53,6 +53,9 @@ public class QuartzScheduler implements Scheduler {
     /** Map key for the scheduling options. */
     static final String DATA_MAP_OPTIONS = "QuartzJobScheduler.Options";
 
+    /** Map key  for non-serializable context. **/
+    static final String DATA_MAP_CONTEXT = "QuartzJobScheduler.Context";
+
     /** Map key for the logger. */
     static final String DATA_MAP_LOGGER = "QuartzJobScheduler.Logger";
 
@@ -65,7 +68,7 @@ public class QuartzScheduler implements Scheduler {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(QuartzScheduler.class.getClassLoader());
-            StdSchedulerFactory factory = new StdSchedulerFactory(configuration);
+            StdOsgiSchedulerFactory factory = new StdOsgiSchedulerFactory(configuration);
             scheduler = factory.getScheduler();
             scheduler.start();
         } catch (Throwable t) {
@@ -110,11 +113,18 @@ public class QuartzScheduler implements Scheduler {
                                    final InternalScheduleOptions options) {
         final JobDataMap jobDataMap = new JobDataMap();
 
-        jobDataMap.put(DATA_MAP_OBJECT, job);
-
+        // Serializable data
         jobDataMap.put(DATA_MAP_NAME, jobName);
-        jobDataMap.put(DATA_MAP_LOGGER, this.logger);
         jobDataMap.put(DATA_MAP_OPTIONS, options);
+
+        final JobDataMap jobContextMap = new JobDataMap();
+
+        // Non-serializable data
+        jobContextMap.put(DATA_MAP_OBJECT, job);
+        jobContextMap.put(DATA_MAP_LOGGER, this.logger);
+
+        // Temporary storage
+        jobDataMap.put(DATA_MAP_CONTEXT, jobContextMap);
 
         return jobDataMap;
     }
@@ -195,10 +205,6 @@ public class QuartzScheduler implements Scheduler {
         }
         final InternalScheduleOptions opts = (InternalScheduleOptions)options;
 
-        if ( opts.argumentException != null ) {
-            throw opts.argumentException;
-        }
-
         // as this method might be called from unbind and during
         // unbind a deactivate could happen, we check the scheduler first
         final org.quartz.Scheduler s = this.scheduler;
@@ -225,7 +231,7 @@ public class QuartzScheduler implements Scheduler {
             opts.name = name;
         }
 
-        final Trigger trigger = opts.trigger.withIdentity(name).build();
+        final Trigger trigger = opts.compile().withIdentity(name).build();
 
         // create the data map
         final JobDataMap jobDataMap = this.initDataMap(name, job, opts);
@@ -258,7 +264,7 @@ public class QuartzScheduler implements Scheduler {
             s.deleteJob(key);
 
             final InternalScheduleOptions opts = (InternalScheduleOptions)options;
-            Trigger trigger = opts.trigger.withIdentity(name).build();
+            Trigger trigger = opts.compile().withIdentity(name).build();
             JobDataMap jobDataMap = this.initDataMap(name, job, opts);
             detail = createJobDetail(name, jobDataMap, opts.canRunConcurrently);
 
@@ -291,17 +297,16 @@ public class QuartzScheduler implements Scheduler {
     }
 
     @Override
-    public Map<Object, ScheduleOptions> getJobs() throws SchedulerError {
+    public Map<String, ScheduleOptions> getJobs() throws SchedulerError {
         try {
-            Map<Object, ScheduleOptions> jobs = new HashMap<>();
+            Map<String, ScheduleOptions> jobs = new HashMap<>();
             org.quartz.Scheduler s = this.scheduler;
             if (s != null) {
                 for (String group : s.getJobGroupNames()) {
                     for (JobKey key : s.getJobKeys(GroupMatcher.jobGroupEquals(group))) {
                         JobDetail detail = s.getJobDetail(key);
                         ScheduleOptions options = (ScheduleOptions) detail.getJobDataMap().get(DATA_MAP_OPTIONS);
-                        Object job = detail.getJobDataMap().get(DATA_MAP_OBJECT);
-                        jobs.put(job, options);
+                        jobs.put(key.getName(), options);
                     }
                 }
             }

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/core/QuartzSchedulerStorage.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/core/QuartzSchedulerStorage.java
@@ -1,0 +1,32 @@
+package org.apache.karaf.scheduler.core;
+
+import org.apache.karaf.scheduler.SchedulerStorage;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+public class QuartzSchedulerStorage implements SchedulerStorage {
+
+    private final Map<Serializable, Object> store = new HashMap<>();
+
+    @Override
+    public <T> T get(final Serializable key) {
+        return (T) this.store.get(key);
+    }
+
+    @Override
+    public void put(final Serializable key, final Object value) {
+        this.store.put(key, value);
+    }
+
+    @Override
+    public boolean contains(final Serializable key) {
+        return this.store.containsKey(key);
+    }
+
+    @Override
+    public void release(final Serializable key) {
+        this.store.remove(key);
+    }
+}

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/core/SchedulerMBeanImpl.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/core/SchedulerMBeanImpl.java
@@ -45,11 +45,11 @@ public class SchedulerMBeanImpl extends StandardMBean implements SchedulerMBean 
             TabularType tableType = new TabularType("Jobs", "Tables of all jobs", jobType, new String[]{ "Job" });
             TabularData table = new TabularDataSupport(tableType);
 
-            Map<Object, ScheduleOptions> jobs = scheduler.getJobs();
-            for (Map.Entry<Object, ScheduleOptions> entry : jobs.entrySet()) {
+            Map<String, ScheduleOptions> jobs = scheduler.getJobs();
+            for (Map.Entry<String, ScheduleOptions> entry : jobs.entrySet()) {
                 CompositeData data = new CompositeDataSupport(jobType,
                         new String[]{ "Job", "Schedule" },
-                        new Object[]{ entry.getValue().name(), entry.getValue().schedule()});
+                        new Object[]{ entry.getKey(), entry.getValue().schedule()});
                 table.put(data);
             }
             return table;

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/core/StdOsgiScheduler.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/core/StdOsgiScheduler.java
@@ -1,0 +1,108 @@
+package org.apache.karaf.scheduler.core;
+
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerKey;
+import org.quartz.impl.StdScheduler;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class StdOsgiScheduler extends StdScheduler {
+
+    private final QuartzSchedulerStorage storage;
+
+
+    /**
+     * <p>
+     * Construct a <code>StdScheduler</code> instance to proxy the given
+     * <code>QuartzScheduler</code> instance, and with the given <code>SchedulingContext</code>.
+     * </p>
+     *
+     * @param sched
+     */
+    public StdOsgiScheduler(final org.quartz.core.QuartzScheduler sched) {
+        super(sched);
+        this.storage = new QuartzSchedulerStorage();
+    }
+
+    public QuartzSchedulerStorage getStorage() {
+        return storage;
+    }
+
+    @Override
+    public Date scheduleJob(final JobDetail jobDetail, final Trigger trigger)
+            throws SchedulerException {
+
+        JobDataMap context = (JobDataMap) jobDetail.getJobDataMap().get(QuartzScheduler.DATA_MAP_CONTEXT);
+        storage.put(jobDetail.getKey().toString(), context);
+
+        jobDetail.getJobDataMap().remove(QuartzScheduler.DATA_MAP_CONTEXT);
+
+        final Date result = super.scheduleJob(jobDetail, trigger);
+
+        return result;
+    }
+
+    @Override
+    public boolean deleteJob(JobKey jobKey) throws SchedulerException {
+        final String contextKey = jobKey.toString();
+        if (null != contextKey) {
+            storage.release(contextKey);
+        }
+
+        return super.deleteJob(jobKey);
+    }
+
+    @Override
+    public boolean deleteJobs(List<JobKey> jobKeys) throws SchedulerException {
+        if (null != jobKeys) {
+            final List<String> contextKeyList = new ArrayList<>();
+            for(JobKey jobKey : jobKeys) {
+                contextKeyList.add(jobKey.toString());
+            }
+
+            for(String contextKey : contextKeyList) {
+                storage.release(contextKey);
+            }
+        }
+
+        return super.deleteJobs(jobKeys);
+    }
+
+    @Override
+    public boolean unscheduleJob(TriggerKey triggerKey) throws SchedulerException {
+        final Trigger trigger = getTrigger(triggerKey);
+        final String contextKey = trigger.getJobKey().toString();
+        if (null != contextKey) {
+            storage.release(contextKey);
+        }
+
+        return super.unscheduleJob(triggerKey);
+    }
+
+    @Override
+    public boolean unscheduleJobs(List<TriggerKey> triggerKeys) throws SchedulerException {
+        if (null != triggerKeys) {
+            final List<String> contextKeyList = new ArrayList<>();
+            for(TriggerKey triggerKey : triggerKeys) {
+                final Trigger trigger = getTrigger(triggerKey);
+                final String contextKey = trigger.getJobKey().toString();
+                if (null != contextKey) {
+                    contextKeyList.add(contextKey);
+                }
+            }
+
+            for(String contextKey : contextKeyList) {
+                storage.release(contextKey);
+            }
+        }
+
+        return super.unscheduleJobs(triggerKeys);
+    }
+
+}

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/core/StdOsgiSchedulerFactory.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/core/StdOsgiSchedulerFactory.java
@@ -1,0 +1,31 @@
+package org.apache.karaf.scheduler.core;
+
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.core.QuartzScheduler;
+import org.quartz.core.QuartzSchedulerResources;
+import org.quartz.impl.StdSchedulerFactory;
+
+import java.util.Properties;
+
+public class StdOsgiSchedulerFactory extends StdSchedulerFactory {
+
+    public StdOsgiSchedulerFactory() {
+        throw new IllegalStateException("Not supported. Use: org.apache.karaf.scheduler.core.StdOsgiSchedulerFactory.StdOsgiSchedulerFactory(java.util.Properties)");
+    }
+
+    public StdOsgiSchedulerFactory(final Properties props) throws SchedulerException {
+        super(props);
+    }
+
+    public StdOsgiSchedulerFactory(final String fileName) throws SchedulerException {
+        throw new IllegalStateException("Not supported. Use: org.apache.karaf.scheduler.core.StdOsgiSchedulerFactory.StdOsgiSchedulerFactory(java.util.Properties)");
+    }
+
+    @Override
+    protected Scheduler instantiate(final QuartzSchedulerResources rsrcs, final QuartzScheduler qs) {
+        final Scheduler scheduler = new StdOsgiScheduler(qs);
+        return scheduler;
+    }
+
+}

--- a/scheduler/src/main/java/org/apache/karaf/scheduler/core/WhiteboardHandler.java
+++ b/scheduler/src/main/java/org/apache/karaf/scheduler/core/WhiteboardHandler.java
@@ -115,6 +115,22 @@ public class WhiteboardHandler {
                         .name(name)
                         .canRunConcurrently(concurrent));
             } else {
+                Integer times = -1;
+                {
+                    final Object v = ref.getProperty(Scheduler.PROPERTY_SCHEDULER_TIMES);
+                    if (null != v) {
+                        if (v instanceof Integer) {
+                            times = (Integer) v;
+                        } else if (v instanceof Long) {
+                            times = ((Long) v).intValue();
+                        } else if (v instanceof Number) {
+                            times = ((Number) v).intValue();
+                        } else {
+                            times = new Integer(v.toString());
+                        }
+                    }
+                }
+
                 Long period = null;
                 if (ref.getProperty(Scheduler.PROPERTY_SCHEDULER_PERIOD) != null) {
                     if (ref.getProperty(Scheduler.PROPERTY_SCHEDULER_PERIOD) instanceof Long) {
@@ -124,6 +140,8 @@ public class WhiteboardHandler {
                     }
                     if (period < 1) {
                         this.logger.debug("Ignoring service {} : scheduler period is less than 1.", ref);
+                    } else if (times < -1) {
+                        this.logger.debug("Ignoring service {} : scheduler times is defined but is less than -1.", ref);
                     } else {
                         boolean immediate = false;
                         if (ref.getProperty(Scheduler.PROPERTY_SCHEDULER_IMMEDIATE) != null) {
@@ -137,7 +155,7 @@ public class WhiteboardHandler {
                         if (!immediate) {
                             date.setTime(System.currentTimeMillis() + period * 1000);
                         }
-                        this.scheduler.schedule(job, this.scheduler.AT(date, -1, period)
+                        this.scheduler.schedule(job, this.scheduler.AT(date, times, period)
                                 .name(name)
                                 .canRunConcurrently((concurrent != null ? concurrent : true)));
                     }


### PR DESCRIPTION
Updated Scheduler feature to support persistence

Updated Scheduler feature to support persistence ( Oracle JDBC, C3P0 JDBC pool, Serialization ). Updated import packages resolution.

- ScheduleOptions was made Serializable, with addition to move Trigger creation from InternalScheduleOptions's constructor to method compile().
- getJobs() method from Scheduler interface returns String names and not Objects
- Added custom OSGi StdScheduler and StdSchedulerFactory classes, to implemented changes
- Added SchedulerStorage as support for "backward compatibility" and "short lived" jobs. This is not good place to over-use it.
- Updated QuartzJobExecutor to remove non-serializable items from JobDataMap storage
- Updated Scheduler Shell commands to use changed Scheduler API ( job names are as keys - String )
- Made SchedulerError extend RuntimeException, to have cleaner code.
- All bundle import dependencies were made optional

``` 
$ bundle:install -l 30 -s mvn:com.oracle/jdbc-osgi/12.1.0.1

$ feature:install jndi transaction aries-blueprint jdbc scr pax-jdbc-oracle

$ bundle:install -l 30 -s mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.quartz/2.2.4-SNAPSHOT ( Custom build to include Quartz 2.2.1 )

$ bundle:install -l 30 -s mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.c3p0/0.9.5.2_3-SNAPSHOT ( Compatible version with Quartz 2.2.1 )

$ feature:install scheduler

$ scheduler:list

$ feature:repo-add mvn:org.apache.karaf.examples/karaf-scheduler-example-features/4.2.2-SNAPSHOT/xml
$ feature:install karaf-scheduler-example
```