### PR TITLE
[KARAF-6256] Parsing string arrays in org.apache.karaf.management.cfg…

### DIFF
--- a/util/src/main/java/org/apache/karaf/util/tracker/BaseActivator.java
+++ b/util/src/main/java/org/apache/karaf/util/tracker/BaseActivator.java
@@ -274,7 +274,7 @@ public class BaseActivator implements BundleActivator, Runnable, ThreadFactory {
             return StreamSupport.stream(((Iterable<?>) val).spliterator(), false)
                     .map(Object::toString).toArray(String[]::new);
         } else {
-            return val.toString().split(",");
+            return val.toString().split("\\s*,\\s*");
         }
     }
 


### PR DESCRIPTION
… doesn't ignore spaces

Issue: https://issues.apache.org/jira/browse/KARAF-6256

Small fix, which allows to define properties with spaces after comma (enabledProtocols=TLSv1.2, TLSv1.1 would be parsed as "TLSv1.2" and "TLSv1.1")