### PR TITLE
[KARAF-5932] karaf-maven-plugin use user supplied settings.xml

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MojoSupport.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MojoSupport.java
@@ -128,6 +128,14 @@ public abstract class MojoSupport extends AbstractMojo {
     // called by Plexus when injecting the mojo's session
     public void setMavenSession(MavenSession mavenSession) {
         this.mavenSession = mavenSession;
+
+        if (mavenSession != null) {
+            // check for custom settings.xml and pass it onto pax-url-aether
+            File settingsFile = mavenSession.getRequest().getUserSettingsFile();
+            if (settingsFile != null && settingsFile.isFile()) {
+                System.setProperty("org.ops4j.pax.url.mvn.settings", settingsFile.getPath());
+            }
+        }
     }
 
     protected Map createManagedVersionMap(String projectId,


### PR DESCRIPTION
When the user or CI tool supplies a custom settings.xml file on the maven command line the karaf-maven-plugin ignores the file.

This was originally highlighted by rkmoquin: http://karaf.922171.n3.nabble.com/4-1-5-and-Karaf-Maven-Plugin-td4052587.html