### PR TITLE
[KARAF-6258] Do not print error for user interrupted script

### DIFF
--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/ConsoleSessionImpl.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/ConsoleSessionImpl.java
@@ -70,7 +70,6 @@ import org.jline.reader.*;
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal.Signal;
 import org.jline.terminal.impl.DumbTerminal;
-import org.osgi.service.event.EventAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -578,7 +577,9 @@ public class ConsoleSessionImpl implements Session {
             session.execute(script);
         } catch (Exception e) {
             LOGGER.debug("Error in initialization script {}", scriptFileName, e);
-            System.err.println("Error in initialization script: " + scriptFileName + ": " + e.getMessage());
+            if (!(e instanceof InterruptedException)) {
+                System.err.println("Error in initialization script: " + scriptFileName + ": " + e.getMessage());
+            }
         } finally {
             session.put("script", oldScript);
         }

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/ShellCommand.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/ShellCommand.java
@@ -151,7 +151,7 @@ public class ShellCommand implements Command, SessionAware {
     }
 
     public void destroy() {
-	}
+    }
 
     private void executeScript(String names, Session session) {
         FilesStream.stream(names).forEach(p -> doExecuteScript(session, p));
@@ -164,7 +164,9 @@ public class ShellCommand implements Command, SessionAware {
             session.execute(script);
         } catch (Exception e) {
             LOGGER.debug("Error in initialization script {}", scriptFileName, e);
-            System.err.println("Error in initialization script: " + scriptFileName + ": " + e.getMessage());
+            if (!(e instanceof InterruptedException)) {
+                System.err.println("Error in initialization script: " + scriptFileName + ": " + e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
Karaf allows for the usage of commands like `log:tail` in
`etc/shell.init.script` which is handy for example for a development
assembly. But if such a command is canceled by a user (e.g. by hitting
Ctrl+C) an error message is logged and printed to stderr, claiming an
error in the initialization script.

While keeping the debug logging, this patch suppresses the stderr
message on user interrupts.