### PR TITLE
[KARAF-6574] Update pax-logging dependency to 1.11.4 and log4j2 to 2.13.0 (karaf-4.2.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
 
         <pax.cdi.version>1.1.2</pax.cdi.version>
         <pax.exam.version>4.13.1</pax.exam.version>
-        <pax.logging.version>1.11.3</pax.logging.version>
+        <pax.logging.version>1.11.4-SNAPSHOT</pax.logging.version>
         <pax.base.version>1.5.1</pax.base.version>
         <pax.swissbox.version>1.8.3</pax.swissbox.version>
         <pax.url.version>2.6.2</pax.url.version>


### PR DESCRIPTION
1.11.4-SNAPSHOT for now to run tests. Will ssquash PR when pax-logging 1.11.4 is released