### PR TITLE
[KARAF-6156] Update JaasHelper to support extending Karaf JAAS (4.1.x)

### DIFF
--- a/util/src/main/java/org/apache/karaf/util/jaas/JaasHelper.java
+++ b/util/src/main/java/org/apache/karaf/util/jaas/JaasHelper.java
@@ -61,15 +61,22 @@ public class JaasHelper {
         if (index > 0) {
             clazz = requestedRole.substring(0, index);
             role = requestedRole.substring(index + 1);
+            
+            for (Principal p : principals) {
+                if (clazz.equals(p.getClass().getName()) && role.equals(p.getName())) {
+                    return true;
+                }
+            }
         } else {
-            clazz = RolePrincipal.class.getName();
             role = requestedRole;
-        }
-        for (Principal p : principals) {
-            if (clazz.equals(p.getClass().getName()) && role.equals(p.getName())) {
-                return true;
+            
+            for (Principal p : principals) {
+                if (RolePrincipal.class.isAssignableFrom(p.getClass()) && role.equals(p.getName())) {
+                    return true;
+                }
             }
         }
+        
         return false;
     }
 


### PR DESCRIPTION
Use an .isAssignableFrom() instead of class name string comparison. This allows for extending Karaf JAAS [User,Group,Role]Principal classes
