### PR TITLE
KARAF-6276: Delete update file in finally block

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/BundleInstallSupportImpl.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/BundleInstallSupportImpl.java
@@ -140,13 +140,17 @@ public class BundleInstallSupportImpl implements BundleInstallSupport {
 
     @Override
     public void updateBundle(Bundle bundle, String uri, InputStream is) throws BundleException {
+        File file = null;
         // We need to wrap the bundle to insert a Bundle-UpdateLocation header
         try {
-            File file = BundleUtils.fixBundleWithUpdateLocation(is, uri);
+            file = BundleUtils.fixBundleWithUpdateLocation(is, uri);
             bundle.update(new FileInputStream(file));
-            file.delete();
         } catch (IOException e) {
             throw new BundleException("Unable to update bundle", e);
+        } finally {
+            if (file != null) {
+                file.delete();
+            }
         }
     }
 


### PR DESCRIPTION
As described in [KARAF-6276](https://issues.apache.org/jira/browse/KARAF-6276) an intermediate bundle update file might not be deleted when an exception occurs during update.
This should fix this by moving the `file#delete` call into a finally block.

Signed-off-by: Henning Treu <henning.treu@instana.com>