### PR TITLE
Wrap NIO IOException where it's thrown.

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -667,7 +667,7 @@ public class GenerateDescriptorMojo extends MojoSupport {
      * Extract the MANIFEST from the give file.
      */
 
-    private Manifest getManifest(File file) throws IOException {
+    private Manifest getManifest(File file) {
         final InputStream is;
         try {
             is = Files.newInputStream(file.toPath());
@@ -686,6 +686,9 @@ public class GenerateDescriptorMojo extends MojoSupport {
                 }
                 return m;
             }
+        } catch (IOException e) {
+            getLog().warn("Error while reading artifact", e);
+            return null;
         }
     }
 


### PR DESCRIPTION
Hi there.  Over at the Apache Tamaya project, we're using the karaf-maven-plugin on our extensions.  The extensions themselves are built as a bunch of modules in a maven pom, and some have dependencies between them.  When karaf-maven-plugin resolves one of those dependencies, it will often resolve it to the target/classes directory of the newly-built project, and not to a jar file which hasn't yet been installed.  Importantly that means that any operations that assume it is a jar will fail. That's been going on for a while and is probably fine.

Starting with karaf v4.1.3 and continuing through 4.2.2 we started seeing the surprising error message `Unable to create features.xml file: java.io.IOException: Is a directory` when running maven.  Turns out the IOException from the jar operations is no longer being caught and converted to a warning.  I found http://mail.openjdk.java.net/pipermail/nio-dev/2014-December/002877.html which taught me that while old-style `FileInputStream` throws an exception if you try to open a stream on a directory, NIO is happy to create the stream but throws the exception once you read from it. https://github.com/peculater/karaf/commit/ed797960d2a43eee8c04a9572478320af2420cfb added the NIO logic but didn't move the catch for the sneaky exception.