### PR TITLE
Update httpclient.version to 4.5.13 to address CVE-2020-13956. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
         <hibernate.ejb.version>3.4.0.GA</hibernate.ejb.version>
         <hibernate.version>5.4.22.Final</hibernate.version>
         <hibernate.validator.version>6.1.6.Final</hibernate.validator.version>
-        <httpclient.version>4.5.6</httpclient.version>
+        <httpclient.version>4.5.13</httpclient.version>
         <jansi.version>1.18</jansi.version>
         <javassist.version>3.9.0.GA</javassist.version>
         <jline.version>3.16.0</jline.version>


### PR DESCRIPTION
As per https://bugzilla.redhat.com/show_bug.cgi?id=1886587, http.client libraries below version 4.5.13 have the vulnerability [CVE-2020-13956](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13956). 

As Karaf 4.2.x rebundles http.client (4.5.6) classes as seen at https://github.com/apache/karaf/blob/karaf-4.2.10/jaas/modules/pom.xml#L180 . This makes it vulnerable and hence our security scans are detecting it as a vulnerable library. Hence updating the httpclient.version to 4.5.13.