### PR TITLE
KARAF-6207, bootFeatures sometimes being ignored

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
@@ -536,14 +536,6 @@ public class AssemblyMojo extends MojoSupport {
                .bundles(toArray(startupBundles))
                .profiles(toArray(startupProfiles));
 
-        // Boot stage
-        builder.defaultStage(Builder.Stage.Boot)
-                .kars(toArray(bootKars))
-                .repositories(bootFeatures.isEmpty() && bootProfiles.isEmpty() && installAllFeaturesByDefault, toArray(bootRepositories))
-                .features(toArray(bootFeatures))
-                .bundles(toArray(bootBundles))
-                .profiles(toArray(bootProfiles));
-
         // Installed stage
         builder.defaultStage(Builder.Stage.Installed)
                 .kars(toArray(installedKars))
@@ -551,6 +543,14 @@ public class AssemblyMojo extends MojoSupport {
                 .features(toArray(installedFeatures))
                 .bundles(toArray(installedBundles))
                 .profiles(toArray(installedProfiles));
+
+        // Boot stage
+        builder.defaultStage(Builder.Stage.Boot)
+                .kars(toArray(bootKars))
+                .repositories(bootFeatures.isEmpty() && bootProfiles.isEmpty() && installAllFeaturesByDefault, toArray(bootRepositories))
+                .features(toArray(bootFeatures))
+                .bundles(toArray(bootBundles))
+                .profiles(toArray(bootProfiles));
 
         // Generate the assembly
         builder.generateAssembly();


### PR DESCRIPTION
According to the documentation, the maven-karaf-plugin will install
features listed in the installedFeatures in the "system" internal
repository. Features listed in bootFeatures are additionally added to
the boot-features in the features service configuration file.

Hence, the configuration options do not conflict and a configuration
like this should result in the features being installed and added to the
boot-features configuration:

    <configuration>
      <bootFeatures>
        <feature>foo</feature>
      </bootFeatures>
      <installedFeatures>
        <feature>foo</feature>
      </installedFeatures>
    </configuration>

In fact, the configuration should be equivalent to `foo` being listed
just as a bootFeature.

But what actually happens is that the installedFeature will overwrite
the bootFeature and the feature is not added to the boot-features
configuration.

This patch switches the handling of bootFeatures and installedFeatures
which makes a feature configured in both sections a bootFeature,
adhering to the specifications of both configurations.