### PR TITLE
[KARAF-6609] Upgrade to Pax Web 7.2.15 and Jetty 9.4.28.v20200408

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
         <httpclient.version>4.5.6</httpclient.version>
         <jansi.version>1.18</jansi.version>
         <javassist.version>3.9.0.GA</javassist.version>
-        <jetty.version>9.4.22.v20191022</jetty.version>
+        <jetty.version>9.4.28.v20200408</jetty.version>
         <jline.version>3.14.1</jline.version>
         <junit.version>4.13</junit.version>
         <jsw.version>3.2.3</jsw.version>
@@ -284,7 +284,7 @@
         <pax.base.version>1.5.1</pax.base.version>
         <pax.swissbox.version>1.8.3</pax.swissbox.version>
         <pax.url.version>2.6.2</pax.url.version>
-        <pax.web.version>7.2.14</pax.web.version>
+        <pax.web.version>7.2.15</pax.web.version>
         <pax.tinybundle.version>3.0.0</pax.tinybundle.version>
         <pax.jdbc.version>1.4.4</pax.jdbc.version>
         <pax.jms.version>1.0.6</pax.jms.version>


### PR DESCRIPTION
Preparing for Pax Web 7.2.15 update (as soon as it will be on Maven Central).