### PR TITLE
[KARAF-6274] Karaf 4.2.5 maven plugin breaks if no archives are generated

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/ArchiveMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/ArchiveMojo.java
@@ -115,11 +115,13 @@ public class ArchiveMojo extends MojoSupport {
     public void execute() throws MojoExecutionException, MojoFailureException {
         org.apache.maven.artifact.Artifact artifact = project.getArtifact();
         artifact.setFile(targetFile);
-        try {
-            if (project.getPackaging().equals("karaf-assembly") && !archiveTarGz && !archiveZip) {
-                throw new IllegalArgumentException("For karaf-assembly packaging, you have to specify at least one archive type (tar.gz or zip)");
-            }
 
+        // abort if there are no archives to be created
+        if (!archiveTarGz && !archiveZip) {
+            return;
+        }
+
+        try {
             if (project.getPackaging().equals("karaf-assembly")) {
                 if (archiveZip) {
                     archive("zip", false, true);


### PR DESCRIPTION
Karaf 4.2.5 includes a line checking if archiveTarGz or archiveZip is
selected, throwing an error otherwise. Unfortunately, this line breaks
our build and a few of our use cases where we do not pack our
assemblies.

For example, we have a development assembly which we have end up in a
special folder unpacked and prepared to be launched. We could, of
course, pack and then automatically unpack it but that would just be a
waste of time.

We also have some assemblies which we pack with additional files
(documentation, …) which is handled separately. Again a use-case for
assemblies unpacked by the karaf-maven-plugin.

The change in question is commit 7da5044 (pull request #811)