### PR TITLE
Fixed thread issue so BookingDisplayThread stops properly

### DIFF
--- a/examples/karaf-bundle-example/karaf-bundle-example-client/src/main/java/org/apache/karaf/examples/bundle/client/Display.java
+++ b/examples/karaf-bundle-example/karaf-bundle-example-client/src/main/java/org/apache/karaf/examples/bundle/client/Display.java
@@ -39,7 +39,7 @@ public class Display {
      * Init method used to start the thread.
      */
     public void init() {
-        BookingDisplayThread thread = new BookingDisplayThread(clientService);
+        thread = new BookingDisplayThread(clientService);
         thread.start();
     }
 


### PR DESCRIPTION
Fixed thread issue so BookingDisplayThread stops displaying output on bundle:stop.