### PR TITLE
Enable karaf assembly builder to be sequential

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
@@ -95,6 +95,12 @@ public class AssemblyMojo extends MojoSupport {
     @Parameter
     protected File featuresProcessing;
 
+    /**
+     * If set > 0, the feature resolver concurrency, otherwise it defaults to the machine one.
+     */
+    @Parameter
+    protected int resolverParallelism;
+
     /*
      * There are three builder stages related to maven dependency scopes:
      *  - Stage.Startup : scope=compile
@@ -500,6 +506,9 @@ public class AssemblyMojo extends MojoSupport {
         builder.defaultStartLevel(defaultStartLevel);
         if (featuresProcessing != null) {
             builder.setFeaturesProcessing(featuresProcessing.toPath());
+        }
+        if (resolverParallelism > 0) {
+            builder.resolverParallelism(resolverParallelism);
         }
 
         // Set up remote repositories from Maven build, to be used by pax-url-aether resolver


### PR DESCRIPTION
Not sure it is needed to merge it upstream but it enables to configure the concurrency of the resolver used by assembly mojo + if the concurrency is one to run it sequentially.