### PR TITLE
[KARAF-6125] Standardized timezone handling for audit dates

### DIFF
--- a/audit/src/main/java/org/apache/karaf/audit/Activator.java
+++ b/audit/src/main/java/org/apache/karaf/audit/Activator.java
@@ -154,7 +154,7 @@ public class Activator extends BaseActivator implements ManagedService {
                 int files = getInt(FILE_FILES, 32);
                 boolean compress = getBoolean(FILE_COMPRESS, true);
                 EventLayout layout = createLayout(getString(FILE_LAYOUT, FILE_LAYOUT));
-                loggers.add(new FileEventLogger(path, encoding, policy, files, compress, this, layout));
+                loggers.add(new FileEventLogger(path, encoding, policy, files, compress, this, layout, TimeZone.getDefault()));
             }
             if (getBoolean(UDP_ENABLED, false)) {
                 String host = getString(UDP_HOST, "localhost");

--- a/audit/src/main/java/org/apache/karaf/audit/logger/FileEventLogger.java
+++ b/audit/src/main/java/org/apache/karaf/audit/logger/FileEventLogger.java
@@ -35,6 +35,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.TimeZone;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -54,9 +55,12 @@ public class FileEventLogger implements EventLogger {
     private long size;
     private Path path;
     private Writer writer;
-    private FastDateFormat fastDateFormat = new FastDateFormat();
+    private FastDateFormat fastDateFormat;
+    private TimeZone timeZone;
 
-    public FileEventLogger(String path, String encoding, String policy, int files, boolean compress, ThreadFactory factory, EventLayout layout) throws IOException {
+    public FileEventLogger(String path, String encoding, String policy, int files, boolean compress, ThreadFactory factory, EventLayout layout, TimeZone timeZone) throws IOException {
+        this.fastDateFormat = new FastDateFormat(timeZone, Locale.ENGLISH);
+        this.timeZone = timeZone;
         this.path = Paths.get(path);
         this.encoding = Charset.forName(encoding);
         this.policy = policy;
@@ -161,7 +165,7 @@ public class FileEventLogger implements EventLogger {
                     .filter(p -> p.startsWith(fix[0]))
                     .filter(p -> !p.endsWith(".tmp"))
                     .collect(Collectors.toList());
-            String date = new FastDateFormat().getDate(timestamp, FastDateFormat.YYYY_MM_DD);
+            String date = new FastDateFormat(timeZone, Locale.ENGLISH).getDate(timestamp, FastDateFormat.YYYY_MM_DD);
             List<String> sameDate = paths.stream()
                     .filter(p -> p.matches("\\Q" + fix[0] + "-" + date + "\\E(-[0-9]+)?\\Q" + fix[1] + "\\E"))
                     .collect(Collectors.toList());

--- a/audit/src/main/java/org/apache/karaf/audit/util/FastDateFormat.java
+++ b/audit/src/main/java/org/apache/karaf/audit/util/FastDateFormat.java
@@ -76,7 +76,9 @@ public class FastDateFormat {
             if (MMM_D2.equals(pattern)) {
                 StringBuffer sb = new StringBuffer();
                 FieldPosition fp = new FieldPosition(DateFormat.Field.DAY_OF_MONTH);
-                new SimpleDateFormat("MMM dd", locale).format(new Date(now), sb, fp);
+                SimpleDateFormat sdf = new SimpleDateFormat("MMM dd", locale);
+                sdf.setCalendar(Calendar.getInstance(timeZone, locale));
+                sdf.format(new Date(now), sb, fp);
                 if (sb.charAt(fp.getBeginIndex()) == '0') {
                     sb.setCharAt(fp.getBeginIndex(), ' ');
                 }

--- a/audit/src/test/java/org/apache/karaf/audit/logger/EventLoggerTest.java
+++ b/audit/src/test/java/org/apache/karaf/audit/logger/EventLoggerTest.java
@@ -37,6 +37,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -153,7 +154,7 @@ public class EventLoggerTest {
         EventLayout layout = new GelfLayout();
         Path path = Files.createTempDirectory("file-logger");
         String file = path.resolve("file.log").toString();
-        EventLogger logger = new FileEventLogger(file, "UTF-8", "daily", 2, false, Executors.defaultThreadFactory(), layout);
+        EventLogger logger = new FileEventLogger(file, "UTF-8", "daily", 2, false, Executors.defaultThreadFactory(), layout, TimeZone.getTimeZone("GMT+01:00"));
 
         logger.write(new MapEvent(map, 1510902000000L));
         logger.write(new MapEvent(map, 1510984800000L));
@@ -192,7 +193,7 @@ public class EventLoggerTest {
         EventLayout layout = new GelfLayout();
         Path path = Files.createTempDirectory("file-logger");
         String file = path.resolve("file.log").toString();
-        EventLogger logger = new FileEventLogger(file, "UTF-8", "daily", 2, false, Executors.defaultThreadFactory(), layout);
+        EventLogger logger = new FileEventLogger(file, "UTF-8", "daily", 2, false, Executors.defaultThreadFactory(), layout, TimeZone.getTimeZone("GMT+01:00"));
 
         for (int i = 0; i < 10; i++) {
             logger.write(new MapEvent(map, 1510902000000L + TimeUnit.DAYS.toMillis(i)));
@@ -217,10 +218,9 @@ public class EventLoggerTest {
         EventLayout layout = new GelfLayout();
         Path path = Files.createTempDirectory("file-logger");
         String file = path.resolve("file.log").toString();
-        EventLogger logger = new FileEventLogger(file, "UTF-8", "size(10)", 2, false, Executors.defaultThreadFactory(), layout);
+        EventLogger logger = new FileEventLogger(file, "UTF-8", "size(10)", 2, false, Executors.defaultThreadFactory(), layout, TimeZone.getTimeZone("GMT+01:00"));
         for (int i = 0; i < 10; i++) {
-            logger.write(new MapEvent(map, Timestamp.valueOf(
-                                           LocalDateTime.of(2017, 11, 17, 7, 0)).getTime() 
+            logger.write(new MapEvent(map, LocalDateTime.of(2017, 11, 17, 7, 0).toInstant(ZoneOffset.of("+01:00")).toEpochMilli()
                                            + TimeUnit.HOURS.toMillis(i)));
         }
         logger.close();
@@ -243,11 +243,10 @@ public class EventLoggerTest {
         EventLayout layout = new GelfLayout();
         Path path = Files.createTempDirectory("file-logger");
         String file = path.resolve("file.log").toString();
-        EventLogger logger = new FileEventLogger(file, "UTF-8", "size(10)", 2, true, Executors.defaultThreadFactory(), layout);
+        EventLogger logger = new FileEventLogger(file, "UTF-8", "size(10)", 2, true, Executors.defaultThreadFactory(), layout, TimeZone.getTimeZone("GMT+01:00"));
 
         for (int i = 0; i < 10; i++) {
-            logger.write(new MapEvent(map, Timestamp.valueOf(
-                                           LocalDateTime.of(2017, 11, 17, 7, 0)).getTime() 
+            logger.write(new MapEvent(map, LocalDateTime.of(2017, 11, 17, 7, 0).toInstant(ZoneOffset.of("+01:00")).toEpochMilli()
                                            + TimeUnit.HOURS.toMillis(i)));
         }
         logger.close();


### PR DESCRIPTION
Fixed a couple of cases where the FastDateFormat was not using a consistent timezone (sometimes provided and sometimes the default). This also required fixing a couple of callers of the FastDateFormat, which was mostly related to tests.
This bug caused audit file names to sometimes incorrectly roll between days depending on the timezone of the user.