### PR TITLE
Fix ternary precedence

### DIFF
--- a/shell/console/src/main/java/org/apache/felix/gogo/commands/CommandException.java
+++ b/shell/console/src/main/java/org/apache/felix/gogo/commands/CommandException.java
@@ -56,7 +56,7 @@ public class CommandException extends Exception {
     public String getNiceHelp() {
         return help != null ? help
                 : SimpleAnsi.COLOR_RED + "Error executing command: " 
-                 + getMessage() != null ? getMessage() : getClass().getName()
+                 + (getMessage() != null ? getMessage() : getClass().getName())
                  + SimpleAnsi.COLOR_DEFAULT;
     }
 

--- a/shell/console/src/main/java/org/apache/karaf/shell/commands/CommandException.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/commands/CommandException.java
@@ -58,7 +58,7 @@ public class CommandException extends Exception {
     public String getNiceHelp() {
         return  help != null ? help
                     : SimpleAnsi.COLOR_RED + "Error executing command: " 
-                    + getMessage() != null ? getMessage() : getClass().getName()
+                    + (getMessage() != null ? getMessage() : getClass().getName())
                     + SimpleAnsi.COLOR_DEFAULT;
     }
 


### PR DESCRIPTION
Message construction in two instances of getNiceHelp() is incorrect,
because of precedence in ternary operator arguments:

    X + getMessage() != null ? getMessage() : getClass().getName()

tests X + getMessage(), not getMessage(). This patch adds parentheses
to group the operations correctly.

Signed-off-by: Stephen Kitt <skitt@redhat.com>