### PR TITLE
Update pax-logging-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
 
         <pax.cdi.version>1.0.0.RC2</pax.cdi.version>
         <pax.exam.version>4.11.0</pax.exam.version>
-        <pax.logging.version>1.10.1</pax.logging.version>
+        <pax.logging.version>1.10.7</pax.logging.version>
         <pax.base.version>1.5.0</pax.base.version>
         <pax.url.version>2.5.4</pax.url.version>
         <pax.web.version>6.0.11</pax.web.version>


### PR DESCRIPTION
Update pax-logging-version to 1.10.7, because in 1.10.1 stacktraceAsString doesn't work.