### PR TITLE
[KARAF-6593] Replace references in client script to slf4j-api bundle jar with pax-logging-api and remove it from assembly. Set version of slf4j-api to 1.7.29 in parent pom.

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/client
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/client
@@ -82,7 +82,6 @@ setupClassPath() {
     CLASSPATH="${CLASSPATH}:${KARAF_HOME}/system/org/apache/sshd/sshd-core/@@sshd.version@@/sshd-core-@@sshd.version@@.jar"
     CLASSPATH="${CLASSPATH}:${KARAF_HOME}/system/org/fusesource/jansi/jansi/@@jansi.version@@/jansi-@@jansi.version@@.jar"
     CLASSPATH="${CLASSPATH}:${KARAF_HOME}/system/org/jline/jline/@@jline.version@@/jline-@@jline.version@@.jar"
-    CLASSPATH="${CLASSPATH}:${KARAF_HOME}/system/org/slf4j/slf4j-api/@@slf4j.version@@/slf4j-api-@@slf4j.version@@.jar"
 }
 
 init() {

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/client.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/client.bat
@@ -218,7 +218,6 @@ set CLASSPATH=%KARAF_HOME%\system\org\apache\karaf\org.apache.karaf.client\@@pro
 set CLASSPATH=%CLASSPATH%;%KARAF_HOME%\system\org\apache\sshd\sshd-core\@@sshd.version@@\sshd-core-@@sshd.version@@.jar
 set CLASSPATH=%CLASSPATH%;%KARAF_HOME%\system\org\jline\jline\@@jline.version@@\jline-@@jline.version@@.jar
 set CLASSPATH=%CLASSPATH%;%KARAF_HOME%\system\org\fusesource\jansi\jansi\@@jansi.version@@\jansi-@@jansi.version@@.jar
-set CLASSPATH=%CLASSPATH%;%KARAF_HOME%\system\org\slf4j\slf4j-api\@@slf4j.version@@\slf4j-api-@@slf4j.version@@.jar
 
 :EXECUTE
     set arg1=%~1

--- a/assemblies/features/framework/pom.xml
+++ b/assemblies/features/framework/pom.xml
@@ -246,11 +246,6 @@
                                     <artifactId>jline</artifactId>
                                     <outputDirectory>target/classes/resources/system/org/jline/jline/${jline.version}</outputDirectory>
                                 </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.slf4j</groupId>
-                                    <artifactId>slf4j-api</artifactId>
-                                    <outputDirectory>target/classes/resources/system/org/slf4j/slf4j-api/${slf4j.version}</outputDirectory>
-                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -81,7 +81,7 @@
                         <Bundle-Description>Shell client bundle for Apache Karaf.</Bundle-Description>
                         <Private-Package>
                             org.apache.karaf.client;
-                            org.slf4j.impl;
+                            org.slf4j*;
                             org.apache.felix.utils.properties;
                             org.apache.karaf.util.config;
                             META-INF;-split-package:=merge-first

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
 
         <portlet-api.version>2.0</portlet-api.version>
         <plexus-utils.version>3.0.24</plexus-utils.version>
-        <slf4j.version>1.7.12</slf4j.version>
+        <slf4j.version>1.7.29</slf4j.version>
 
         <spring.osgi.version>1.2.1</spring.osgi.version>
         <spring31.version>3.1.4.RELEASE</spring31.version>


### PR DESCRIPTION
@jbonofre : Plz have a look on this.