### PR TITLE
Add OFF to the help description of log:set command

### DIFF
--- a/log/src/main/java/org/apache/karaf/log/command/SetLogLevel.java
+++ b/log/src/main/java/org/apache/karaf/log/command/SetLogLevel.java
@@ -33,7 +33,7 @@ import org.apache.karaf.shell.support.completers.StringsCompleter;
 @Service
 public class SetLogLevel implements Action {
     
-    @Argument(index = 0, name = "level", description = "The log level to set (TRACE, DEBUG, INFO, WARN, ERROR) or DEFAULT to unset", required = true, multiValued = false)
+    @Argument(index = 0, name = "level", description = "The log level to set (OFF, TRACE, DEBUG, INFO, WARN, ERROR) or DEFAULT to unset", required = true, multiValued = false)
     @Completion(value = StringsCompleter.class, values = { "OFF", "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "DEFAULT" })
     String level;
 


### PR DESCRIPTION
Since [KARAF-4828](https://issues.apache.org/jira/browse/KARAF-4828) `OFF` is supported as a log level to the `log:set` command. This PR adds it to the help description.