### PR TITLE
KARAF-6103 - When doing a "mvn compile" the karaf-maven-plugin causes…

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -20,16 +20,7 @@ package org.apache.karaf.tooling.features;
 import static java.lang.String.format;
 import static org.apache.karaf.deployer.kar.KarArtifactInstaller.FEATURE_CLASSIFIER;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintStream;
-import java.io.StringWriter;
+import java.io.*;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -668,27 +659,44 @@ public class GenerateDescriptorMojo extends MojoSupport {
      */
 
     private Manifest getManifest(File file) {
-        final InputStream is;
-        try {
-            is = Files.newInputStream(file.toPath());
-        } catch (Exception e) {
-            getLog().warn("Error while opening artifact", e);
-            return null;
-        }
-
-        try (BufferedInputStream bis = new BufferedInputStream(is)) {
-            bis.mark(256 * 1024);
-
-            try (JarInputStream jar = new JarInputStream(bis)) {
-                Manifest m = jar.getManifest();
-                if (m == null) {
-                    getLog().warn("Manifest not present in the first entry of the zip - " + file.getName());
+        // In case of a maven build below the 'package' phase, references to the 'target/classes'
+        // directories are passed in instead of jar-file references.
+        if(file.isDirectory()) {
+            File manifestFile = new File(file, "META-INF/MANIFEST.MF");
+            if(manifestFile.exists() && manifestFile.isFile()) {
+                try {
+                    InputStream manifestInputStream = new FileInputStream(manifestFile);
+                    return new Manifest(manifestInputStream);
+                } catch (IOException e) {
+                    getLog().warn("Error while reading artifact from directory", e);
+                    return null;
                 }
-                return m;
             }
-        } catch (IOException e) {
-            getLog().warn("Error while reading artifact", e);
+            getLog().warn("Manifest not present in the module directory " + file.getAbsolutePath());
             return null;
+        } else {
+            final InputStream is;
+            try {
+                is = Files.newInputStream(file.toPath());
+            } catch (Exception e) {
+                getLog().warn("Error while opening artifact", e);
+                return null;
+            }
+
+            try (BufferedInputStream bis = new BufferedInputStream(is)) {
+                bis.mark(256 * 1024);
+
+                try (JarInputStream jar = new JarInputStream(bis)) {
+                    Manifest m = jar.getManifest();
+                    if (m == null) {
+                        getLog().warn("Manifest not present in the first entry of the zip - " + file.getName());
+                    }
+                    return m;
+                }
+            } catch (IOException e) {
+                getLog().warn("Error while reading artifact", e);
+                return null;
+            }
         }
     }
 


### PR DESCRIPTION
… a IOException

- Added a check to detect if the "file" passed in to getMetadata() is a file or a directory.
- Implemented an alternate process for reading MANIFEST.MF files from directories.