### PR TITLE
Update jaxb export versions

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
+++ b/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
@@ -422,12 +422,12 @@ jre-1.8= \
  javax.tools, \
  javax.transaction; javax.transaction.xa; partial=true; mandatory:=partial, \
  javax.xml, \
- javax.xml.bind;version="2.2.1", \
- javax.xml.bind.annotation;version="2.2.1", \
- javax.xml.bind.annotation.adapters;version="2.2.1", \
- javax.xml.bind.attachment;version="2.2.1", \
- javax.xml.bind.helpers;version="2.2.1", \
- javax.xml.bind.util;version="2.2.1", \
+ javax.xml.bind;version="2.2.8", \
+ javax.xml.bind.annotation;version="2.2.8", \
+ javax.xml.bind.annotation.adapters;version="2.2.8", \
+ javax.xml.bind.attachment;version="2.2.8", \
+ javax.xml.bind.helpers;version="2.2.8", \
+ javax.xml.bind.util;version="2.2.8", \
  javax.xml.crypto, \
  javax.xml.crypto.dom, \
  javax.xml.crypto.dsig, \
@@ -617,12 +617,12 @@ jre-9= \
  javax.tools, \
  javax.transaction; javax.transaction.xa; partial=true; mandatory:=partial, \
  javax.xml, \
- javax.xml.bind;version="2.2.1", \
- javax.xml.bind.annotation;version="2.2.1", \
- javax.xml.bind.annotation.adapters;version="2.2.1", \
- javax.xml.bind.attachment;version="2.2.1", \
- javax.xml.bind.helpers;version="2.2.1", \
- javax.xml.bind.util;version="2.2.1", \
+ javax.xml.bind;version="2.3.0", \
+ javax.xml.bind.annotation;version="2.3.0", \
+ javax.xml.bind.annotation.adapters;version="2.3.0", \
+ javax.xml.bind.attachment;version="2.3.0", \
+ javax.xml.bind.helpers;version="2.3.0", \
+ javax.xml.bind.util;version="2.3.0", \
  javax.xml.crypto, \
  javax.xml.crypto.dom, \
  javax.xml.crypto.dsig, \

--- a/main/src/test/resources/test-karaf-home/etc/jre.properties
+++ b/main/src/test/resources/test-karaf-home/etc/jre.properties
@@ -430,12 +430,12 @@ jre-1.8= \
  javax.tools, \
  javax.transaction; javax.transaction.xa; partial=true; mandatory:=partial, \
  javax.xml, \
- javax.xml.bind;version="2.2.1", \
- javax.xml.bind.annotation;version="2.2.1", \
- javax.xml.bind.annotation.adapters;version="2.2.1", \
- javax.xml.bind.attachment;version="2.2.1", \
- javax.xml.bind.helpers;version="2.2.1", \
- javax.xml.bind.util;version="2.2.1", \
+ javax.xml.bind;version="2.2.8", \
+ javax.xml.bind.annotation;version="2.2.8", \
+ javax.xml.bind.annotation.adapters;version="2.2.8", \
+ javax.xml.bind.attachment;version="2.2.8", \
+ javax.xml.bind.helpers;version="2.2.8", \
+ javax.xml.bind.util;version="2.2.8", \
  javax.xml.crypto, \
  javax.xml.crypto.dom, \
  javax.xml.crypto.dsig, \
@@ -625,12 +625,12 @@ jre-9= \
  javax.tools, \
  javax.transaction; javax.transaction.xa; partial=true; mandatory:=partial, \
  javax.xml, \
- javax.xml.bind;version="2.2.1", \
- javax.xml.bind.annotation;version="2.2.1", \
- javax.xml.bind.annotation.adapters;version="2.2.1", \
- javax.xml.bind.attachment;version="2.2.1", \
- javax.xml.bind.helpers;version="2.2.1", \
- javax.xml.bind.util;version="2.2.1", \
+ javax.xml.bind;version="2.3.0", \
+ javax.xml.bind.annotation;version="2.3.0", \
+ javax.xml.bind.annotation.adapters;version="2.3.0", \
+ javax.xml.bind.attachment;version="2.3.0", \
+ javax.xml.bind.helpers;version="2.3.0", \
+ javax.xml.bind.util;version="2.3.0", \
  javax.xml.crypto, \
  javax.xml.crypto.dom, \
  javax.xml.crypto.dsig, \


### PR DESCRIPTION
Java 8 shipped version 2.2.8
Java 9 shipped version 2.3.0

Signed-off-by: Robert Varga <nite@hq.sk>