### PR TITLE
Remove SSH hostKeyFormat from the config file

### DIFF
--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -293,12 +293,6 @@ sftpEnabled=true
 hostKey = ${karaf.etc}/host.key
 
 #
-# The format used for hostKey.
-# Possible values are simple (Karaf internal), or PEM (OpenSSH format)
-#
-hostKeyFormat = simple
-
-#
 # Self defined key size in 1024, 2048, 3072, or 4096
 # If not set, this defaults to 2048.
 #

--- a/itests/test/src/test/filtered-resources/etc/feature.xml
+++ b/itests/test/src/test/filtered-resources/etc/feature.xml
@@ -184,12 +184,6 @@
             hostKey = ${karaf.etc}/host.key
 
             #
-            # The format used for hostKey.
-            # Possible values are simple (Karaf internal), or PEM (OpenSSH format)
-            #
-            hostKeyFormat = simple
-
-            #
             # Role name used for SSH access authorization
             #
             # sshRole = admin

--- a/itests/test/src/test/java/org/apache/karaf/itests/ssh/SshKeyFormatTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/ssh/SshKeyFormatTest.java
@@ -50,7 +50,6 @@ public class SshKeyFormatTest extends SshCommandTestBase {
         File keyFile = new File("src/test/resources/org/apache/karaf/itests/ssh/test.pem");
         return options(composite(super.config()),
                 editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "hostKey", keyFile.getAbsolutePath()),
-                editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "hostKeyFormat", "PEM"),
                 bundle("mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.not-yet-commons-ssl/0.3.11_1"),
                 bundle("mvn:com.google.guava/guava/16.0.1")
                 );


### PR DESCRIPTION
It isn't used anywhere in the code.