### PR TITLE
Revert "Update karaf-maven-plugin:dockerfile goal to use adoptopenjdk…

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/DockerfileMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/DockerfileMojo.java
@@ -46,7 +46,7 @@ public class DockerfileMojo extends MojoSupport {
         File dockerFile = new File(destDir, "Dockerfile");
         try {
             StringBuilder buffer = new StringBuilder();
-            buffer.append("FROM adoptopenjdk:11-jre-hotspot").append("\n");
+            buffer.append("FROM openjdk:8-jre").append("\n");
             buffer.append("ENV KARAF_INSTALL_PATH /opt").append("\n");
             buffer.append("ENV KARAF_HOME $KARAF_INSTALL_PATH/apache-karaf").append("\n");
             buffer.append("ENV KARAF_EXEC exec").append("\n");


### PR DESCRIPTION
…:11-jre-hotspot base image"

This reverts commit fcd24460fc0f2d6b91ddf2ef950358bd361cd1b8.

Hello,

as written [on the compatibility page](https://karaf.apache.org/download.html) karaf in version 2.x should support java 8+, which was broken by the reverted commit. This blocks us upgrading from 2.2.9 to 2.2.10.

Thanks!