### PR TITLE
Updating Jackson to 2.9.10

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9</version>
+            <version>2.9.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf</groupId>

--- a/examples/karaf-rest-example/pom.xml
+++ b/examples/karaf-rest-example/pom.xml
@@ -42,7 +42,7 @@
     
     <properties>
         <cxf.version>3.3.2</cxf.version>
-        <jackson.version>2.9.4</jackson.version>
+        <jackson.version>2.9.10</jackson.version>
     </properties>
 
 </project>


### PR DESCRIPTION
We should update Jackson to the latest version due to CVE-2019-14540.