### PR TITLE
Avoid Arrays.asList() with single items

### DIFF
--- a/event/src/test/java/org/apache/karaf/event/command/EventSendCommandTest.java
+++ b/event/src/test/java/org/apache/karaf/event/command/EventSendCommandTest.java
@@ -27,11 +27,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.karaf.event.command.EventSendCommand;
 import org.easymock.Capture;
 import org.junit.Test;
 import org.osgi.service.event.Event;
@@ -49,7 +49,7 @@ public class EventSendCommandTest {
 
         replay(send.eventAdmin);
         send.topic = "myTopic";
-        send.properties = Arrays.asList("a=b");
+        send.properties = Collections.singletonList("a=b");
         send.execute();
         verify(send.eventAdmin);
         
@@ -79,12 +79,12 @@ public class EventSendCommandTest {
     
     @Test(expected=IllegalArgumentException.class)
     public void testParseNoKeyValue() {
-        EventSendCommand.parse(Arrays.asList("="));
+        EventSendCommand.parse(Collections.singletonList("="));
     }
     
     @Test(expected=IllegalArgumentException.class)
     public void testParseNoKey() {
-        EventSendCommand.parse(Arrays.asList("=b"));
+        EventSendCommand.parse(Collections.singletonList("=b"));
     }
     
     @Test

--- a/features/core/src/test/java/org/apache/karaf/features/internal/service/BootFeaturesInstallerTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/service/BootFeaturesInstallerTest.java
@@ -19,6 +19,7 @@ package org.apache.karaf.features.internal.service;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -49,7 +50,7 @@ public class BootFeaturesInstallerTest extends TestBase {
     public void testParser() {
         BootFeaturesInstaller installer = new BootFeaturesInstaller(null, null, new String[0], "", false);
         Assert.assertEquals(asList(setOf("test1", "test2"), setOf("test3")), installer.parseBootFeatures(" ( test1 , test2 ) , test3 "));
-        Assert.assertEquals(asList(setOf("test1", "test2", "test3")), installer.parseBootFeatures(" test1 , test2, test3"));
+        Assert.assertEquals(Collections.singletonList(setOf("test1", "test2", "test3")), installer.parseBootFeatures(" test1 , test2, test3"));
         Assert.assertEquals(asList(setOf("test1"), setOf("test2"), setOf("test3")), installer.parseBootFeatures("(test1), (test2), test3"));
     }
     

--- a/features/core/src/test/java/org/apache/karaf/features/internal/service/OverridesTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/service/OverridesTest.java
@@ -18,6 +18,7 @@ package org.apache.karaf.features.internal.service;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -122,7 +123,7 @@ public class OverridesTest {
     public void testNotMatching() throws IOException {
         Map<String, Resource> map = asResourceMap(b100, b110);
         assertEquals(b100, map.get(getUri(b100)));
-        Overrides.override(map, Arrays.asList(getUri(b110)));
+        Overrides.override(map, Collections.singletonList(getUri(b110)));
         assertEquals(b100, map.get(getUri(b100)));
     }
 

--- a/features/extension/src/test/java/org/apache/karaf/features/extension/BundleWiresTest.java
+++ b/features/extension/src/test/java/org/apache/karaf/features/extension/BundleWiresTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -64,7 +64,7 @@ public class BundleWiresTest {
     @Test
     public void testFromBundle() throws IOException {
         BundleWire wire = packageWire(packageFilter, bundleCap(targetBundleId, targetBundleVersion));
-        Bundle bundle = wiredBundle(Arrays.asList(wire));
+        Bundle bundle = wiredBundle(Collections.singletonList(wire));
         c.replay();
         BundleWires bwires = new BundleWires(bundle);
         bwires.save(BASE_PATH);

--- a/instance/src/test/java/org/apache/karaf/instance/command/CreateCommandTest.java
+++ b/instance/src/test/java/org/apache/karaf/instance/command/CreateCommandTest.java
@@ -41,7 +41,7 @@ public class CreateCommandTest extends TestCase {
         cc.location = "top";
         cc.javaOpts = "foo";
         cc.features = new ArrayList<>(Arrays.asList("abc", "def"));
-        cc.featureURLs = new ArrayList<>(Arrays.asList("http://something"));
+        cc.featureURLs = new ArrayList<>(Collections.singletonList("http://something"));
         cc.instance = "myInstance";
         cc.verbose = true;
 

--- a/instance/src/test/java/org/apache/karaf/instance/core/InstanceSettingsTest.java
+++ b/instance/src/test/java/org/apache/karaf/instance/core/InstanceSettingsTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.karaf.instance.core;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -27,17 +26,17 @@ import org.junit.Assert;
 public class InstanceSettingsTest extends TestCase {
     public void testInstanceSettings() {
         InstanceSettings is =
-            new InstanceSettings(1, 1, 1, null, null, Collections.emptyList(), Arrays.asList("hi"));
+            new InstanceSettings(1, 1, 1, null, null, Collections.emptyList(), Collections.singletonList("hi"));
         assertEquals(1, is.getSshPort());
         assertEquals(1, is.getRmiRegistryPort());
         assertEquals(1, is.getRmiServerPort());
         Assert.assertNull(is.getLocation());
-        assertEquals(Arrays.asList("hi"), is.getFeatures());
+        assertEquals(Collections.singletonList("hi"), is.getFeatures());
         assertEquals(0, is.getFeatureURLs().size());
     }
     
     public void testEqualsHashCode() {
-        testEqualsHashCode(1, 1, 1, "top", "foo", Collections.emptyList(), Arrays.asList("hi"));
+        testEqualsHashCode(1, 1, 1, "top", "foo", Collections.emptyList(), Collections.singletonList("hi"));
         testEqualsHashCode(0, 0, 0, null, null, null, null);
     }
 
@@ -49,9 +48,10 @@ public class InstanceSettingsTest extends TestCase {
     }
     
     public void testEqualsHashCode2() {
-        InstanceSettings is = new InstanceSettings(1, 1, 1, "top", "foo", Collections.emptyList(), Arrays.asList("hi"));
-        Assert.assertFalse(is.equals(null));
-        Assert.assertFalse(is.equals(new Object()));
+        InstanceSettings is = new InstanceSettings(1, 1, 1, "top", "foo", Collections.emptyList(),
+            Collections.singletonList("hi"));
+        Assert.assertNotEquals(null, is);
+        Assert.assertNotEquals(is, new Object());
         assertEquals(is, is);
     }
 }

--- a/instance/src/test/java/org/apache/karaf/instance/core/internal/InstanceServiceImplTest.java
+++ b/instance/src/test/java/org/apache/karaf/instance/core/internal/InstanceServiceImplTest.java
@@ -23,12 +23,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.felix.utils.properties.TypedProperties;
 import org.apache.karaf.instance.core.Instance;
 import org.apache.karaf.instance.core.InstanceSettings;
 import org.junit.BeforeClass;
@@ -68,7 +67,8 @@ public class InstanceServiceImplTest {
             p.store(os, "Test comment");
         }
 
-        InstanceSettings s = new InstanceSettings(8122, 1122, 44444, null, null, null, Arrays.asList("test"));
+        InstanceSettings s = new InstanceSettings(8122, 1122, 44444, null, null, null,
+            Collections.singletonList("test"));
         as.addFeaturesFromSettings(f, s);
 
         Properties p2 = new Properties();

--- a/jaas/blueprint/jasypt/src/main/java/org/apache/karaf/jaas/blueprint/jasypt/handler/NamespaceHandler.java
+++ b/jaas/blueprint/jasypt/src/main/java/org/apache/karaf/jaas/blueprint/jasypt/handler/NamespaceHandler.java
@@ -15,7 +15,7 @@
 package org.apache.karaf.jaas.blueprint.jasypt.handler;
 
 import java.net.URL;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -52,6 +52,7 @@ public class NamespaceHandler implements org.apache.aries.blueprint.NamespaceHan
 
     private int idCounter;
 
+    @Override
     public URL getSchemaLocation(String namespace) {
         switch (namespace) {
             case "http://karaf.apache.org/xmlns/jasypt/v1.0.0":
@@ -61,12 +62,14 @@ public class NamespaceHandler implements org.apache.aries.blueprint.NamespaceHan
         }
     }
 
+    @Override
     public Set<Class> getManagedClasses() {
-        return new HashSet<>(Arrays.asList(
-                EncryptablePropertyPlaceholder.class
+        return new HashSet<>(Collections.singletonList(
+            EncryptablePropertyPlaceholder.class
         ));
     }
 
+    @Override
     public Metadata parse(Element element, ParserContext context) {
         String name = element.getLocalName() != null ? element.getLocalName() : element.getNodeName();
         if (PROPERTY_PLACEHOLDER_ELEMENT.equals(name)) {
@@ -75,6 +78,7 @@ public class NamespaceHandler implements org.apache.aries.blueprint.NamespaceHan
         throw new ComponentDefinitionException("Bad xml syntax: unknown element '" + name + "'");
     }
 
+    @Override
     public ComponentMetadata decorate(Node node, ComponentMetadata componentMetadata, ParserContext parserContext) {
         throw new ComponentDefinitionException("Bad xml syntax: node decoration is not supported");
     }

--- a/management/server/src/test/java/org/apache/karaf/management/KarafMBeanServerGuardTest.java
+++ b/management/server/src/test/java/org/apache/karaf/management/KarafMBeanServerGuardTest.java
@@ -749,7 +749,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
                 // The following operations should not throw an exception
                 Attribute a1 = new Attribute("Something", "v1");
                 Attribute a2 = new Attribute("Value", 42L);
-                guard.invoke(mbs, im, new Object[]{on, new AttributeList(Arrays.asList(a1))});
+                guard.invoke(mbs, im, new Object[]{on, new AttributeList(Collections.singletonList(a1))});
                 guard.invoke(mbs, im, new Object[]{on, new AttributeList(Arrays.asList(a2, a1))});
 
                 Attribute a3 = new Attribute("Other", Boolean.TRUE);
@@ -762,7 +762,7 @@ public class KarafMBeanServerGuardTest extends TestCase {
 
                 try {
                     Attribute a4 = new Attribute("NonExistent", "v4");
-                    guard.invoke(mbs, im, new Object[]{on, new AttributeList(Arrays.asList(a4))});
+                    guard.invoke(mbs, im, new Object[]{on, new AttributeList(Collections.singletonList(a4))});
                     fail("Should not have found the MBean Declaration");
                 } catch (IllegalStateException ise) {
                     // good

--- a/service/guard/src/test/java/org/apache/karaf/service/guard/impl/GuardProxyCatalogTest.java
+++ b/service/guard/src/test/java/org/apache/karaf/service/guard/impl/GuardProxyCatalogTest.java
@@ -786,7 +786,7 @@ public class GuardProxyCatalogTest {
         final Hashtable<String, Object> serviceProps = new Hashtable<>();
         serviceProps.put(Constants.OBJECTCLASS, new String [] {TestServiceAPI.class.getName(), TestServiceAPI2.class.getName()});
         serviceProps.put(Constants.SERVICE_ID, serviceID);
-        serviceProps.put(GuardProxyCatalog.SERVICE_GUARD_ROLES_PROPERTY, Arrays.asList("someone")); // will be overwritten
+        serviceProps.put(GuardProxyCatalog.SERVICE_GUARD_ROLES_PROPERTY, Collections.singletonList("someone")); // will be overwritten
         Object myObject = new Object();
         serviceProps.put("foo.bar", myObject);
 
@@ -1202,7 +1202,7 @@ public class GuardProxyCatalogTest {
         final Hashtable<String, Object> serviceProps = new Hashtable<>();
         serviceProps.put(Constants.OBJECTCLASS, objClsMap.keySet().toArray(new String [] {}));
         serviceProps.put(Constants.SERVICE_ID, serviceID);
-        serviceProps.put(GuardProxyCatalog.SERVICE_GUARD_ROLES_PROPERTY, Arrays.asList("everyone")); // will be overwritten
+        serviceProps.put(GuardProxyCatalog.SERVICE_GUARD_ROLES_PROPERTY, Collections.singletonList("everyone")); // will be overwritten
         serviceProps.put("bar", "foo");
 
         // The mock bundle context for the bundle providing the service is set up here
@@ -1228,7 +1228,7 @@ public class GuardProxyCatalogTest {
                     for (String key : expectedProxyProps.keySet()) {
                         if (GuardProxyCatalog.SERVICE_GUARD_ROLES_PROPERTY.equals(key)) {
                             assertTrue("The roles property should have been overwritten",
-                                    !Arrays.asList("everyone").equals(props.get(key)));
+                                    !Collections.singletonList("everyone").equals(props.get(key)));
                         } else {
                             assertEquals(expectedProxyProps.get(key), props.get(key));
                         }
@@ -1297,7 +1297,7 @@ public class GuardProxyCatalogTest {
         for (String key : expectedProxyProps.keySet()) {
             if (GuardProxyCatalog.SERVICE_GUARD_ROLES_PROPERTY.equals(key)) {
                 assertTrue("The roles property should have been overwritten",
-                        !Arrays.asList("everyone").equals(proxySR.getProperty(key)));
+                        !Collections.singletonList("everyone").equals(proxySR.getProperty(key)));
             } else {
                 assertEquals(expectedProxyProps.get(key), proxySR.getProperty(key));
             }

--- a/service/guard/src/test/java/org/apache/karaf/service/guard/tools/ACLConfigurationParserTest.java
+++ b/service/guard/src/test/java/org/apache/karaf/service/guard/tools/ACLConfigurationParserTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 public class ACLConfigurationParserTest {
     @Test
     public void testParseRoles() {
-        assertEquals(Arrays.asList("some_role"),
+        assertEquals(Collections.singletonList("some_role"),
                 ACLConfigurationParser.parseRoles(" some_role   "));
         assertEquals(Arrays.asList("a","b","C"),
                 ACLConfigurationParser.parseRoles("a,b,C"));
@@ -69,36 +69,36 @@ public class ACLConfigurationParserTest {
         List<String> roles4 = new ArrayList<>();
         assertEquals(Specificity.ARGUMENT_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("bar", new Object [] {"aa", 42}, new String [] {"java.lang.String", "int"}, config, roles4));
-        assertEquals(Arrays.asList("ra"), roles4);
+        assertEquals(Collections.singletonList("ra"), roles4);
 
         List<String> roles5 = new ArrayList<>();
         assertEquals(Specificity.ARGUMENT_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("bar", new Object [] {"bb", 42}, new String [] {"java.lang.String", "int"}, config, roles5));
-        assertEquals(Arrays.asList("rb"), roles5);
+        assertEquals(Collections.singletonList("rb"), roles5);
 
         List<String> roles6 = new ArrayList<>();
         assertEquals(Specificity.ARGUMENT_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("bar", new Object [] {"cc", 17}, new String [] {"java.lang.String", "int"}, config, roles6));
-        assertEquals(Arrays.asList("rc"), roles6);
+        assertEquals(Collections.singletonList("rc"), roles6);
 
         List<String> roles7 = new ArrayList<>();
         assertEquals(Specificity.SIGNATURE_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("bar", new Object [] {"aaa", 42}, new String [] {"java.lang.String", "int"}, config, roles7));
-        assertEquals(Arrays.asList("rd"), roles7);
+        assertEquals(Collections.singletonList("rd"), roles7);
 
         List<String> roles8 = new ArrayList<>();
         assertEquals(Specificity.SIGNATURE_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("bar", new Object [] {"aa"}, new String [] {"java.lang.String"}, config, roles8));
-        assertEquals(Arrays.asList("re"), roles8);
+        assertEquals(Collections.singletonList("re"), roles8);
 
         List<String> roles9 = new ArrayList<>();
         assertEquals(Specificity.NAME_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("bar", new Object [] {42}, new String [] {"int"}, config, roles9));
-        assertEquals(Arrays.asList("rf"), roles9);
+        assertEquals(Collections.singletonList("rf"), roles9);
 
         List<String> roles10 = new ArrayList<>();
         assertEquals(Specificity.WILDCARD_MATCH,
                 ACLConfigurationParser.getRolesForInvocation("barr", new Object [] {42}, new String [] {"int"}, config, roles10));
-        assertEquals(Arrays.asList("rg"), roles10);
+        assertEquals(Collections.singletonList("rg"), roles10);
     }
 }

--- a/shell/console/src/main/java/org/apache/karaf/shell/console/commands/NamespaceHandler.java
+++ b/shell/console/src/main/java/org/apache/karaf/shell/console/commands/NamespaceHandler.java
@@ -19,7 +19,7 @@
 package org.apache.karaf.shell.console.commands;
 
 import java.net.URL;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -88,8 +88,8 @@ public class NamespaceHandler implements org.apache.aries.blueprint.NamespaceHan
     }
 
 	public Set<Class> getManagedClasses() {
-		return new HashSet<>(Arrays.asList(
-                BlueprintCommand.class
+		return new HashSet<>(Collections.singletonList(
+            BlueprintCommand.class
         ));
 	}
 

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/commands/SubShellCommand.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/commands/SubShellCommand.java
@@ -19,7 +19,7 @@
 package org.apache.karaf.shell.impl.console.commands;
 
 import java.io.PrintStream;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.karaf.shell.api.console.Session;
@@ -61,7 +61,7 @@ public class SubShellCommand extends TopLevelCommand {
     @Override
     protected void printHelp(Session session, PrintStream out) {
         try {
-            new HelpCommand(session.getFactory()).execute(session, Arrays.asList("shell|" + name));
+            new HelpCommand(session.getFactory()).execute(session, Collections.singletonList("shell|" + name));
         } catch (Exception e) {
             throw new RuntimeException("Unable to print subshell help", e);
         }

--- a/webconsole/instance/src/test/java/org/apache/karaf/webconsole/instance/InstancePluginTest.java
+++ b/webconsole/instance/src/test/java/org/apache/karaf/webconsole/instance/InstancePluginTest.java
@@ -39,8 +39,8 @@ public class InstancePluginTest extends TestCase {
     public void testParseStringList() throws Exception {
         assertEquals(Arrays.asList("a", "b"), testParseStringList(" a ,b"));
         assertEquals(Collections.emptyList(), testParseStringList(null));
-        assertEquals(Arrays.asList("hello"), testParseStringList("hello"));
-        assertEquals(Arrays.asList("b"), testParseStringList(",b,"));
+        assertEquals(Collections.singletonList("hello"), testParseStringList("hello"));
+        assertEquals(Collections.singletonList("b"), testParseStringList(",b,"));
     }
     
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
This switches to Collections.singletonList() where appropriate, along
with a little clean-up (adding missing @Overrides, fixing a couple of
asserts).

Signed-off-by: Stephen Kitt <skitt@redhat.com>