### PR TITLE
Fixing encrypted passwork regression

### DIFF
--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/properties/AutoEncryptionSupport.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/properties/AutoEncryptionSupport.java
@@ -108,24 +108,34 @@ public class AutoEncryptionSupport implements Runnable, Closeable {
         boolean changed = false;
         for (String userName : users.keySet()) {
             String user = userName;
+            String userInfos = users.get(user);
 
             if (user.startsWith(PropertiesBackingEngine.GROUP_PREFIX)) {
                 continue;
             }
 
             // the password is in the first position
-            String[] infos = users.get(user).split(",");
+            String[] infos = userInfos.split(",");
             String storedPassword = infos[0];
 
             // check if the stored password is flagged as encrypted
             String encryptedPassword = encryptionSupport.encrypt(storedPassword);
             if (!storedPassword.equals(encryptedPassword)) {
                 LOGGER.debug("The password isn't flagged as encrypted, encrypt it.");
+                userInfos = encryptedPassword + ",";
+                for (int i = 1; i < infos.length; i++) {
+                    if (i == (infos.length - 1)) {
+                        userInfos = userInfos + infos[i];
+                    } else {
+                        userInfos = userInfos + infos[i] + ",";
+                    }
+                }
+
                 if (user.contains("\\")) {
                     users.remove(user);
                     user = user.replace("\\", "\\\\");
                 }
-                users.put(user, encryptedPassword + "," + String.join(",", infos));
+                users.put(user, userInfos);
                 changed = true;
             }
         }


### PR DESCRIPTION
There is a serious regression when encrypting passwords in this patch:

8833b6e16d4d42a0d2c60b400af07277d293deb7

Thankfully it was only applied on master...it encrypts the password, but leaves the unencrypted password "as is". This PR reverts the merge that applies to password encryption only.

Tested in container.