### PR TITLE
Set the Content-Type header in the webconsole for gogo. Currently we …

### DIFF
--- a/webconsole/gogo/src/main/java/org/apache/karaf/webconsole/gogo/GogoPlugin.java
+++ b/webconsole/gogo/src/main/java/org/apache/karaf/webconsole/gogo/GogoPlugin.java
@@ -165,6 +165,7 @@ public class GogoPlugin extends AbstractWebConsolePlugin {
                     ie.printStackTrace();
                 }
             } else {
+                response.setHeader("Content-Type", "text/html");
                 response.getOutputStream().write(dump.getBytes());
             }
         }


### PR DESCRIPTION
…only set it correctly for the gzip case