### PR TITLE
[KARAF-6093] Fix jax-ws packages being exported by bundle 0

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
+++ b/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
@@ -445,14 +445,6 @@ jre-1.8= \
  javax.xml.transform.stax, \
  javax.xml.transform.stream, \
  javax.xml.validation, \
- javax.xml.ws;version="2.2", \
- javax.xml.ws.handler;version="2.2", \
- javax.xml.ws.handler.soap;version="2.2", \
- javax.xml.ws.http;version="2.2", \
- javax.xml.ws.soap;version="2.2", \
- javax.xml.ws.spi;version="2.2", \
- javax.xml.ws.wsaddressing;version="2.2", \
- javax.xml.ws.spi.http;version="2.2", \
  javax.xml.xpath, \
  javafx.animation, \
  javafx.application, \


### PR DESCRIPTION
Removing `javax.xml.soap` from `jre.properties` wasn't enough (https://github.com/apache/karaf/pull/719). Also needed to remove `javax.xml.ws` packages since they use `javax.xml.soap`.