### PR TITLE
Feature/optimize docker script and update docs

### DIFF
--- a/assemblies/docker/README.md
+++ b/assemblies/docker/README.md
@@ -35,9 +35,10 @@ On macOS, an easy way to install `buildx` is to install [Docker Desktop Edge](ht
 Images are based on the Docker official [AdoptOpenJDK 11 JRE Hotspot](https://hub.docker.com/_/adoptopenjdk?tab=tags&page=1&name=11-jre-hotspot) image. If you want to
 build the Karaf image you have the following choices:
 
-1. Create the docker image from the SNAPSHOT version (from local distribution)
+1. Create the docker image from a local distribution package
 2. Create the docker image from an Apache Karaf archive, for example (apache-karaf-4.2.9.tar.gz)
 3. Create the docker image from a specific version of Apache Karaf
+4. Create the docker image from remote or local custom Apache Karaf distribution
 
 If you run `build.sh` without arguments then you could see how to usage this command.
 
@@ -52,11 +53,11 @@ Usage:
   The supported platforms (OS/Arch) depend on the build's base image, in this case [adoptopenjdk:11-jre-hotspot](https://hub.docker.com/_/adoptopenjdk?tab=tags&page=1&name=11-jre-hotspot).
 ```
 
-To create the docker image from the SNAPSHOT version (from local distribution) 
-you can execute the command below. Remember that before you can successfully run 
-this command, you must build the project 
-(for example with the command `mvn clean install -DskipTests`). For more info
-you can read: [Building Apache Karaf](https://github.com/apache/karaf/blob/master/BUILDING.md#building-apache-karaf)
+To create the docker image from local distribution) you can execute the command 
+below. Remember that before you can successfully run this command, you must build 
+the project (for example with the command `mvn clean install -DskipTests`). 
+For more info you can read: 
+[Building Apache Karaf](https://github.com/apache/karaf/blob/master/BUILDING.md#building-apache-karaf)
 
 ```bash
 ./build.sh --from-local-dist
@@ -74,7 +75,7 @@ You can also specify the image name with the `--image-name` flag, for example
 (replacing the version, image name, and targets as appropriate):
 
 ```bash
-./build.sh --from-local-dist --archive ~/Downloads/apache-karaf-4.2.9.tar.gz --image-name amusarra/karaf:4.2.9-dev
+./build.sh --from-local-dist --archive ~/Downloads/apache-karaf-4.2.9.tar.gz --image-name myrepo/mykaraf:x.x.x
 ```
 
 If you want to build the docker image for a specific version of Karaf
@@ -82,7 +83,7 @@ you can run `build.sh` command in this way (replacing the version, image name,
 and targets as appropriate):
 
 ```bash
-./build.sh --from-release --karaf-version 4.2.9 --image-name amusarra/karaf:4.2.9
+./build.sh --from-release --karaf-version 4.2.9 --image-name myrepo/mykaraf:x.x.x
 ```
 
 If you want to build the container for a specific version of Karaf and
@@ -90,7 +91,7 @@ specific version of the platform, and push the image to the Docker Hub repositor
 you can use this command (replacing the version, image name, and targets as appropriate):
 
 ```bash
-./build.sh --from-release --karaf-version 4.2.9 --image-name amusarra/karaf:4.2.9 \
+./build.sh --from-release --karaf-version 4.2.9 --image-name myrepo/mykaraf:x.x.x \
  --build-multi-platform linux/arm64,linux/arm/v7,linux/amd64
 ```
 

--- a/assemblies/docker/README.md
+++ b/assemblies/docker/README.md
@@ -33,30 +33,63 @@ On macOS, an easy way to install `buildx` is to install [Docker Desktop Edge](ht
 ## Build
 
 Images are based on the Docker official [AdoptOpenJDK 11 JRE Hotspot](https://hub.docker.com/_/adoptopenjdk?tab=tags&page=1&name=11-jre-hotspot) image. If you want to
-build the Karaf image run:
+build the Karaf image you have the following choices:
 
-```
-sh build.sh
+1. Create the docker image from the SNAPSHOT version (from local distribution)
+2. Create the docker image from an Apache Karaf archive, for example (apache-karaf-4.2.9.tar.gz)
+3. Create the docker image from a specific version of Apache Karaf
+
+If you run `build.sh` without arguments then you could see how to usage this command.
+
+```bash
+Usage:
+  build.sh --from-local-dist [--archive <archive>] [--image-name <image>] [--build-multi-platform <comma-separated platforms>]
+  build.sh --from-release --karaf-version <x.x.x> [--image-name <image>] [--build-multi-platform <comma-separated platforms>]
+  build.sh --help
+
+  If the --image-name flag is not used the built image name will be 'karaf'.
+  Check the supported build platforms; you can verify with this command: docker buildx ls
+  The supported platforms (OS/Arch) depend on the build's base image, in this case [adoptopenjdk:11-jre-hotspot](https://hub.docker.com/_/adoptopenjdk?tab=tags&page=1&name=11-jre-hotspot).
 ```
 
-or
+To create the docker image from the SNAPSHOT version (from local distribution) 
+you can execute the command below. Remember that before you can successfully run 
+this command, you must build the project 
+(for example with the command `mvn clean install -DskipTests`). For more info
+you can read: [Building Apache Karaf](https://github.com/apache/karaf/blob/master/BUILDING.md#building-apache-karaf)
 
-```
-docker build -t karaf .
+```bash
+./build.sh --from-local-dist
 ```
 
-If you want to build the container for a specific version of Karaf
-you can configure it with the `KARAF_VERSION` arg:
+For create the docker image from the local dist version but with the archive,
+you can execute the below command. Remember that before you can successfully run 
+this command.
 
+```bash
+./build.sh --from-local-dist --archive ~/home/amusarra/apache-karaf-4.2.9.tar.gz
 ```
-docker build --build-arg KARAF_VERSION=4.2.0 -t "karaf:4.2.0" karaf
+
+You can also specify the image name with the `--image-name` flag, for example
+(replacing the version, image name, and targets as appropriate):
+
+```bash
+./build.sh --from-local-dist --archive ~/Downloads/apache-karaf-4.2.9.tar.gz --image-name amusarra/karaf:4.2.9-dev
+```
+
+If you want to build the docker image for a specific version of Karaf
+you can run `build.sh` command in this way (replacing the version, image name, 
+and targets as appropriate):
+
+```bash
+./build.sh --from-release --karaf-version 4.2.9 --image-name amusarra/karaf:4.2.9
 ```
 
 If you want to build the container for a specific version of Karaf and
 specific version of the platform, and push the image to the Docker Hub repository,
 you can use this command (replacing the version, image name, and targets as appropriate):
 
-```
+```bash
 ./build.sh --from-release --karaf-version 4.2.9 --image-name amusarra/karaf:4.2.9 \
  --build-multi-platform linux/arm64,linux/arm/v7,linux/amd64
 ```

--- a/assemblies/docker/build.sh
+++ b/assemblies/docker/build.sh
@@ -26,8 +26,8 @@ Usage:
   build.sh --help
 
   If the --image-name flag is not used the built image name will be 'karaf'.
-  Check the supported build platforms; you can verify with this command: `docker buildx ls`
-  The supported platforms (OS/Arch) depend on the build's base image, in this case [`openjdk:8u212-jre-alpine`](https://hub.docker.com/_/openjdk?tab=tags&page=1&name=8u212-jre-alpine).
+  Check the supported build platforms; you can verify with this command: docker buildx ls
+  The supported platforms (OS/Arch) depend on the build's base image, in this case [adoptopenjdk:11-jre-hotspot](https://hub.docker.com/_/adoptopenjdk?tab=tags&page=1&name=11-jre-hotspot).
   
 HERE
   exit 1
@@ -86,12 +86,12 @@ if [ -n "${FROM_RELEASE}" ]; then
 
   [ -n "${KARAF_VERSION}" ] || usage
 
-  KARAF_BASE_URL="$(curl -s https://www.apache.org/dyn/closer.cgi\?preferred\=true)karaf/${KARAF_VERSION}/"
+  KARAF_BASE_URL="$(curl -s https://www.apache.org/dyn/closer.cgi\?preferred=true)karaf/${KARAF_VERSION}/"
   KARAF_DIST_FILE_NAME="apache-karaf-${KARAF_VERSION}.tar.gz"
   CURL_OUTPUT="${TMPDIR}/${KARAF_DIST_FILE_NAME}"
 
   echo "Downloading ${KARAF_DIST_FILE_NAME} from ${KARAF_BASE_URL}"
-  curl -s ${KARAF_BASE_URL}${KARAF_DIST_FILE_NAME} --output ${CURL_OUTPUT}
+  curl -s "${KARAF_BASE_URL}${KARAF_DIST_FILE_NAME}" --output "${CURL_OUTPUT}"
 
   KARAF_DIST="${CURL_OUTPUT}"
 
@@ -100,7 +100,7 @@ elif [ -n "${FROM_LOCAL}" ]; then
   if [ -n "${ARCHIVE}" ]; then
      DIST_DIR=${ARCHIVE}
   else 
-     DIST_DIR=../apache-karaf/target/apache-karaf-*.tar.gz
+     DIST_DIR="../apache-karaf/target/apache-karaf-*.tar.gz"
   fi
   KARAF_DIST=${TMPDIR}/apache-karaf.tar.gz
   echo "Using karaf dist: ${DIST_DIR}"
@@ -114,7 +114,7 @@ fi
 
 if [ -n "${BUILD_MULTI_PLATFORM}" ]; then
   echo "Checking if buildx installed..."
-  VERSION_BUILD_X=`docker buildx version` > /dev/null 2>&1
+  VERSION_BUILD_X=$(docker buildx version) > /dev/null 2>&1
 
   if [ $? -eq 0 ]; then
     echo "Found buildx {${VERSION_BUILD_X}} on your docker system"
@@ -125,7 +125,7 @@ if [ -n "${BUILD_MULTI_PLATFORM}" ]; then
     BUILD_X_PLATFORM="--platform ${BUILD_MULTI_PLATFORM}"
   else
     echo "Error: buildx not installed with your docker system"
-    exit -1
+    exit 2
   fi
 
 fi


### PR DESCRIPTION
This pull request contains a minor fix on the build.sh script and the update of the README file to make it clearer to build the Apache Karaf Docker image using the various possible ways.

I also wanted to update the documentation (`docker.adoc`) but I saw that it explicitly refers to the official Docker Hub repository which doesn't exist yet, so I stopped updating. In case let me know, I would be available to align the documentation as the README.