### PR TITLE
[KARAF-5796] Use .hprof extension for heap dump

### DIFF
--- a/diagnostic/core/src/main/java/org/apache/karaf/diagnostic/core/internal/HeapDumpProvider.java
+++ b/diagnostic/core/src/main/java/org/apache/karaf/diagnostic/core/internal/HeapDumpProvider.java
@@ -46,10 +46,10 @@ public class HeapDumpProvider implements DumpProvider {
                 "com.sun.management:type=HotSpotDiagnostic", diagnosticMXBeanClass);
 
             Method method = diagnosticMXBeanClass.getMethod("dumpHeap", String.class, boolean.class);
-            method.invoke(diagnosticMXBean, "heapdump.txt", false);
+            method.invoke(diagnosticMXBean, "heapdump.hprof", false);
 
             // copy the dump in the destination
-            File heapDumpFile = new File("heapdump.txt");
+            File heapDumpFile = new File("heapdump.hprof");
             in = new FileInputStream(heapDumpFile);
             out = destination.add("heapdump.txt");
             LogDumpProvider.copy(in, out);


### PR DESCRIPTION
Backport of the fix of issue KARAF-5796 into the karaf-3.0.x branch.