### PR TITLE
[Examples] remove "cxf" context path from REST-endpoint URLs

### DIFF
--- a/examples/karaf-rest-example/README.md
+++ b/examples/karaf-rest-example/README.md
@@ -36,6 +36,7 @@ The "client" bundle uses the `BookingService` with a REST client stub.
 * **karaf-rest-example-client** is a regular Blueprint bundle using the `BookingService`.
 * **karaf-rest-example-client-http** is a regular Blueprint REST client bundle using Java Http.
 * **karaf-rest-example-client-cxf** is a regular Blueprint REST client bundle using Apache CXF.
+* **karaf-rest-example-client-jersey** is a regular Blueprint REST client bundle using Jakarta Jersey.
 * **karaf-rest-example-whiteboard** is another way to deploy REST services using whiteboard pattern.
 * **karaf-rest-example-features** provides a Karaf features repository used for the deployment.
 
@@ -80,6 +81,14 @@ karaf@root()> feature:install karaf-rest-example-client-cxf
 ```
 
 The `karaf-rest-example-client-cxf` feature provides `booking:*` commands you can use to call the REST service.
+
+And the service client feature using Jakarta Jersey:
+
+```
+karaf@root()> feature:install karaf-rest-example-client-jersey
+```
+
+The `karaf-rest-example-client-jersey` feature provides `booking:*` commands you can use to call the REST service.
 
 ## Usage
 

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/src/main/java/org/apache/karaf/examples/rest/client/cxf/AddBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/src/main/java/org/apache/karaf/examples/rest/client/cxf/AddBookingCommand.java
@@ -43,7 +43,7 @@ public class AddBookingCommand implements Action {
     String flight;
 
     @Option(name = "--url", description = "Location of the REST service", required = false, multiValued = false)
-    String restLocation = "http://localhost:8181/cxf/booking/";
+    String restLocation = "http://localhost:8181/booking/";
 
     @Override
     public Object execute() throws Exception {

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/src/main/java/org/apache/karaf/examples/rest/client/cxf/ListBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/src/main/java/org/apache/karaf/examples/rest/client/cxf/ListBookingCommand.java
@@ -33,7 +33,7 @@ import java.util.List;
 public class ListBookingCommand implements Action {
 
     @Option(name = "--url", description = "Location of the REST service", required = false, multiValued = false)
-    String restLocation = "http://localhost:8181/cxf/booking/";
+    String restLocation = "http://localhost:8181/booking/";
 
     @Override
     public Object execute() throws Exception {

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-http/src/main/java/org/apache/karaf/examples/rest/client/http/AddBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-http/src/main/java/org/apache/karaf/examples/rest/client/http/AddBookingCommand.java
@@ -42,7 +42,7 @@ public class AddBookingCommand implements Action {
     String flight;
 
     @Option(name = "--url", description = "Location of the REST service", required = false, multiValued = false)
-    String restLocation = "http://localhost:8181/cxf/booking/";
+    String restLocation = "http://localhost:8181/booking/";
 
     @Override
     public Object execute() throws Exception {

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-http/src/main/java/org/apache/karaf/examples/rest/client/http/ListBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-http/src/main/java/org/apache/karaf/examples/rest/client/http/ListBookingCommand.java
@@ -31,7 +31,7 @@ import java.net.URL;
 public class ListBookingCommand implements Action {
 
     @Option(name = "--url", description = "Location of the REST service", required = false, multiValued = false)
-    String restLocation = "http://localhost:8181/cxf/booking/";
+    String restLocation = "http://localhost:8181/booking/";
 
     @Override
     public Object execute() throws Exception {

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<!-- Licensed to the Apache Software Foundation (ASF) under one or more 
+		contributor license agreements. See the NOTICE file distributed with this 
+		work for additional information regarding copyright ownership. The ASF licenses 
+		this file to You under the Apache License, Version 2.0 (the "License"); you 
+		may not use this file except in compliance with the License. You may obtain 
+		a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless 
+		required by applicable law or agreed to in writing, software distributed 
+		under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
+		OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
+		the specific language governing permissions and limitations under the License. -->
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.karaf.examples</groupId>
+		<artifactId>karaf-rest-example-client</artifactId>
+		<version>4.3.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>karaf-rest-example-client-jersey</artifactId>
+	<name>Apache Karaf :: Examples :: REST :: Client :: Jakarta Jersey</name>
+	<packaging>bundle</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>javax.ws.rs</groupId>
+			<artifactId>javax.ws.rs-api</artifactId>
+			<version>2.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.karaf.examples</groupId>
+			<artifactId>karaf-rest-example-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.core</groupId>
+			<artifactId>jersey-client</artifactId>
+			<version>2.30</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.jaxrs</groupId>
+			<artifactId>jackson-jaxrs-json-provider</artifactId>
+			<version>2.9.6</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.karaf.shell</groupId>
+			<artifactId>org.apache.karaf.shell.core</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.karaf.tooling</groupId>
+				<artifactId>karaf-services-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<configuration>
+					<instructions>
+						<Import-Package>
+							org.apache.karaf.shell*;version="[4,5)",
+							*
+						</Import-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/AddBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/AddBookingCommand.java
@@ -1,0 +1,64 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.examples.rest.client.jersey;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+
+import org.apache.karaf.examples.rest.api.Booking;
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+
+@Service
+@Command(scope = "booking", name = "add", description = "Add booking")
+public class AddBookingCommand implements Action {
+
+    @Argument(index = 0, name = "id", description = "Booking ID", required = true, multiValued = false)
+    long id;
+
+    @Argument(index = 1, name = "customer", description = "Customer name", required = true, multiValued = false)
+    String customer;
+
+    @Argument(index = 2, name = "flight", description = "Flight number", required = true, multiValued = false)
+    String flight;
+
+    @Option(name = "--url", description = "Location of the REST service", required = false, multiValued = false)
+    String restLocation = "http://localhost:8181/cxf/booking/";
+
+    @Override
+    public Object execute() throws Exception {
+        Booking booking = new Booking();
+        booking.setId(id);
+        booking.setFlight(flight);
+        booking.setCustomer(customer);
+
+        Client client = ClientBuilder.newClient();
+        client.register(new JacksonJsonProvider());
+        WebTarget target = client.target(restLocation);
+        target.request().post(Entity.json(booking));
+
+        return null;
+    }
+
+}

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/AddBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/AddBookingCommand.java
@@ -44,7 +44,7 @@ public class AddBookingCommand implements Action {
     String flight;
 
     @Option(name = "--url", description = "Location of the REST service", required = false, multiValued = false)
-    String restLocation = "http://localhost:8181/cxf/booking/";
+    String restLocation = "http://localhost:8181/booking/";
 
     @Override
     public Object execute() throws Exception {

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/ListBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/ListBookingCommand.java
@@ -1,0 +1,55 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.examples.rest.client.jersey;
+
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import org.apache.karaf.examples.rest.api.Booking;
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+
+import java.util.List;
+
+@Service
+@Command(scope = "booking", name = "list", description = "List booking")
+public class ListBookingCommand implements Action {
+
+    @Option(name = "--url", description = "Location of the REST service", required = false, multiValued = false)
+    String restLocation = "http://localhost:8181/cxf/booking/";
+
+    @Override
+    public Object execute() throws Exception {
+    	Client client = ClientBuilder.newClient();
+        client.register(new JacksonJsonProvider());
+        WebTarget target = client.target(restLocation);
+        
+        List<Booking> bookings = (List<Booking>) target.request(MediaType.APPLICATION_JSON).get(new GenericType<List<Booking>>() {});
+        for (Booking booking : bookings) {
+            System.out.println(booking.getId() + " " + booking.getCustomer() + " " + booking.getFlight());
+        }
+
+        return null;
+    }
+
+}

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/ListBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/ListBookingCommand.java
@@ -36,7 +36,7 @@ import java.util.List;
 public class ListBookingCommand implements Action {
 
     @Option(name = "--url", description = "Location of the REST service", required = false, multiValued = false)
-    String restLocation = "http://localhost:8181/cxf/booking/";
+    String restLocation = "http://localhost:8181/booking/";
 
     @Override
     public Object execute() throws Exception {

--- a/examples/karaf-rest-example/karaf-rest-example-client/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-client/pom.xml
@@ -35,6 +35,7 @@
     <modules>
         <module>karaf-rest-example-client-cxf</module>
         <module>karaf-rest-example-client-http</module>
+        <module>karaf-rest-example-client-jersey</module>
     </modules>
 
 </project>

--- a/examples/karaf-rest-example/karaf-rest-example-features/src/main/feature/feature.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-features/src/main/feature/feature.xml
@@ -20,6 +20,7 @@
 
     <repository>mvn:org.apache.cxf.karaf/apache-cxf/${cxf.version}/xml/features</repository>
     <repository>mvn:org.apache.aries.jax.rs/org.apache.aries.jax.rs.features/1.0.6/xml</repository>
+    <repository>mvn:no.priv.bang.karaf/jersey-karaf-feature/1.7.0/xml/features</repository>
     
     <feature name="karaf-rest-example-common" version="${project.version}">
         <bundle>mvn:org.apache.karaf.examples/karaf-rest-example-api/${project.version}</bundle>
@@ -45,6 +46,11 @@
     
     <feature name="karaf-rest-example-client-cxf" version="${project.version}">
         <bundle>mvn:org.apache.karaf.examples/karaf-rest-example-client-cxf/${project.version}</bundle>
+    </feature>
+    
+    <feature name="karaf-rest-example-client-jersey" version="${project.version}">
+    	<feature>jersey-karaf-feature</feature>
+        <bundle>mvn:org.apache.karaf.examples/karaf-rest-example-client-jersey/${project.version}</bundle>
     </feature>
 
     <feature name="karaf-rest-example-whiteboard" version="${project.version}">

--- a/examples/karaf-soap-example/README.md
+++ b/examples/karaf-soap-example/README.md
@@ -73,7 +73,7 @@ karaf@root()> feature:install karaf-soap-example-client
 You can take a look on the WSDL generated for our SOAP WS:
 
 ```
-http://localhost:8181/cxf/example?wsdl
+http://localhost:8181/example?wsdl
 ```
 
 The client feature installs `booking:*` commands. You can add a new booking using the `booking:add` command:

--- a/examples/karaf-soap-example/karaf-soap-example-client/src/main/java/org/apache/karaf/examples/soap/client/AddCommand.java
+++ b/examples/karaf-soap-example/karaf-soap-example-client/src/main/java/org/apache/karaf/examples/soap/client/AddCommand.java
@@ -37,7 +37,7 @@ public class AddCommand implements Action {
     String flight;
 
     @Option(name = "--url", description = "Location of the SOAP service", required = false, multiValued = false)
-    String url = "http://localhost:8181/cxf/example";
+    String url = "http://localhost:8181/example";
 
     @Override
     public Object execute() throws Exception {

--- a/examples/karaf-soap-example/karaf-soap-example-client/src/main/java/org/apache/karaf/examples/soap/client/ListCommand.java
+++ b/examples/karaf-soap-example/karaf-soap-example-client/src/main/java/org/apache/karaf/examples/soap/client/ListCommand.java
@@ -28,7 +28,7 @@ import org.apache.karaf.shell.support.table.ShellTable;
 public class ListCommand implements Action {
 
     @Option(name = "--url", description = "Location of the SOAP service", required = false, multiValued = false)
-    String url = "http://localhost:8181/cxf/example";
+    String url = "http://localhost:8181/example";
 
     @Override
     public Object execute() throws Exception {


### PR DESCRIPTION
[Examples] remove "cxf" context path from REST-endpoint URLs

...as publishing done to / for now on.