### PR TITLE
Add <javase/> to karaf-docker-example-static-dist

### DIFF
--- a/examples/karaf-docker-example/karaf-docker-example-static-dist/pom.xml
+++ b/examples/karaf-docker-example/karaf-docker-example-static-dist/pom.xml
@@ -108,6 +108,7 @@
                     <framework>static</framework>
                     <useReferenceUrls>true</useReferenceUrls>
                     <environment>static</environment>
+                    <javase>1.8</javase>
                 </configuration>
             </plugin>
         </plugins>

--- a/manual/src/main/asciidoc/developer-guide/karaf-maven-plugin.adoc
+++ b/manual/src/main/asciidoc/developer-guide/karaf-maven-plugin.adoc
@@ -561,6 +561,14 @@ It's also possible to generate a Karaf instance as a static distribution (kind o
 |`String`
 |An environment identifier that may be used to select different variant of PID configuration file, e.g., `org.ops4j.pax.url.mvn.cfg#docker`. Default value: null
 
+|`framework`
+|`String[]`
+|The features providing the Karaf framework (optional)
+
+|`javase`
+|`String`
+|The Java version to use for the verify
+
 |`defaultStartLevel`
 |`int`
 |Default start level for bundles in features that don't specify it. Default value: 30


### PR DESCRIPTION
Specifying javase is quite critical to resolve a number of modern
bundles. The dynamic-dist example has it mentioned, this adds it
to the static example to have parity between the two.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>