### PR TITLE
Put JAVA_OPTS between quotes for handling parameters with spaces

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf
@@ -299,7 +299,7 @@ run() {
 
         if [ "${ROOT_INSTANCE_RUNNING}" = "false" ] || [ "${CHECK_ROOT_INSTANCE_RUNNING}" = "false" ] ; then
             if [ "${VERSION}" -gt "8" ]; then
-                ${KARAF_EXEC} "${JAVA}" ${JAVA_OPTS} \
+                ${KARAF_EXEC} "${JAVA}" "${JAVA_OPTS}" \
                     --add-reads=java.xml=java.logging \
                     --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED \
                     --patch-module java.base=lib/endorsed/org.apache.karaf.specs.locator-@@project.version@@.jar \
@@ -330,7 +330,7 @@ run() {
                     -classpath "${CLASSPATH}" \
                     ${MAIN} "$@"
             else
-                ${KARAF_EXEC} "${JAVA}" ${JAVA_OPTS} \
+                ${KARAF_EXEC} "${JAVA}" "${JAVA_OPTS}" \
                     -Djava.endorsed.dirs="${JAVA_ENDORSED_DIRS}" \
                     -Djava.ext.dirs="${JAVA_EXT_DIRS}" \
                     -Dkaraf.instances="${KARAF_HOME}/instances" \


### PR DESCRIPTION
Certain Java options might contain spaces, for example the `-XX:OnError` which can be used to execute a command or script and takes the parameter `%p` as placeholder for the current PID of the Java process. However, due to the way e.g. Bash handles variables in scripts, it makes a lot of difference whether these are placed between quotes. Without quotes, spaces are handled so that they break up parameters.
This causes e.g. the following `export JAVA_OPTS="-XX:OnError=\"echo %p\""` to be handled as two separate arguments resulting in the error: `Error: Could not find or load main class %p`

The only downside I found from quoting is if e.g. a user has a script `export JAVA_OPTS="${JAVA_OPTS} ${MY_OPTS}"` and `JAVA_OPTS` was not previously set, an additional space is introduced which is not handled nicely.