### PR TITLE
Fix: Support whitespaces within karaf path on windows

### DIFF
--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/standalone/Main.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/standalone/Main.java
@@ -151,7 +151,7 @@ public class Main {
     private List<URL> getJarsInJars(List<URL> urls) throws IOException {
         List<URL> result = new ArrayList<>();
         for (URL url : urls) {
-            try (JarFile jarFile = new JarFile(url.getFile())) {
+            try (JarFile jarFile = new JarFile(url.toURI().getPath())) {
                 Manifest manifest = jarFile.getManifest();
                 String embeddedArtifacts = manifest.getMainAttributes().getValue(JarInJarConstants.REDIRECTED_CLASS_PATH_MANIFEST_NAME);
                 if (embeddedArtifacts != null) {

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/standalone/Main.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/standalone/Main.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.Reader;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -148,7 +149,7 @@ public class Main {
         run(sessionFactory, sb.toString(), in, out, err, cl);
     }
 
-    private List<URL> getJarsInJars(List<URL> urls) throws IOException {
+    private List<URL> getJarsInJars(List<URL> urls) throws IOException, URISyntaxException {
         List<URL> result = new ArrayList<>();
         for (URL url : urls) {
             try (JarFile jarFile = new JarFile(url.toURI().getPath())) {


### PR DESCRIPTION
Hello JB,

I was just updating from 4.0.10 to 4.2.8 on a windows10 with the current openjdk 242.

We are using the standalone mode to install our service during installation process.

`Call bin\shell.bat "wrapper:install -s AUTO_START -n kserver -d kserver -D kserver`

Executing this lead to following error:

    Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
    Exception in thread "main" java.io.FileNotFoundException: C:\Program%20Files\kserver\bin\..\system\com\fasterxml\jackson\core\jackson-annotations\2.10.1\jackson-annotations-2.10.1.jar (Das System kann den angegebenen Pfad nicht finden)
        at java.util.zip.ZipFile.open(Native Method)
        at java.util.zip.ZipFile.<init>(ZipFile.java:225)
        at java.util.zip.ZipFile.<init>(ZipFile.java:155)
        at java.util.jar.JarFile.<init>(JarFile.java:166)
        at java.util.jar.JarFile.<init>(JarFile.java:103)
        at org.apache.karaf.shell.impl.console.standalone.Main.getJarsInJars(Main.java:154)
        at org.apache.karaf.shell.impl.console.standalone.Main.run(Main.java:136)
        at org.apache.karaf.shell.impl.console.standalone.Main.run(Main.java:81)
        at org.apache.karaf.shell.impl.console.standalone.Main.main(Main.java:63)

The reason for this is the getFile() doesn't work (assume because of the whitespace)
https://github.com/apache/karaf/blob/master/shell/core/src/main/java/org/apache/karaf/shell/impl/console/standalone/Main.java#L154

This first test will fail. The second test works for windows10
I don't know if this has other side effects on other systems. But on windows this is what works.

    public class UrlTest {

        @Test // This one fails
        public void testURL() throws IOException, URISyntaxException {
            List<URL> files = this.getFiles(new File("C:\\Program Files\\kserver\\bin\\..\\system"));
            System.out.println(files.size());
            for(URL file : files) {
                try (JarFile jar = new JarFile(new File(file.getFile()))) {
                    System.out.println(jar.size());
                }
            }
        }

        @Test // Works
        public void testURL() throws IOException, URISyntaxException {
            List<URL> files = this.getFiles(new File("C:\\Program Files\\kserver\\bin\\..\\system"));
            System.out.println(files.size());
            for(URL file : files) {
                try (JarFile jar = new JarFile(new File(file.toURI().getPath()))) {
                    System.out.println(jar.size());
                }
            }
        }

        private static List<URL> getFiles(File base) throws MalformedURLException {
            List<URL> urls = new ArrayList<>();
            getFiles(base, urls);
            return urls;
        }

        private static void getFiles(File base, List<URL> urls) throws MalformedURLException {
            for (File f : base.listFiles()) {
                if (f.isDirectory()) {
                    getFiles(f, urls);
                } else if (f.getName().endsWith(".jar")) {
                    urls.add(f.toURI().toURL());
                }
            }
        }
    }


