### PR TITLE
[KARAF-5628] Corrupt gc.log due to unseparated VM settings

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/client
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/client
@@ -68,8 +68,10 @@ PROGNAME=`basename "${REALNAME}"`
 #
 # Sourcing environment settings for karaf similar to tomcats setenv
 #
-KARAF_SCRIPT="${PROGNAME}"
-export KARAF_SCRIPT
+if [ "x${KARAF_SCRIPT}" = "x" ]; then
+    KARAF_SCRIPT="${PROGNAME}"
+    export KARAF_SCRIPT
+fi
 if [ -f "${DIRNAME}/setenv" ]; then
   . "${DIRNAME}/setenv"
 fi

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/client.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/client.bat
@@ -26,7 +26,9 @@ set TERM=windows
 set ARGS=%*
 
 rem Sourcing environment settings for karaf similar to tomcats setenv
-SET KARAF_SCRIPT="client.bat"
+if "%KARAF_SCRIPT%" == "" (
+    SET KARAF_SCRIPT="client.bat"
+)
 if exist "%DIRNAME%setenv.bat" (
   call "%DIRNAME%setenv.bat"
 )

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/inc
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/inc
@@ -271,6 +271,21 @@ setupDebugOptions() {
     fi
 }
 
+setupVendorSepcifics() {
+    #Set the JVM_VENDOR specific JVM flags
+    if [ "${JVM_VENDOR}" = "SUN" ]; then
+        JAVA_VENDOR_OPTS="-Dcom.sun.management.jmxremote"
+    elif [ "${JVM_VENDOR}" = "IBM" ]; then
+        if ${os400}; then
+            JAVA_VENDOR_OPTS=
+        elif ${aix}; then
+            JAVA_VENDOR_OPTS="-Xverify:none -Xdump:heap -Xlp "
+        else
+            JAVA_VENDOR_OPTS="-Xverify:none"
+        fi
+    fi
+}
+
 setupDefaults() {
     #
     # Set up some easily accessible MIN/MAX params for JVM mem usage
@@ -286,18 +301,9 @@ setupDefaults() {
 
     DEFAULT_JAVA_OPTS="-Xms${JAVA_MIN_MEM} -Xmx${JAVA_MAX_MEM} -XX:+UnlockDiagnosticVMOptions "
 
-    #Set the JVM_VENDOR specific JVM flags
-    if [ "${JVM_VENDOR}" = "SUN" ]; then
-        DEFAULT_JAVA_OPTS="${DEFAULT_JAVA_OPTS} -Dcom.sun.management.jmxremote"
-    elif [ "${JVM_VENDOR}" = "IBM" ]; then
-        if ${os400}; then
-            DEFAULT_JAVA_OPTS="${DEFAULT_JAVA_OPTS}"
-        elif ${aix}; then
-            DEFAULT_JAVA_OPTS="-Xverify:none -Xdump:heap -Xlp ${DEFAULT_JAVA_OPTS}"
-        else
-            DEFAULT_JAVA_OPTS="-Xverify:none ${DEFAULT_JAVA_OPTS}"
-        fi
-    fi
+    setupVendorSepcifics
+
+    DEFAULT_JAVA_OPTS="${DEFAULT_JAVA_OPTS} ${JAVA_VENDOR_OPTS}"
 
     DEFAULT_JAVA_DEBUG_PORT="5005"
     if [ "x${JAVA_DEBUG_PORT}" = "x" ]; then
@@ -332,4 +338,3 @@ convertPaths() {
         fi
     fi
 }
-

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/instance
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/instance
@@ -68,8 +68,10 @@ PROGNAME=`basename "${REALNAME}"`
 #
 # Sourcing environment settings for karaf similar to tomcats setenv
 #
-KARAF_SCRIPT="${PROGNAME}"
-export KARAF_SCRIPT
+if [ "x${KARAF_SCRIPT}" = "x" ]; then
+    KARAF_SCRIPT="${PROGNAME}"
+    export KARAF_SCRIPT
+fi
 if [ -f "${DIRNAME}/setenv" ]; then
   . "${DIRNAME}/setenv"
 fi

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/instance.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/instance.bat
@@ -25,7 +25,9 @@ set PROGNAME=%~nx0%
 set ARGS=%*
 
 rem Sourcing environment settings for karaf similar to tomcats setenv
-SET KARAF_SCRIPT="instance.bat"
+if "%KARAF_SCRIPT%" == "" (
+	SET KARAF_SCRIPT="instance.bat"
+)
 if exist "%DIRNAME%setenv.bat" (
   call "%DIRNAME%setenv.bat"
 )

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf
@@ -69,8 +69,10 @@ LOCAL_CLASSPATH=$CLASSPATH
 #
 # Sourcing environment settings for karaf similar to tomcats setenv
 #
-KARAF_SCRIPT="${PROGNAME}"
-export KARAF_SCRIPT
+if [ "x${KARAF_SCRIPT}" = "x" ]; then
+    KARAF_SCRIPT="${PROGNAME}"
+    export KARAF_SCRIPT
+fi
 if [ -f "${DIRNAME}/setenv" ]; then
   . "${DIRNAME}/setenv"
 fi

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat
@@ -25,7 +25,10 @@ set PROGNAME=%~nx0%
 set ARGS=%*
 
 rem Sourcing environment settings for karaf similar to tomcats setenv
-SET KARAF_SCRIPT="karaf.bat"
+
+if "%KARAF_SCRIPT%" == "" (
+	SET KARAF_SCRIPT="karaf.bat"
+)
 if exist "%DIRNAME%setenv.bat" (
   call "%DIRNAME%setenv.bat"
 )

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/shell
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/shell
@@ -68,8 +68,10 @@ PROGNAME=`basename "${REALNAME}"`
 #
 # Sourcing environment settings for karaf similar to tomcats setenv
 #
-KARAF_SCRIPT="${PROGNAME}"
-export KARAF_SCRIPT
+if [ "x${KARAF_SCRIPT}" = "x" ]; then
+    KARAF_SCRIPT="${PROGNAME}"
+    export KARAF_SCRIPT
+fi
 if [ -f "${DIRNAME}/setenv" ]; then
   . "${DIRNAME}/setenv"
 fi

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/shell.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/shell.bat
@@ -25,7 +25,9 @@ set PROGNAME=%~nx0%
 set ARGS=%*
 
 rem Sourcing environment settings for karaf similar to tomcats setenv
-SET KARAF_SCRIPT="shell.bat"
+if "%KARAF_SCRIPT%" == "" (
+	SET KARAF_SCRIPT="shell.bat"
+)
 if exist "%DIRNAME%setenv.bat" (
   call "%DIRNAME%setenv.bat"
 )

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/start
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/start
@@ -68,8 +68,10 @@ PROGNAME=`basename "${REALNAME}"`
 #
 # Sourcing environment settings for karaf similar to tomcats setenv
 #
-KARAF_SCRIPT="${PROGNAME}"
-export KARAF_SCRIPT
+if [ "x${KARAF_SCRIPT}" = "x" ]; then
+    KARAF_SCRIPT="${PROGNAME}"
+    export KARAF_SCRIPT
+fi
 if [ -f "${DIRNAME}/setenv" ]; then
   . "${DIRNAME}/setenv"
 fi

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/start.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/start.bat
@@ -25,7 +25,9 @@ set PROGNAME=%~nx0%
 set ARGS=%*
 
 rem Sourcing environment settings for karaf similar to tomcats setenv
-SET KARAF_SCRIPT="start.bat"
+if "%KARAF_SCRIPT%" == "" (
+	SET KARAF_SCRIPT="start.bat"
+)
 if exist "%DIRNAME%setenv.bat" (
   call "%DIRNAME%setenv.bat"
 )

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/status
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/status
@@ -68,8 +68,10 @@ PROGNAME=`basename "${REALNAME}"`
 #
 # Sourcing environment settings for karaf similar to tomcats setenv
 #
-KARAF_SCRIPT="${PROGNAME}"
-export KARAF_SCRIPT
+if [ "x${KARAF_SCRIPT}" = "x" ]; then
+    KARAF_SCRIPT="${PROGNAME}"
+    export KARAF_SCRIPT
+fi
 if [ -f "${DIRNAME}/setenv" ]; then
   . "${DIRNAME}/setenv"
 fi
@@ -96,4 +98,3 @@ main() {
 }
 
 main "$@"
-

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/status.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/status.bat
@@ -25,7 +25,9 @@ set PROGNAME=%~nx0%
 set ARGS=%*
 
 rem Sourcing environment settings for karaf similar to tomcats setenv
-SET KARAF_SCRIPT="status.bat"
+if "%KARAF_SCRIPT%" == "" (
+	SET KARAF_SCRIPT="status.bat"
+)
 if exist "%DIRNAME%setenv.bat" (
   call "%DIRNAME%setenv.bat"
 )

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/stop
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/stop
@@ -68,8 +68,10 @@ PROGNAME=`basename "${REALNAME}"`
 #
 # Sourcing environment settings for karaf similar to tomcats setenv
 #
-KARAF_SCRIPT="${PROGNAME}"
-export KARAF_SCRIPT
+if [ "x${KARAF_SCRIPT}" = "x" ]; then
+    KARAF_SCRIPT="${PROGNAME}"
+    export KARAF_SCRIPT
+fi
 if [ -f "${DIRNAME}/setenv" ]; then
   . "${DIRNAME}/setenv"
 fi

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/stop.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/stop.bat
@@ -25,7 +25,9 @@ set PROGNAME=%~nx0%
 set ARGS=%*
 
 rem Sourcing environment settings for karaf similar to tomcats setenv
-SET KARAF_SCRIPT="stop.bat"
+if "%KARAF_SCRIPT%" == "" (
+	SET KARAF_SCRIPT="stop.bat"
+)
 if exist "%DIRNAME%setenv.bat" (
   call "%DIRNAME%setenv.bat"
 )


### PR DESCRIPTION
setenv would recognize original calling script. So EXTRA_JAVA_OPTS or JAVA_OPTS could be set from there script based with bat/sh if statement.