### PR TITLE
Updating plexus

### DIFF
--- a/examples/karaf-websocket-example/pom.xml
+++ b/examples/karaf-websocket-example/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-servlet</artifactId>
-            <version>9.4.11.v20180605</version>
+            <version>${jetty.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,7 @@
         <pax.transx.version>0.4.3</pax.transx.version>
 
         <portlet-api.version>2.0</portlet-api.version>
+        <plexus-utils.version>3.0.24</plexus-utils.version>
         <slf4j.version>1.7.12</slf4j.version>
 
         <spring.osgi.version>1.2.1</spring.osgi.version>

--- a/tooling/karaf-maven-plugin/pom.xml
+++ b/tooling/karaf-maven-plugin/pom.xml
@@ -40,7 +40,6 @@
         <jacoco-class-line-covered-ratio>0.00</jacoco-class-line-covered-ratio>
         <jacoco-class-instruction-covered-ratio>0.00</jacoco-class-instruction-covered-ratio>
         <jacoco-class-missed-count-maximum>1</jacoco-class-missed-count-maximum>
-        <plexus-utils.version>3.0.24</plexus-utils.version>
     </properties>
 
     <dependencies>
@@ -136,7 +135,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
-            <version>3.5</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/tooling/karaf-services-maven-plugin/pom.xml
+++ b/tooling/karaf-services-maven-plugin/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.0</version>
+            <version>${plexus-utils.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
This PR removes a few warnings about dependencies containing known CVEs:

plexus-utils-3.0.jar (pkg:maven/org.codehaus.plexus/plexus-utils@3.0, cpe:2.3:a:plexus-utils_project:plexus-utils:3.0:*:*:*:*:*:*:*) : CVE-2017-1000487
plexus-archiver-3.5.jar (pkg:maven/org.codehaus.plexus/plexus-archiver@3.5, cpe:2.3:a:plexus-archiver_project:plexus-archiver:3.5:*:*:*:*:*:*:*) : CVE-2018-1002200
websocket-servlet-9.4.11.v20180605.jar (pkg:maven/org.eclipse.jetty.websocket/websocket-servlet@9.4.11.v20180605, cpe:2.3:a:eclipse:jetty:9.4.11:20180605:*:*:*:*:*:*, cpe:2.3:a:jetty:jetty:9.4.11.v20180605:*:*:*:*:*:*:*) : CVE-2018-12545