### PR TITLE
Switch to use java.nio.file.Files.createTempFile

### DIFF
--- a/config/src/main/java/org/apache/karaf/config/core/impl/ConfigRepositoryImpl.java
+++ b/config/src/main/java/org/apache/karaf/config/core/impl/ConfigRepositoryImpl.java
@@ -22,6 +22,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -167,7 +168,7 @@ public class ConfigRepositoryImpl implements ConfigRepository {
         if (alias != null && !"".equals(alias.trim())) {
             file = new File(new File(System.getProperty("karaf.etc")), factoryPid + "-" + alias + ".cfg");
         } else {
-            file = File.createTempFile(factoryPid + "-", ".cfg", new File(System.getProperty("karaf.etc")));
+            file = Files.createTempFile(new File(System.getProperty("karaf.etc")).toPath(), factoryPid + "-", ".cfg").toFile();
         }
         props.putAll(properties);
         props.save(file);

--- a/diagnostic/boot/src/main/java/org/apache/karaf/diagnostic/core/providers/HeapDumpProvider.java
+++ b/diagnostic/boot/src/main/java/org/apache/karaf/diagnostic/core/providers/HeapDumpProvider.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 
 /**
  * Create a heap dump.
@@ -41,7 +42,7 @@ public class HeapDumpProvider implements DumpProvider {
             Object diagnosticMXBean = ManagementFactory.newPlatformMXBeanProxy(mBeanServer,
                 "com.sun.management:type=HotSpotDiagnostic", diagnosticMXBeanClass);
 
-            heapDumpFile = File.createTempFile("heapdump", ".hprof");
+            heapDumpFile = Files.createTempFile("heapdump", ".hprof").toFile();
             heapDumpFile.delete();
             
             Method method = diagnosticMXBeanClass.getMethod("dumpHeap", String.class, boolean.class);

--- a/features/core/src/main/java/org/apache/karaf/features/internal/download/impl/SimpleDownloadTask.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/download/impl/SimpleDownloadTask.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.karaf.util.StreamUtils;
@@ -71,7 +72,7 @@ public class SimpleDownloadTask extends AbstractRetryableDownloadTask {
                 throw new IOException("Unable to create directory " + dir.toString());
             }
 
-            File tmpFile = File.createTempFile("download-", null, dir);
+            File tmpFile = Files.createTempFile(dir.toPath(), "download-", null).toFile();
             
             urlObj = new URL(DownloadManagerHelper.stripStartLevel(urlObj.toString()));
             try (InputStream is = urlObj.openStream();
@@ -110,7 +111,7 @@ public class SimpleDownloadTask extends AbstractRetryableDownloadTask {
         // when downloading an embedded blueprint or spring xml file, then it must be as a temporary file
         File dir = new File(System.getProperty("karaf.data"), "tmp");
         dir.mkdirs();
-        File tmpFile = File.createTempFile("download-", null, dir);
+        File tmpFile = Files.createTempFile(dir.toPath(), "download-", null).toFile();
         try (InputStream is = new URL(url).openStream();
              OutputStream os = new FileOutputStream(tmpFile))
         {

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/KarMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/KarMojo.java
@@ -19,6 +19,7 @@
 package org.apache.karaf.tooling;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -308,7 +309,7 @@ public class KarMojo extends MojoSupport {
 
                 if (artifact.isSnapshot()) {
                     // the artifact is a snapshot, create the maven-metadata-local.xml
-                    final File metadataTmp = File.createTempFile("maven-metadata-local.xml", ".tmp");
+                    final File metadataTmp = Files.createTempFile("maven-metadata-local.xml", ".tmp").toFile();
 
                     try {
                         MavenUtil.generateMavenMetadata(artifact, metadataTmp);

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
@@ -46,6 +46,7 @@ import org.osgi.framework.ServiceReference;
 import java.io.*;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -222,7 +223,7 @@ public class RunMojo extends MojoSupport {
     }
 
     private static void extractTarGzDistribution(File sourceDistribution, File _targetFolder) throws IOException {
-        File uncompressedFile = File.createTempFile("uncompressedTarGz-", ".tar");
+        File uncompressedFile = Files.createTempFile("uncompressedTarGz-", ".tar").toFile();
         extractGzArchive(new FileInputStream(sourceDistribution), uncompressedFile);
         extract(new TarArchiveInputStream(new FileInputStream(uncompressedFile)), _targetFolder);
         FileUtils.forceDelete(uncompressedFile);

--- a/util/src/main/java/org/apache/karaf/jpm/impl/ProcessImpl.java
+++ b/util/src/main/java/org/apache/karaf/jpm/impl/ProcessImpl.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.InterruptedIOException;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -109,10 +110,10 @@ public class ProcessImpl implements Process {
     }
 
     public static Process create(File dir, String command) throws IOException {
-        //File input = File.createTempFile("jpm.", ".input");
-        //File output = File.createTempFile("jpm.", ".output");
-        //File error = File.createTempFile("jpm.", ".error");
-        File pidFile = File.createTempFile("jpm.", ".pid");
+        //File input = Files.createTempFile("jpm.", ".input").toFile();
+        //File output = Files.createTempFile("jpm.", ".output").toFile();
+        //File error = Files.createTempFile("jpm.", ".error").toFile();
+        File pidFile = Files.createTempFile("jpm.", ".pid").toFile();
         try {
             Map<String, String> props = new HashMap<>();
             //props.put("${in.file}", input.getCanonicalPath());

--- a/util/src/main/java/org/apache/karaf/jpm/impl/ScriptUtils.java
+++ b/util/src/main/java/org/apache/karaf/jpm/impl/ScriptUtils.java
@@ -23,13 +23,14 @@ import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Scanner;
 
 public class ScriptUtils {
 
     public static int execute(String name, Map<String, String> props) throws IOException {
-        File script = File.createTempFile("jpm.", ".script");
+        File script = Files.createTempFile("jpm.", ".script").toFile();
         try {
             if (isWindows()) {
                 String res = "windows/" + name + ".vbs";

--- a/util/src/main/java/org/apache/karaf/util/bundles/BundleUtils.java
+++ b/util/src/main/java/org/apache/karaf/util/bundles/BundleUtils.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.zip.CRC32;
@@ -34,7 +35,7 @@ import org.osgi.framework.Constants;
 public class BundleUtils {
 
     public static File fixBundleWithUpdateLocation(InputStream is, String uri) throws IOException {
-        File file = File.createTempFile("update-", ".jar");
+        File file = Files.createTempFile("update-", ".jar").toFile();
         try (ZipInputStream zis = new ZipInputStream(is);
              ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(file))) {
 


### PR DESCRIPTION
According to the Javadoc:

The Files.createTempFile method provides an alternative method to create an empty file in the temporary-file directory. Files created by that method may have more restrictive access permissions to files created by this method and so may be more suited to security-sensitive applications.