### PR TITLE
[KARAF-6116] Adds support to karaf-maven-plugin add-to-repo for timestamped snapshots

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MavenUtil.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MavenUtil.java
@@ -208,7 +208,7 @@ public class MavenUtil {
     }
     
     public static String getFileName(Artifact artifact) {
-        return artifact.getArtifactId() + "-" + artifact.getBaseVersion()
+        return artifact.getArtifactId() + "-" + artifact.getVersion()
             + (artifact.getClassifier() != null ? "-" + artifact.getClassifier() : "") + "." + artifact.getType();
     }
 


### PR DESCRIPTION
Following the design in the Aether resolver library, the file name should use the artifact's version and not the base version. For timestamped snapshots (ie. 0.1.0-20190111.021945-8), the base version resolves to (0.1.0-SNAPSHOT).
Without this change, normal Maven resolving (ie. within Karaf when using a mvn: URL), of a timestamped artifact won't work since it'll be looking for the wrong file name.