### PR TITLE
Remove old SSH algorithms

### DIFF
--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -333,21 +333,21 @@ completionMode = GLOBAL
 
 #
 # Override allowed SSH cipher algorithms.
-# Default: aes128-ctr,arcfour128,aes128-cbc,3des-cbc,blowfish-cbc
+# Default: aes256-ctr,aes192-ctr,aes128-ctr
 #
-# ciphers = aes128-ctr,arcfour128,aes128-cbc,3des-cbc,blowfish-cbc
+# ciphers = aes256-ctr,aes192-ctr,aes128-ctr
 
 #
 # Override allowed SSH HMAC algorithms.
-# Default: hmac-sha2-512,hmac-sha2-256,hmac-sha1
+# Default: hmac-sha2-512,hmac-sha2-256
 #
-# macs = hmac-sha2-512,hmac-sha2-256,hmac-sha1
+# macs = hmac-sha2-512,hmac-sha2-256
 
 #
 # Override allowed SSH key exchange algorithms.
-# Default: diffie-hellman-group-exchange-sha256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1
+# Default: ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
 #
-# kexAlgorithms = diffie-hellman-group-exchange-sha256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1
+# kexAlgorithms = ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
 
 #
 # Override moduli-url.

--- a/itests/test/src/test/filtered-resources/etc/feature.xml
+++ b/itests/test/src/test/filtered-resources/etc/feature.xml
@@ -229,21 +229,21 @@
 
             #
             # Override allowed SSH cipher algorithms.
-            # Default: aes128-ctr,arcfour128,aes128-cbc,3des-cbc,blowfish-cbc
+            # Default: aes256-ctr,aes192-ctr,aes128-ctr
             #
-            # ciphers = aes128-ctr,arcfour128,aes128-cbc,3des-cbc,blowfish-cbc
+            # ciphers = aes256-ctr,aes192-ctr,aes128-ctr
 
             #
             # Override allowed SSH HMAC algorithms.
-            # Default: hmac-sha2-512,hmac-sha2-256,hmac-sha1
+            # Default: hmac-sha2-512,hmac-sha2-256
             #
-            # macs = hmac-sha2-512,hmac-sha2-256,hmac-sha1
+            # macs = hmac-sha2-512,hmac-sha2-256
 
             #
             # Override allowed SSH key exchange algorithms.
-            # Default: diffie-hellman-group-exchange-sha256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1
+            # Default: ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
             #
-            # kexAlgorithms = diffie-hellman-group-exchange-sha256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1
+            # kexAlgorithms = ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
 
             #
             # Override moduli-url.

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/Activator.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/Activator.java
@@ -153,9 +153,9 @@ public class Activator extends BaseActivator implements ManagedService {
         String[] authMethods        = getStringArray("authMethods", "keyboard-interactive,password,publickey");
         int keySize                 = getInt("keySize", 2048);
         String algorithm            = getString("algorithm", "RSA");
-        String[] macs               = getStringArray("macs", "hmac-sha2-512,hmac-sha2-256,hmac-sha1");
-        String[] ciphers            = getStringArray("ciphers", "aes128-ctr,arcfour128,aes128-cbc,3des-cbc,blowfish-cbc");
-        String[] kexAlgorithms      = getStringArray("kexAlgorithms", "diffie-hellman-group-exchange-sha256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1");
+        String[] macs               = getStringArray("macs", "hmac-sha2-512,hmac-sha2-256");
+        String[] ciphers            = getStringArray("ciphers", "aes256-ctr,aes192-ctr,aes128-ctr");
+        String[] kexAlgorithms      = getStringArray("kexAlgorithms", "ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256");
         String welcomeBanner        = getString("welcomeBanner", null);
         String moduliUrl            = getString("moduli-url", null);
         boolean sftpEnabled         = getBoolean("sftpEnabled", true);


### PR DESCRIPTION
This PR modernizes the default SSH algorithms as follows:
a) Remove SHA-1 algorithms
b) Remove CBC ciphers)
c) Remove old ciphers (3-DES, Blowfish, Arcfour).
d) Add AES 256 + 192 ctr to the default ciphers.

Note: Tested successfully using openssh client