### PR TITLE
Revert "[ARIES-1793] Upgrade to blueprint-core 1.10.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
         <aries.application.api.version>1.0.0</aries.application.api.version>
         <aries.application.management.version>1.0.0</aries.application.management.version>
         <aries.blueprint.api.version>1.0.1</aries.blueprint.api.version>
-        <aries.blueprint.core.version>1.10.0</aries.blueprint.core.version>
+        <aries.blueprint.core.version>1.9.0</aries.blueprint.core.version>
         <aries.blueprint.core.compatibility.version>1.0.0</aries.blueprint.core.compatibility.version>
         <aries.blueprint.cm.version>1.2.0</aries.blueprint.cm.version>
         <aries.blueprint.web.version>1.0.1</aries.blueprint.web.version>


### PR DESCRIPTION
Reverts apache/karaf#670 . Because the update to 1.10.0 breaks camel blueprint. We will try to create blueprint core 1.9.1 that works with camel and jpa.