### PR TITLE
Maven plugin feature to define custom bundle location prefixes

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/download/impl/DownloadManagerHelper.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/download/impl/DownloadManagerHelper.java
@@ -16,15 +16,35 @@
  */
 package org.apache.karaf.features.internal.download.impl;
 
+import java.util.Collection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class DownloadManagerHelper {
 
-    private static final Pattern IGNORED_PROTOCOL_PATTERN = Pattern.compile("^(jar|war|war-i|warref|webbundle|wrap|spring|blueprint):.*$");
+    private static final String DEFAULT_IGNORED_PROTOCOL_PATTERN = "jar|war|war-i|warref|webbundle|wrap|spring|blueprint";
+    private static Pattern ignoredProtocolPattern;
+
+    static {
+        setIgnoredProtocolPattern(DEFAULT_IGNORED_PROTOCOL_PATTERN);
+    }
 
     private DownloadManagerHelper() {
         //Utility Class
+    }
+
+    private static void setIgnoredProtocolPattern(String pattern){
+        String defaultPattRegex = "^(" + pattern + "):.*$";
+        ignoredProtocolPattern = Pattern.compile(defaultPattRegex);
+    }
+
+    public static void setExtraProtocols( Collection<String> protocols ){
+        StringBuilder sb = new StringBuilder( DEFAULT_IGNORED_PROTOCOL_PATTERN );
+        for (String proto : protocols) {
+            sb.append( "|" + proto );
+        }
+
+        setIgnoredProtocolPattern(sb.toString());
     }
 
     /**
@@ -35,11 +55,11 @@ public final class DownloadManagerHelper {
      */
     public static String stripUrl(String url) {
         String strippedUrl = url;
-        Matcher matcher = IGNORED_PROTOCOL_PATTERN.matcher(strippedUrl);
+        Matcher matcher = ignoredProtocolPattern.matcher(strippedUrl);
         while (matcher.matches()) {
             String protocol = matcher.group(1);
             strippedUrl = strippedUrl.substring(protocol.length() + 1);
-            matcher = IGNORED_PROTOCOL_PATTERN.matcher(strippedUrl);
+            matcher = ignoredProtocolPattern.matcher(strippedUrl);
         }
         if (strippedUrl.contains("?")) {
             strippedUrl = strippedUrl.substring(0, strippedUrl.indexOf('?'));

--- a/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
+++ b/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
@@ -73,6 +73,7 @@ import org.apache.karaf.features.internal.download.DownloadCallback;
 import org.apache.karaf.features.internal.download.DownloadManager;
 import org.apache.karaf.features.internal.download.Downloader;
 import org.apache.karaf.features.internal.download.StreamProvider;
+import org.apache.karaf.features.internal.download.impl.DownloadManagerHelper;
 import org.apache.karaf.features.internal.model.Bundle;
 import org.apache.karaf.features.internal.model.Conditional;
 import org.apache.karaf.features.internal.model.ConfigFile;
@@ -745,6 +746,13 @@ public class Builder {
         this.blacklistedBundleURIs.addAll(bundles);
         return this;
     }
+
+
+    public Builder extraProtocols(Collection<String> protocols) {
+        DownloadManagerHelper.setExtraProtocols(protocols);
+        return this;
+    }
+
 
     /**
      * Configure a list of blacklisted features XML repository URIs (see {@link LocationPattern})
@@ -1660,6 +1668,7 @@ public class Builder {
             }
             LOGGER.info("   Feature {} is defined as an installed feature", feature.getId());
             for (Bundle bundle : feature.getBundle()) {
+
                 if (!ignoreDependencyFlag || !bundle.isDependency()) {
                     installer.installArtifact(bundle);
                 }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
@@ -162,6 +162,12 @@ public class AssemblyMojo extends MojoSupport {
     protected int defaultStartLevel = 30;
 
     /**
+     * List of additional allowed protocols on bundles location URI
+     */
+    @Parameter
+    private List<String> extraProtocols;
+
+    /**
      * List of compile-scope features XML files to be used in startup stage (etc/startup.properties)
      */
     @Parameter
@@ -474,6 +480,7 @@ public class AssemblyMojo extends MojoSupport {
         Builder builder = Builder.newInstance();
 
         // Set up miscellaneous options
+        builder.extraProtocols(extraProtocols);
         builder.offline(mavenSession.isOffline());
         builder.localRepository(localRepo.getBasedir());
         builder.resolverWrapper((resolver) -> new ReactorMavenResolver(reactor, resolver));


### PR DESCRIPTION
Allowing custom deployers on karaf 4 plugin, this comes in hand of the following PR https://github.com/apache/karaf/pull/489 that was merged in the past for karaf 3.

The idea is to have the following definition in karaf-maven-plugin
`<extraProtocols>
         <param>pentaho-webjars</param>
            <param>pentaho-platform-plugin-mvn</param>
          </extraProtocols>
`

which allows the following declaration
`<bundle>pentaho-webjars:mvn:org.webjars.npm/underscore/1.8.3</bundle>`

Please note, that we need this because we are doing our own karaf assembly.

