### PR TITLE
Adding support for SSH using elliptic curves

### DIFF
--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -287,10 +287,16 @@ sshRole = ssh
 sftpEnabled=true
 
 #
-# The location of the hostKey file defines where the private/public key of the server
+# The location of the hostKey file defines where the private key of the server
 # is located. If no file is at the defined location it will be ignored.
 #
 hostKey = ${karaf.etc}/host.key
+
+#
+# The location of the hostKeyPub file defines where the public key of the server
+# is located. If no file is at the defined location it will be ignored.
+#
+#hostKeyPub = ${karaf.etc}/host.key.pub
 
 #
 # Self defined key size in 1024, 2048, 3072, or 4096

--- a/manual/src/main/asciidoc/user-guide/remote.adoc
+++ b/manual/src/main/asciidoc/user-guide/remote.adoc
@@ -76,10 +76,16 @@ sshIdleTimeout = 1800000
 sshRealm = karaf
 
 #
-# The location of the hostKey file defines where the private/public key of the server
+# The location of the hostKey file defines where the private key of the server
 # is located. If no file is at the defined location it will be ignored.
 #
 hostKey = ${karaf.etc}/host.key
+
+#
+# The location of the hostKeyPub file defines where the public key of the server
+# is located. If no file is at the defined location it will be ignored.
+#
+#hostKeyPub = ${karaf.etc}/host.key.pub
 
 #
 # Role name used for SSH access authorization
@@ -122,8 +128,8 @@ The `etc/org.apache.karaf.shell.cfg` configuration file contains different prope
 * `sshHost` is the address of the network interface where the SSHd server is bound. The default value is 0.0.0.0,
  meaning that the SSHd server is bound on all network interfaces. You can bind on a target interface providing the IP
  address of the network interface.
-* `hostKey` is the location of the `host.key` file. By defaut, it uses `etc/host.key`. This file stores the public
- and private key pair of the SSHd server.
+* `hostKey` is the location of the `host.key` file. By defaut, it uses `etc/host.key`. This file stores the 
+ private key of the SSHd server.
 * `sshRole` is the default role used for SSH access. See the [Security section|security] of this user guide for details.
 * `sftpEnabled` controls if the SSH server start the SFTP system or not. When enabled, Karaf SSHd supports SFTP, meaning
  that you can remotely access to the Karaf filesystem with any sftp clients.

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/Activator.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/Activator.java
@@ -149,7 +149,8 @@ public class Activator extends BaseActivator implements ManagedService {
         String sshRealm             = getString("sshRealm", "karaf");
         Class<?>[] roleClasses      = getClassesArray("sshRoleTypes", "org.apache.karaf.jaas.boot.principal.RolePrincipal");
         String sshRole              = getString("sshRole", null);
-        String hostKey              = getString("hostKey", System.getProperty("karaf.etc") + "/host.key");
+        String privateHostKey       = getString("hostKey", System.getProperty("karaf.etc") + "/host.key");
+        String publicHostKey        = getString("hostKeyPublic", System.getProperty("karaf.etc") + "/host.key.pub");
         String[] authMethods        = getStringArray("authMethods", "keyboard-interactive,password,publickey");
         int keySize                 = getInt("keySize", 2048);
         String algorithm            = getString("algorithm", "RSA");
@@ -160,8 +161,9 @@ public class Activator extends BaseActivator implements ManagedService {
         String moduliUrl            = getString("moduli-url", null);
         boolean sftpEnabled         = getBoolean("sftpEnabled", true);
         
-        Path serverKeyPath = Paths.get(hostKey);
-        KeyPairProvider keyPairProvider = new OpenSSHKeyPairProvider(serverKeyPath.toFile(), algorithm, keySize);
+        Path serverPrivateKeyPath = Paths.get(privateHostKey);
+        Path serverPublicKeyPath = Paths.get(publicHostKey);
+        KeyPairProvider keyPairProvider = new OpenSSHKeyPairProvider(serverPrivateKeyPath, serverPublicKeyPath, algorithm, keySize);
         KarafJaasAuthenticator authenticator = new KarafJaasAuthenticator(sshRealm, sshRole, roleClasses);
         UserAuthFactoriesFactory authFactoriesFactory = new UserAuthFactoriesFactory();
         authFactoriesFactory.setAuthMethods(authMethods);

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/KarafJaasAuthenticator.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/KarafJaasAuthenticator.java
@@ -31,7 +31,6 @@ import javax.security.auth.login.FailedLoginException;
 import javax.security.auth.login.LoginContext;
 
 import org.apache.karaf.jaas.boot.principal.ClientPrincipal;
-import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.modules.publickey.PublickeyCallback;
 import org.apache.sshd.common.session.Session;
 import org.apache.sshd.server.auth.password.PasswordAuthenticator;

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/SshTerminal.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/SshTerminal.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 import java.util.Map;
 

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/keygenerator/PemWriter.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/keygenerator/PemWriter.java
@@ -18,10 +18,11 @@
  */
 package org.apache.karaf.shell.ssh.keygenerator;
 
-import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyPair;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,17 +31,27 @@ import org.apache.commons.ssl.PEMItem;
 import org.apache.commons.ssl.PEMUtil;
 
 public class PemWriter {
-    private File keyFile;
+    private Path privateKeyPath;
+    private Path publicKeyPath;
 
-    public PemWriter(File keyFile) {
-        this.keyFile = keyFile;
+    public PemWriter(Path privateKeyPath, Path publicKeyPath) {
+        this.privateKeyPath = privateKeyPath;
+        this.publicKeyPath = publicKeyPath;
     }
-    
+
     public void writeKeyPair(String resource, KeyPair kp) throws IOException, FileNotFoundException {
         Collection<Object> items = new ArrayList<>();
+
         items.add(new PEMItem(kp.getPrivate().getEncoded(), "PRIVATE KEY"));
         byte[] bytes = PEMUtil.encode(items);
-        try (FileOutputStream os = new FileOutputStream(keyFile)) {
+        try (OutputStream os = Files.newOutputStream(privateKeyPath)) {
+            os.write(bytes);
+        }
+
+        items.clear();
+        items.add(new PEMItem(kp.getPublic().getEncoded(), "PUBLIC KEY"));
+        bytes = PEMUtil.encode(items);
+        try (OutputStream os = Files.newOutputStream(publicKeyPath)) {
             os.write(bytes);
         }
     }

--- a/shell/ssh/src/main/resources/OSGI-INF/metatype/metatype.properties
+++ b/shell/ssh/src/main/resources/OSGI-INF/metatype/metatype.properties
@@ -33,11 +33,14 @@ sshHost.description = name of the host used to bind the SSH daemon
 sshRealm.name = SSH Realm
 sshRealm.description = name of the JAAS realm to use for SSH authentication
 
-hostKey.name = Host key
-hostKey.description = location of the host key for SSH
+hostKey.name = Private host key
+hostKey.description = location of the private host key for SSH
+
+hostKeyPub.name = Public host key
+hostKeyPub.description = location of the public host key for SSH
 
 keySize.name = Key size
 keySize.description = Secret key size in 1024, 2048, 3072, or 4096
 
 algorithm.name = Key algorithm
-algorithm.description = Host key algorithm in DSA, RSA, etc
+algorithm.description = Host key algorithm in DSA, RSA, EC, etc

--- a/shell/ssh/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/shell/ssh/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -23,6 +23,7 @@
         <AD id="sshHost" type="String" default="0.0.0.0" name="%sshHost.name" description="%sshHost.description"/>
         <AD id="sshRealm" type="String" default="karaf" name="%sshRealm.name" description="%sshRealm.description"/>
         <AD id="hostKey" type="String" default="${karaf.etc}/host.key" name="%hostKey.name" description="%hostKey.description"/>
+        <AD id="hostKeyPublic" type="String" default="${karaf.etc}/host.key.pub" name="%hostKeyPublic.name" description="%hostKeyPublic.description"/>
         <AD id="keySize" type="Integer" default="2048" name="%keySize.name" description="%keySize.description"/>
         <AD id="algorithm" type="String" default="RSA" name="%algorithm.name" description="%algorithm.description"/>
     </OCD>

--- a/shell/ssh/src/test/java/org/apache/karaf/shell/ssh/keygenerator/OpenSSHGeneratorKeyFileProviderTest.java
+++ b/shell/ssh/src/test/java/org/apache/karaf/shell/ssh/keygenerator/OpenSSHGeneratorKeyFileProviderTest.java
@@ -21,7 +21,10 @@ package org.apache.karaf.shell.ssh.keygenerator;
 import java.io.File;
 import java.nio.file.Files;
 import java.security.KeyPair;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPublicKey;
 import java.util.List;
 
 import org.apache.commons.ssl.PKCS8Key;
@@ -34,25 +37,31 @@ public class OpenSSHGeneratorKeyFileProviderTest {
 
     @Test
     public void writeSshKey() throws Exception {
-        File temp = File.createTempFile(this.getClass().getCanonicalName(), ".pem");
-        temp.deleteOnExit();
+        File privateKeyTemp = File.createTempFile(this.getClass().getCanonicalName(), ".priv");
+        privateKeyTemp.deleteOnExit();
+        File publicKeyTemp = File.createTempFile(this.getClass().getCanonicalName(), ".pub");
+        publicKeyTemp.deleteOnExit();
 
         KeyPair kp = new OpenSSHKeyPairGenerator(KeyUtils.RSA_ALGORITHM, 1024).generate();
-        new PemWriter(temp).writeKeyPair(KeyUtils.RSA_ALGORITHM, kp);
+        new PemWriter(privateKeyTemp.toPath(), publicKeyTemp.toPath()).writeKeyPair(KeyUtils.RSA_ALGORITHM, kp);
 
         //File path = new File("/home/cschneider/.ssh/id_rsa");
-        OpenSSHKeyPairProvider prov = new OpenSSHKeyPairProvider(temp, KeyUtils.RSA_ALGORITHM, 1024);
+        OpenSSHKeyPairProvider prov =
+            new OpenSSHKeyPairProvider(privateKeyTemp.toPath(), publicKeyTemp.toPath(), KeyUtils.RSA_ALGORITHM, 1024);
         KeyPair keys = prov.loadKeys().iterator().next();
         Assert.assertNotNull(keys);
         Assert.assertTrue("Loaded key is not RSA Key", keys.getPrivate() instanceof RSAPrivateCrtKey);
+        Assert.assertTrue("Loaded key is not RSA Key", keys.getPublic() instanceof RSAPublicKey);
     }
 
     @Test
     public void convertSimpleKey() throws Exception {
-        File temp = File.createTempFile(this.getClass().getCanonicalName(), ".pem");
-        temp.deleteOnExit();
+        File privateKeyTemp = File.createTempFile(this.getClass().getCanonicalName(), ".priv");
+        privateKeyTemp.deleteOnExit();
+        File publicKeyTemp = File.createTempFile(this.getClass().getCanonicalName(), ".pub");
+        publicKeyTemp.deleteOnExit();
 
-        SimpleGeneratorHostKeyProvider simpleGenerator = new SimpleGeneratorHostKeyProvider(temp);
+        SimpleGeneratorHostKeyProvider simpleGenerator = new SimpleGeneratorHostKeyProvider(privateKeyTemp);
         simpleGenerator.setKeySize(2048);
         simpleGenerator.setAlgorithm("DSA");
         List<KeyPair> keys = simpleGenerator.loadKeys();
@@ -60,7 +69,8 @@ public class OpenSSHGeneratorKeyFileProviderTest {
 
         Assert.assertEquals("DSA", simpleKeyPair.getPrivate().getAlgorithm());
 
-        OpenSSHKeyPairProvider provider = new OpenSSHKeyPairProvider(temp, "DSA", 2048);
+        OpenSSHKeyPairProvider provider = 
+            new OpenSSHKeyPairProvider(privateKeyTemp.toPath(), publicKeyTemp.toPath(), "DSA", 2048);
         KeyPair convertedKeyPair = provider.loadKeys().iterator().next();
         Assert.assertEquals("DSA", convertedKeyPair.getPrivate().getAlgorithm());
 
@@ -68,10 +78,27 @@ public class OpenSSHGeneratorKeyFileProviderTest {
         Assert.assertArrayEquals(simpleKeyPair.getPublic().getEncoded(),convertedKeyPair.getPublic().getEncoded());
 
         //also test that the original file has been replaced
-        PKCS8Key pkcs8 = new PKCS8Key(Files.newInputStream(temp.toPath()), null );
+        PKCS8Key pkcs8 = new PKCS8Key(Files.newInputStream(privateKeyTemp.toPath()), null );
         KeyPair keyPair = new KeyPair(pkcs8.getPublicKey(), pkcs8.getPrivateKey());
         Assert.assertArrayEquals(simpleKeyPair.getPrivate().getEncoded(),keyPair.getPrivate().getEncoded());
+    }
 
+    @Test
+    public void writeECSshKey() throws Exception {
+        File privateKeyTemp = File.createTempFile(this.getClass().getCanonicalName(), ".priv");
+        privateKeyTemp.deleteOnExit();
+        File publicKeyTemp = File.createTempFile(this.getClass().getCanonicalName(), ".pub");
+        publicKeyTemp.deleteOnExit();
+
+        KeyPair kp = new OpenSSHKeyPairGenerator(KeyUtils.EC_ALGORITHM, 256).generate();
+        new PemWriter(privateKeyTemp.toPath(), publicKeyTemp.toPath()).writeKeyPair(KeyUtils.EC_ALGORITHM, kp);
+
+        OpenSSHKeyPairProvider prov =
+            new OpenSSHKeyPairProvider(privateKeyTemp.toPath(), publicKeyTemp.toPath(), KeyUtils.EC_ALGORITHM, 256);
+        KeyPair keys = prov.loadKeys().iterator().next();
+        Assert.assertNotNull(keys);
+        Assert.assertTrue("Loaded key is not EC Key", keys.getPrivate() instanceof ECPrivateKey);
+        Assert.assertTrue("Loaded key is not EC Key", keys.getPublic() instanceof ECPublicKey);
     }
 
 }


### PR DESCRIPTION
Right now you can't SSH into Karaf using elliptic curve keys. The fix involves creating a new config parameter, that defaults to etc/host.key.pub to write out the public key that's generated.

Tested successfully in Karaf using an OpenSSH client.