### PR TITLE
Fix async logging comment message

### DIFF
--- a/assemblies/features/base/src/main/resources/resources/etc/org.ops4j.pax.logging.cfg
+++ b/assemblies/features/base/src/main/resources/resources/etc/org.ops4j.pax.logging.cfg
@@ -32,7 +32,7 @@ log4j2.out.pattern = \u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{F
 
 # Root logger
 log4j2.rootLogger.level = INFO
-# uncomment to use asynchronous loggers, which require mvn:com.lmax/disruptor/3.3.2 library
+# uncomment to use asynchronous loggers, which require mvn:com.lmax/disruptor/3.3.2 and mvn:org.ops4j.pax.logging/pax-logging-log4j2-extra/1.11.4 libraries
 #log4j2.rootLogger.type = asyncRoot
 #log4j2.rootLogger.includeLocation = false
 log4j2.rootLogger.appenderRef.RollingFile.ref = RollingFile


### PR DESCRIPTION
I was trying to enable asynchronous logging and found that with just the com.lmax/disruptor dependency I was getting a "NoClassDefFound" exception. With some research, I found I needed to add the `pax-logging-log4j2-extra` artifact. Now my custom distro starts