### PR TITLE
[KARAF-5937] karaf-maven-plugin verify logs cause of failure

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
@@ -341,7 +341,8 @@ public class VerifyMojo extends MojoSupport {
                 getLog().info("Verification of feature " + id + " succeeded");
             } catch (Exception e) {
                 if (e.getCause() instanceof ResolutionException || !getLog().isDebugEnabled()) {
-                    getLog().warn(e.getMessage());
+                    getLog().warn(e.getMessage() + ": " + id);
+                    getLog().warn(e.getCause().getMessage());
                 } else {
                     getLog().warn(e);
                 }


### PR DESCRIPTION
When a feature verification fails, include details in logs to explain why it failed.

https://issues.apache.org/jira/browse/KARAF-5937