### PR TITLE
Karaf 4.2.x whitelist

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/model/processing/FeaturesProcessing.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/model/processing/FeaturesProcessing.java
@@ -56,6 +56,7 @@ import static org.apache.karaf.features.internal.service.Overrides.OVERRIDE_RANG
 @XmlRootElement(name = "featuresProcessing", namespace = FeaturesProcessing.FEATURES_PROCESSING_NS)
 @XmlType(name = "featuresProcessing", propOrder = {
         "blacklistedRepositories",
+        "whitelistedRepositories",
         "blacklistedFeatures",
         "blacklistedBundles",
         "overrideBundleDependency",
@@ -73,6 +74,12 @@ public class FeaturesProcessing {
     private List<String> blacklistedRepositories = new LinkedList<>();
     @XmlTransient
     private List<LocationPattern> blacklistedRepositoryLocationPatterns = new LinkedList<>();
+    
+    @XmlElementWrapper(name = "whitelistedRepositories")
+    @XmlElement(name = "repository")
+    private List<String> whitelistedRepositories = new LinkedList<>();
+    @XmlTransient
+    private List<LocationPattern> whitelistedRepositoryLocationPatterns = new LinkedList<>();
 
     @XmlElementWrapper(name = "blacklistedFeatures")
     @XmlElement(name = "feature")
@@ -104,10 +111,18 @@ public class FeaturesProcessing {
         return blacklistedRepositories;
     }
 
+    public List<String> getWhitelistedRepositories() {
+        return whitelistedRepositories;
+    }
+    
     public List<LocationPattern> getBlacklistedRepositoryLocationPatterns() {
         return blacklistedRepositoryLocationPatterns;
     }
 
+    public List<LocationPattern> getWhitelistedRepositoryLocationPatterns() {
+        return whitelistedRepositoryLocationPatterns;
+    }
+    
     public List<BlacklistedFeature> getBlacklistedFeatures() {
         return blacklistedFeatures;
     }
@@ -210,6 +225,15 @@ public class FeaturesProcessing {
                 iterator.remove();
             }
         }
+        
+        for (String repositoryURI : getWhitelistedRepositories()) {
+            try {
+                whitelistedRepositoryLocationPatterns.add(new LocationPattern(repositoryURI));
+            } catch (IllegalArgumentException e) {
+                LOG.warn("Can't parse whitelisted repository location pattern: " + repositoryURI + ". Ignoring.");
+            }
+        }
+        
     }
 
     /**

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/Blacklist.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/Blacklist.java
@@ -51,11 +51,13 @@ public class Blacklist {
     public static final String TYPE_FEATURE = "feature";
     public static final String TYPE_BUNDLE = "bundle";
     public static final String TYPE_REPOSITORY = "repository";
+    public static final String TYPE_NOT_REPOSITORY = "notRepository";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Blacklist.class);
     private Clause[] clauses;
 
     private List<LocationPattern> repositoryBlacklist = new LinkedList<>();
+    private List<LocationPattern> repositoryWhitelist = new LinkedList<>();
     private List<FeaturePattern> featureBlacklist = new LinkedList<>();
     private List<LocationPattern> bundleBlacklist = new LinkedList<>();
 
@@ -121,6 +123,22 @@ public class Blacklist {
                         }
                     }
                     break;
+                case TYPE_NOT_REPOSITORY:
+                    location = c.getName();
+                    if (c.getAttribute(BLACKLIST_URL) != null) {
+                        location = c.getAttribute(BLACKLIST_URL);
+                    }
+                    if (location == null) {
+                        // should not happen?
+                        LOG.warn("Repository blacklist URI is empty. Ignoring.");
+                    } else {
+                        try {
+                            repositoryWhitelist.add(new LocationPattern(location));
+                        } catch (IllegalArgumentException e) {
+                            LOG.warn("Problem parsing repository whitelist URI \"" + location + "\": " + e.getMessage() + ". Ignoring.");
+                        }
+                    }
+                    break;
                 case TYPE_FEATURE:
                     try {
                         featureBlacklist.add(new FeaturePattern(c.toString()));
@@ -154,6 +172,11 @@ public class Blacklist {
      * @return
      */
     public boolean isRepositoryBlacklisted(String uri) {
+        for (LocationPattern pattern : repositoryWhitelist) {
+            if (pattern.matches(uri)) {
+                return false;
+            }
+        }
         for (LocationPattern pattern : repositoryBlacklist) {
             if (pattern.matches(uri)) {
                 return true;
@@ -207,6 +230,7 @@ public class Blacklist {
         }
         if (others != null) {
             this.repositoryBlacklist.addAll(others.repositoryBlacklist);
+            this.repositoryWhitelist.addAll(others.repositoryWhitelist);
             this.featureBlacklist.addAll(others.featureBlacklist);
             this.bundleBlacklist.addAll(others.bundleBlacklist);
         }
@@ -228,6 +252,14 @@ public class Blacklist {
     }
 
     /**
+     * Directly add {@link LocationPattern} as whitelisted features XML repository URI
+     * @param locationPattern
+     */
+    public void whitelistRepository(LocationPattern locationPattern) {
+        repositoryWhitelist.add(locationPattern);
+    }
+    
+    /**
      * Directly add {@link FeaturePattern} as blacklisted feature ID
      * @param featurePattern
      */
@@ -247,6 +279,10 @@ public class Blacklist {
         return repositoryBlacklist;
     }
 
+    public List<LocationPattern> getRepositoryWhitelist() {
+        return repositoryWhitelist;
+    }
+    
     public List<FeaturePattern> getFeatureBlacklist() {
         return featureBlacklist;
     }

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/FeaturesProcessorImpl.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/FeaturesProcessorImpl.java
@@ -242,11 +242,19 @@ public class FeaturesProcessorImpl implements FeaturesProcessor {
 
     @Override
     public boolean isRepositoryBlacklisted(String uri) {
+    	
+        for (LocationPattern lp : processing.getWhitelistedRepositoryLocationPatterns()) {
+            if (lp.matches(uri)) {
+                return false;
+            }
+        }
+
         for (LocationPattern lp : processing.getBlacklistedRepositoryLocationPatterns()) {
             if (lp.matches(uri)) {
                 return true;
             }
         }
+        
 
         return false;
     }
@@ -275,6 +283,7 @@ public class FeaturesProcessorImpl implements FeaturesProcessor {
         count += getInstructions().getBlacklistedRepositories().size();
         count += getInstructions().getBlacklistedFeatures().size();
         count += getInstructions().getBlacklistedBundles().size();
+        count += getInstructions().getWhitelistedRepositories().size();
         count += getInstructions().getOverrideBundleDependency().getRepositories().size();
         count += getInstructions().getOverrideBundleDependency().getFeatures().size();
         count += getInstructions().getOverrideBundleDependency().getBundles().size();

--- a/profile/src/main/java/org/apache/karaf/profile/Profile.java
+++ b/profile/src/main/java/org/apache/karaf/profile/Profile.java
@@ -112,6 +112,11 @@ public interface Profile extends ProfileConstants {
     List<LocationPattern> getBlacklistedRepositories();
 
     /**
+     * Returns a list of whitelisted features XML repositories (URIs) (as {@link LocationPattern location patterns}.
+     */
+    List<LocationPattern> getWhitelistedRepositories();
+    
+    /**
      * Returns a list of libraries (to be added to <code>${karaf.home}/lib</code>) defined in this profile.
      */
     List<String> getLibraries();

--- a/profile/src/main/java/org/apache/karaf/profile/ProfileBuilder.java
+++ b/profile/src/main/java/org/apache/karaf/profile/ProfileBuilder.java
@@ -101,6 +101,10 @@ public interface ProfileBuilder {
 
     ProfileBuilder addBlacklistedRepository(String value);
 
+    ProfileBuilder setWhitelistedRepositories(List<String> values);
+    
+    ProfileBuilder addWhitelistedRepository(String value);
+    
     ProfileBuilder setOverrides(List<String> values);
     
     ProfileBuilder setOptionals(List<String> values);

--- a/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
+++ b/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
@@ -291,6 +291,7 @@ public class Builder {
     List<String> blacklistedFeatureIdentifiers = new ArrayList<>();
     List<String> blacklistedBundleURIs = new ArrayList<>();
     List<String> blacklistedRepositoryURIs = new ArrayList<>();
+    List<String> whitelistedRepositoryURIs = new ArrayList<>();
     BlacklistPolicy blacklistPolicy = BlacklistPolicy.Discard;
     List<String> libraries = new ArrayList<>();
     JavaVersion javase = JavaVersion.Java18;
@@ -766,6 +767,16 @@ public class Builder {
     }
 
     /**
+     * Configure a list of whitelisted features XML repository URIs (see {@link LocationPattern})
+     * @param repositories
+     * @return
+     */
+    public Builder whitelistRepositories(Collection<String> repositories) {
+        this.whitelistedRepositoryURIs.addAll(repositories);
+        return this;
+    }
+    
+    /**
      * TODOCUMENT
      * @param policy
      * @return
@@ -849,6 +860,10 @@ public class Builder {
         return blacklistedRepositoryURIs;
     }
 
+    public List<String> getWhitelistedRepositoryURIs() {
+        return whitelistedRepositoryURIs;
+    }
+    
     public BlacklistPolicy getBlacklistPolicy() {
         return blacklistPolicy;
     }
@@ -1016,6 +1031,7 @@ public class Builder {
         system.forEach((k ,v) -> builder.addConfiguration(Profile.INTERNAL_PID, Profile.SYSTEM_PREFIX + k, v));
         // profile with all the parents configured and stage-agnostic blacklisting configuration added
         blacklistedRepositoryURIs.forEach(builder::addBlacklistedRepository);
+        whitelistedRepositoryURIs.forEach(builder::addWhitelistedRepository);
         blacklistedFeatureIdentifiers.forEach(builder::addBlacklistedFeature);
         blacklistedBundleURIs.forEach(builder::addBlacklistedBundle);
         // final profilep
@@ -1375,6 +1391,7 @@ public class Builder {
     private boolean hasOwnInstructions() {
         int count = 0;
         count += blacklistedRepositoryURIs.size();
+        count += whitelistedRepositoryURIs.size();
         count += blacklistedFeatureIdentifiers.size();
         count += blacklistedBundleURIs.size();
 
@@ -1420,9 +1437,21 @@ public class Builder {
                 LOGGER.warn("Blacklisted features XML repository URI is invalid: {}, ignoring", br);
             }
         }
+        for (String br : whitelistedRepositoryURIs) {
+            // from Maven/Builder configuration
+            try {
+                blacklist.whitelistRepository(new LocationPattern(br));
+            } catch (IllegalArgumentException e) {
+                LOGGER.warn("Blacklisted features XML repository URI is invalid: {}, ignoring", br);
+            }
+        }
         for (LocationPattern br : initialProfile.getBlacklistedRepositories()) {
             // from profile configuration
             blacklist.blacklistRepository(br);
+        }
+        for (LocationPattern br : initialProfile.getWhitelistedRepositories()) {
+            // from profile configuration
+            blacklist.whitelistRepository(br);
         }
         for (String bf : blacklistedFeatureIdentifiers) {
             // from Maven/Builder configuration

--- a/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
+++ b/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
@@ -772,7 +772,8 @@ public class Builder {
      * @return
      */
     public Builder whitelistRepositories(Collection<String> repositories) {
-        this.whitelistedRepositoryURIs.addAll(repositories);
+        if (repositories != null)
+            this.whitelistedRepositoryURIs.addAll(repositories);
         return this;
     }
     

--- a/profile/src/main/java/org/apache/karaf/profile/impl/ProfileBuilderImpl.java
+++ b/profile/src/main/java/org/apache/karaf/profile/impl/ProfileBuilderImpl.java
@@ -268,6 +268,18 @@ public final class ProfileBuilderImpl implements ProfileBuilder {
     }
 
     @Override
+    public ProfileBuilder setWhitelistedRepositories(List<String> values) {
+        addProfileConfiguration(ConfigListType.WHITELISTED_REPOSITORIES, values);
+        return null;
+    }
+
+    @Override
+    public ProfileBuilder addWhitelistedRepository(String value) {
+        addProfileConfiguration(ConfigListType.WHITELISTED_REPOSITORIES, value);
+        return null;
+    }
+    
+    @Override
     public ProfileBuilder setOverrides(List<String> values) {
         addProfileConfiguration(ConfigListType.OVERRIDES, values);
         return this;

--- a/profile/src/main/java/org/apache/karaf/profile/impl/ProfileImpl.java
+++ b/profile/src/main/java/org/apache/karaf/profile/impl/ProfileImpl.java
@@ -156,6 +156,13 @@ final class ProfileImpl implements Profile {
     }
 
     @Override
+    public List<LocationPattern> getWhitelistedRepositories() {
+        return getContainerConfigList(ConfigListType.WHITELISTED_REPOSITORIES).stream()
+                .map(LocationPattern::new)
+                .collect(Collectors.toList());
+    }
+    
+    @Override
     public List<String> getLibraries() {
         return getContainerConfigList(ConfigListType.LIBRARIES);
     }
@@ -287,7 +294,8 @@ final class ProfileImpl implements Profile {
         OPTIONALS("optional"),
         OVERRIDES("override"),
         REPOSITORIES("repository"),
-        BLACKLISTED_REPOSITORIES("blacklisted.repository");
+        BLACKLISTED_REPOSITORIES("blacklisted.repository"),
+        WHITELISTED_REPOSITORIES("whitelisted.repository");
 
         private String value;
 

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
@@ -188,6 +188,12 @@ public class AssemblyMojo extends MojoSupport {
      */
     @Parameter
     private List<String> blacklistedRepositories;
+    /**
+     * List of whitelisted repository URIs. Whitelisted URI may use globs and version ranges. See
+     * {@link org.apache.karaf.features.LocationPattern}.
+     */
+    @Parameter
+    private List<String> whitelistedRepositories;
 
     /**
      * List of features from compile-scope features XML files and KARs to be installed into system repo
@@ -519,6 +525,7 @@ public class AssemblyMojo extends MojoSupport {
         builder.blacklistFeatures(blacklistedFeatures);
         builder.blacklistProfiles(blacklistedProfiles);
         builder.blacklistRepositories(blacklistedRepositories);
+        builder.whitelistRepositories(whitelistedRepositories);
         builder.blacklistPolicy(blacklistPolicy);
 
         // Creating system directory


### PR DESCRIPTION
Adding a whitelist for repositories. Useful if new repositories overlay actual used versions without warning.