### PR TITLE
[KARAF-6268] Only add wrap dependency if necessary

### DIFF
--- a/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/control.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/control.xml
@@ -23,8 +23,10 @@
     <feature name="simplify-feature-as-is" description="simplify-feature-as-is" version="1.0.0.SNAPSHOT">
         <details>Check that bundles are simplified</details>
         <feature version="1.0.0.SNAPSHOT" prerequisite="false" dependency="false">simplify-feature-a</feature>
+        <feature prerequisite="true" dependency="false">wrap</feature>
         <bundle>mvn:test/simplify-bundle-b/1.0-SNAPSHOT</bundle>
         <bundle>mvn:test/simplify-bundle-a/1.0-SNAPSHOT</bundle>
+        <bundle>wrap:mvn:test/simplify-jar-c/1.0-SNAPSHOT</bundle>
     </feature>
     <feature name="simplify-feature-reduced" description="simplify-feature-reduced" version="1.0.0.SNAPSHOT">
         <details>Check that bundles are simplified</details>

--- a/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/pom.xml
@@ -47,6 +47,7 @@
         <module>simplify-feature-as-is</module>
         <module>simplify-feature-reduced</module>
         <module>simplify-features</module>
+        <module>simplify-jar-c</module>
     </modules>
 
     <build>

--- a/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/simplify-jar-c/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/simplify-jar-c/pom.xml
@@ -29,31 +29,12 @@
     </parent>
 
     <groupId>test</groupId>
-    <artifactId>simplify-bundle-a</artifactId>
+    <artifactId>simplify-jar-c</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>test</groupId>
-            <artifactId>simplify-jar-c</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/simplify-jar-c/src/main/java/test/C.java
+++ b/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/simplify-jar-c/src/main/java/test/C.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test.c;
+
+public class C
+{
+    public static String CSTRING = "C-string";
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -504,9 +504,10 @@ public class GenerateDescriptorMojo extends MojoSupport {
 
                     File bundleFile = this.dependencyHelper.resolve(artifact, getLog());
                     Manifest manifest = getManifest(bundleFile);
+                    boolean bundleNeedsWrapping = false;
                     if (manifest == null || !ManifestUtils.isBundle(manifest)) {
                         bundleName = "wrap:" + bundleName;
-                        needWrap = true;
+                        bundleNeedsWrapping = true;
                     }
 
                     Bundle bundle = null;
@@ -525,6 +526,7 @@ public class GenerateDescriptorMojo extends MojoSupport {
                             simplifyBundleDependencies && isBundleIncludedTransitively(feature, otherFeatures, bundle);
                         if (!includedTransitively && (!"provided".equals(entry.getScope()) || !ignoreScopeProvided)) {
                             feature.getBundle().add(bundle);
+                            needWrap |= bundleNeedsWrapping;
                         }
                     }
                     if ("runtime".equals(entry.getScope())) {


### PR DESCRIPTION
When generating a feature, only add the dependency on wrap if a bundle
requiring it really ends up included in the feature.

Signed-off-by: Stephen Kitt <skitt@redhat.com>