### PR TITLE
Improve the documentation of the security config options relating to …

### DIFF
--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -1000,7 +1000,11 @@ uninstall = admin
 #
 ################################################################################
 
+# The JAAS realm name to use for authentication
 realm=karaf
+
+# The role required to access the WebConsole
+role=admin
         </config>
         <feature>http</feature>
         <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.metatype/${felix.metatype.version}</bundle>

--- a/manual/src/main/asciidoc/user-guide/webconsole.adoc
+++ b/manual/src/main/asciidoc/user-guide/webconsole.adoc
@@ -56,6 +56,18 @@ See the link:security[Security section] for details.
 
 [NOTE]
 ====
-Only users with the `admin` role are allowed to logon on the Apache Karaf WebConsole.
+By default, only users with the `admin` role are allowed to logon to the Apache Karaf WebConsole.
 Right now, the WebConsole doesn't use RBAC system as we have for console commands, or MBeans.
 ====
+
+You can change the security configuration of the webconsole in the
+`etc/org.apache.karaf.webconsole.cfg` configuration file:
+
+----
+# The JAAS realm name to use for authentication
+realm=karaf
+
+# The role required to access the WebConsole
+role=admin
+----
+

--- a/webconsole/console/src/main/resources/OSGI-INF/metatype/metatype.properties
+++ b/webconsole/console/src/main/resources/OSGI-INF/metatype/metatype.properties
@@ -26,3 +26,6 @@ webconsole.description = Configuration of Apache Karaf WebConsole
 
 realm.name = Realm
 realm.description = The JAAS realm name to use for authentication
+
+role.name = Role
+role.description = The role required to access the WebConsole

--- a/webconsole/console/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/webconsole/console/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -20,6 +20,7 @@
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0" localization="OSGI-INF/metatype/metatype">
     <OCD id="org.apache.karaf.webconsole" name="%webconsole.name" description="%webconsole.description">
         <AD id="realm" type="String" default="karaf" name="%realm.name" description="%realm.description"/>
+        <AD id="role" type="String" default="admin" name="%role.name" description="%role.description"/>
     </OCD>
     <Designate pid="org.apache.karaf.webconsole">
         <Object ocdref="org.apache.karaf.webconsole"/>


### PR DESCRIPTION
…the webconsole

The 'etc/org.apache.karaf.webconsole.cfg' doesn't include the "role" configuration flag - hence it's unclear that the default is "admin" from looking at it. I also updated the docs accordingly.