### PR TITLE
Set the secure processing feature on all DocumentBuilderFactory insta…

### DIFF
--- a/kar/src/main/java/org/apache/karaf/kar/internal/FeatureDetector.java
+++ b/kar/src/main/java/org/apache/karaf/kar/internal/FeatureDetector.java
@@ -18,8 +18,10 @@ package org.apache.karaf.kar.internal;
 
 import java.io.File;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +41,12 @@ class FeatureDetector {
 
     FeatureDetector() {
         dbf = DocumentBuilderFactory.newInstance();
+        try {
+            dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        } catch (ParserConfigurationException ex) {
+            //
+        }
         dbf.setNamespaceAware(true);
     }
     /**

--- a/log/src/main/java/org/apache/karaf/log/core/internal/LogServiceLog4j2XmlImpl.java
+++ b/log/src/main/java/org/apache/karaf/log/core/internal/LogServiceLog4j2XmlImpl.java
@@ -24,6 +24,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -208,6 +209,8 @@ public class LogServiceLog4j2XmlImpl implements LogServiceInternal {
         factory.setNamespaceAware(true);
         factory.setValidating(false);
         factory.setExpandEntityReferences(false);
+
+        setFeature(factory, XMLConstants.FEATURE_SECURE_PROCESSING, true);
         setFeature(factory, "http://xml.org/sax/features/external-general-entities", false);
         setFeature(factory, "http://xml.org/sax/features/external-parameter-entities", false);
         setFeature(factory, "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);

--- a/util/src/main/java/org/apache/karaf/util/XmlUtils.java
+++ b/util/src/main/java/org/apache/karaf/util/XmlUtils.java
@@ -121,6 +121,7 @@ public class XmlUtils {
         if (dbf == null) {
             dbf = DocumentBuilderFactory.newInstance();
             dbf.setNamespaceAware(true);
+            dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
             dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
             dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);


### PR DESCRIPTION
It's good security practice to set the secure processing feature on DocumentBuilderFactory instances