### PR TITLE
[KARAF-6078] bump jetty to 9.3.24.v20180605

### DIFF
--- a/assemblies/features/standard/pom.xml
+++ b/assemblies/features/standard/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <appendedResourcesDirectory>${basedir}/../../../../etc/appended-resources</appendedResourcesDirectory>
-        <dependency.jetty.version>9.3.21.v20170918</dependency.jetty.version>
+        <dependency.jetty.version>9.3.24.v20180605</dependency.jetty.version>
         <javax.annotation.version>1.2</javax.annotation.version>
         <geronimo.jaspic-spec.version>1.1</geronimo.jaspic-spec.version>
         <aries.spifly.version>1.0.2</aries.spifly.version>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <appendedResourcesDirectory>${basedir}/../etc/appended-resources</appendedResourcesDirectory>
-        <jetty.version>9.3.21.v20170918</jetty.version>
+        <jetty.version>9.3.24.v20180605</jetty.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This aligns jetty version used by features/standard with the version used by pas-web-6.0.11.