### PR TITLE
KARAF-5628: Corrupt gc.log due to unseparated VM settings

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf
@@ -221,6 +221,10 @@ run() {
             'stop')
                 MAIN=org.apache.karaf.main.Stop
                 CHECK_ROOT_INSTANCE_RUNNING=false
+                # not needed when stopping
+                JAVA_OPTS=
+                KARAF_SYSTEM_OPTS=
+                KARAF_OPTS=
                 nodebug=true
                 shift
                 ;;

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat
@@ -346,6 +346,10 @@ if "%KARAF_PROFILER%" == "" goto :RUN
 :EXECUTE_STOP
     SET MAIN=org.apache.karaf.main.Stop
     SET CHECK_ROOT_INSTANCE_RUNNING=false
+    rem not needed when stopping
+    SET JAVA_OPTS=
+    SET KARAF_SYSTEM_OPTS=
+    SET KARAF_OPTS=
     shift
     goto :RUN_LOOP
 


### PR DESCRIPTION
Remove useless parameters on stop