### PR TITLE
KARAF-6925 - Initial attempt at supporting spring-security-crypto

### DIFF
--- a/assemblies/features/standard/pom.xml
+++ b/assemblies/features/standard/pom.xml
@@ -390,6 +390,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Spring Security Crypto encryption deps -->
+        <dependency>
+            <groupId>org.apache.karaf.jaas</groupId>
+            <artifactId>org.apache.karaf.jaas.spring-security-crypto</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- scr deps -->
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -1441,6 +1441,13 @@ org.apache.felix.eventadmin.AddSubject=true
         </conditional>
     </feature>
 
+    <feature name="spring-security-crypto-encryption" description="Advanced encryption support for Karaf security" version="${project.version}">
+        <feature>jaas</feature>
+        <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk15on/${bouncycastle.version}</bundle>
+        <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-crypto/${spring.security53.version}</bundle>
+        <bundle start-level="30">mvn:org.apache.karaf.jaas/org.apache.karaf.jaas.spring-security-crypto/${project.version}</bundle>
+    </feature>
+
     <feature name="scr" description="Declarative Service support" version="${project.version}">
         <bundle dependency="true" start-level="30">mvn:org.osgi/org.osgi.util.function/1.1.0</bundle>
         <bundle dependency="true" start-level="30">mvn:org.osgi/org.osgi.util.promise/1.1.0</bundle>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -317,6 +317,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.karaf.jaas</groupId>
+                <artifactId>org.apache.karaf.jaas.spring-security-crypto</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.karaf.jaas</groupId>
                 <artifactId>org.apache.karaf.jaas.modules</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/jaas/pom.xml
+++ b/jaas/pom.xml
@@ -38,6 +38,7 @@
         <module>config</module>
         <module>modules</module>
         <module>jasypt</module>
+        <module>spring-security-crypto</module>
         <module>command</module>
         <module>blueprint</module>
     </modules>

--- a/jaas/spring-security-crypto/pom.xml
+++ b/jaas/spring-security-crypto/pom.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+    
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.apache.karaf.jaas</groupId>
+        <artifactId>jaas</artifactId>
+        <version>4.3.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    
+    <artifactId>org.apache.karaf.jaas.spring-security-crypto</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Karaf :: JAAS :: Spring Security Crypto Encryption</name>
+    <description>This bundle provide Spring Security Crypto service for the encryption support in the JAAS security framework.</description>
+    
+    <properties>
+        <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>karaf-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    
+    <dependencies>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.karaf.jaas</groupId>
+            <artifactId>org.apache.karaf.jaas.modules</artifactId>    
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.jaas</groupId>
+            <artifactId>org.apache.karaf.jaas.boot</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.spring-security-crypto</artifactId>
+            <version>${spring.security53.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.aries.blueprint</groupId>
+            <artifactId>org.apache.aries.blueprint.api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.blueprint</groupId>
+            <artifactId>org.apache.aries.blueprint.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.connect</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.ops4j.pax.tinybundles</groupId>
+            <artifactId>tinybundles</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.aries.proxy</groupId>
+            <artifactId>org.apache.aries.proxy.api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.proxy</groupId>
+            <artifactId>org.apache.aries.proxy</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries</groupId>
+            <artifactId>org.apache.aries.util</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <scope>test</scope>
+            <version>${bouncycastle.version}</version>
+        </dependency>
+
+
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/*.info</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            org.osgi.framework;version="[1,3)",
+                            *
+                        </Import-Package>
+                        <Private-Package>
+                            org.apache.karaf.jaas.spring_security_crypto.impl
+                        </Private-Package>
+                        <Bundle-Activator>
+                            org.apache.karaf.jaas.spring_security_crypto.impl.Activator
+                        </Bundle-Activator>
+                        <Provide-Capability>
+                            osgi.service;effective:=active;name=spring-security-crypto;objectClass="org.apache.karaf.jaas.modules.EncryptionService"
+                        </Provide-Capability>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jaas/spring-security-crypto/src/main/java/org/apache/karaf/jaas/spring_security_crypto/impl/Activator.java
+++ b/jaas/spring-security-crypto/src/main/java/org/apache/karaf/jaas/spring_security_crypto/impl/Activator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.jaas.spring_security_crypto.impl;
+
+import java.util.Hashtable;
+
+import org.apache.karaf.jaas.modules.EncryptionService;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+public class Activator implements BundleActivator {
+
+    private ServiceRegistration<EncryptionService> registration;
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("name", "spring-security-crypto");
+        registration = context.registerService(
+                EncryptionService.class,
+                new SpringSecurityCryptoEncryptionService(),
+                props);
+
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        registration.unregister();
+    }
+}

--- a/jaas/spring-security-crypto/src/main/java/org/apache/karaf/jaas/spring_security_crypto/impl/SpringSecurityCryptoEncryption.java
+++ b/jaas/spring-security-crypto/src/main/java/org/apache/karaf/jaas/spring_security_crypto/impl/SpringSecurityCryptoEncryption.java
@@ -1,0 +1,122 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  under the License.
+ */
+package org.apache.karaf.jaas.spring_security_crypto.impl;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.karaf.jaas.modules.Encryption;
+import org.apache.karaf.jaas.modules.EncryptionService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.codec.Hex;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder;
+
+/**
+ * Spring Security Crypto implementation of the Encryption service.
+ */
+public class SpringSecurityCryptoEncryption implements Encryption {
+
+    private static final Logger log = LoggerFactory.getLogger(SpringSecurityCryptoEncryption.class);
+    private static final Map<String, Class<? extends PasswordEncoder>> PASSWORD_ENCODERS;
+    private PasswordEncoder passwordEncoder;
+    private String encoding;
+
+    static {
+        Map<String, Class<? extends PasswordEncoder>> passwordEncoders = new HashMap<>();
+        passwordEncoders.put("pbkdf2", Pbkdf2PasswordEncoder.class);
+        passwordEncoders.put("bcrypt", BCryptPasswordEncoder.class);
+        passwordEncoders.put("scrypt", SCryptPasswordEncoder.class);
+        passwordEncoders.put("argon2", Argon2PasswordEncoder.class);
+        PASSWORD_ENCODERS = Collections.unmodifiableMap(passwordEncoders);
+    }
+
+    /**
+     * <p>
+     * Default constructor with the encryption algorithm.
+     * </p>
+     * 
+     * @param params encryption parameters
+     */
+    public SpringSecurityCryptoEncryption(Map<String,String> params) {
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            if (EncryptionService.ALGORITHM.equalsIgnoreCase(entry.getKey())) {
+                if (!PASSWORD_ENCODERS.containsKey(entry.getValue())) {
+                    throw new IllegalArgumentException("Unsupported algorithm parameter: " + entry.getValue());
+                }
+                try {
+                    passwordEncoder = PASSWORD_ENCODERS.get(entry.getValue()).newInstance();
+                } catch (InstantiationException | IllegalAccessException e) {
+                    throw new IllegalArgumentException("Unsupported encryption parameter: " + entry.getKey());
+                }
+            } else if (EncryptionService.ENCODING.equalsIgnoreCase(entry.getKey())) {
+                encoding = entry.getValue();
+            }
+        }
+
+        if (passwordEncoder == null) {
+            throw new IllegalArgumentException("Digest algorithm must be specified");
+        }
+
+        if (encoding != null && encoding.length() > 0
+                && !EncryptionService.ENCODING_HEXADECIMAL.equalsIgnoreCase(encoding)
+                && !EncryptionService.ENCODING_BASE64.equalsIgnoreCase(encoding)) {
+            log.error("Initialization failed. Digest encoding " + encoding + " is not supported.");
+            throw new IllegalArgumentException(
+                    "Unable to configure login module. Digest Encoding " + encoding + " not supported.");
+        }
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.apache.karaf.jaas.modules.Encryption#encryptPassword(java.lang.String)
+     */
+    public String encryptPassword(String plain) {
+        String encryptedPassword = passwordEncoder.encode(plain);
+        if (EncryptionService.ENCODING_HEXADECIMAL.equalsIgnoreCase(encoding)) {
+            return new String(Hex.encode(encryptedPassword.getBytes(StandardCharsets.UTF_8)));
+        } else if (EncryptionService.ENCODING_BASE64.equalsIgnoreCase(encoding)) {
+            return Base64.getEncoder().encodeToString(encryptedPassword.getBytes(StandardCharsets.UTF_8));
+        }
+        return encryptedPassword;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.apache.karaf.jaas.modules.Encryption#checkPassword(java.lang.String, java.lang.String)
+     */
+    public boolean checkPassword(String password, String input) {
+        String decodedInput = input;
+        if (EncryptionService.ENCODING_HEXADECIMAL.equalsIgnoreCase(encoding)) {
+            decodedInput = new String(Hex.decode(input));
+        } else if (EncryptionService.ENCODING_BASE64.equalsIgnoreCase(encoding)) {
+            decodedInput = new String(Base64.getDecoder().decode(input), StandardCharsets.UTF_8);
+        }
+        return passwordEncoder.matches(password, decodedInput);
+    }
+
+}

--- a/jaas/spring-security-crypto/src/main/java/org/apache/karaf/jaas/spring_security_crypto/impl/SpringSecurityCryptoEncryptionService.java
+++ b/jaas/spring-security-crypto/src/main/java/org/apache/karaf/jaas/spring_security_crypto/impl/SpringSecurityCryptoEncryptionService.java
@@ -1,0 +1,27 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  under the License.
+ */
+package org.apache.karaf.jaas.spring_security_crypto.impl;
+
+import java.util.Map;
+
+import org.apache.karaf.jaas.modules.Encryption;
+import org.apache.karaf.jaas.modules.EncryptionService;
+
+public class SpringSecurityCryptoEncryptionService implements EncryptionService {
+
+    public Encryption createEncryption(Map<String, String> params) throws IllegalArgumentException {
+        return new SpringSecurityCryptoEncryption(params);
+    }
+}

--- a/jaas/spring-security-crypto/src/main/resources/OSGI-INF/bundle.info
+++ b/jaas/spring-security-crypto/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,42 @@
+#
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#
+h1. Synopsis
+
+${project.name}
+
+${project.description}
+
+Maven URL:
+[mvn:${project.groupId}/${project.artifactId}/${project.version}]
+
+h1. Description
+
+This bundle uses the Spring Security Crypto tool to provide encryption support in the JAAS security framework. It
+offers stronger encryption algorithms than the Jasypt provider.
+
+The following algorithms are supported:
+ * bcrypt
+ * pbkdf2
+ * scrypt (requires BouncyCastle)
+ * argon2 (requires BouncyCastle)
+
+h1. See also
+
+* Security Framework - section of the Karaf Developer Guide.
+* [https://docs.spring.io/spring-security/site/docs/5.0.x/reference/html/crypto.html] -

--- a/jaas/spring-security-crypto/src/test/java/org/apache/karaf/jaas/spring_security_crypto/impl/SpringSecurityCryptoEncryptionTest.java
+++ b/jaas/spring-security-crypto/src/test/java/org/apache/karaf/jaas/spring_security_crypto/impl/SpringSecurityCryptoEncryptionTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  under the License.
+ */
+package org.apache.karaf.jaas.spring_security_crypto.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.karaf.jaas.modules.EncryptionService;
+
+/**
+ * Test <code>SpringSecurityCryptoEncryption</code>.
+ */
+public class SpringSecurityCryptoEncryptionTest {
+
+    @org.junit.Test
+    public void testCheckPasswordPBKDF12() throws Exception {
+        performTest("pbkdf2", EncryptionService.ENCODING_BASE64);
+        performTest("pbkdf2", EncryptionService.ENCODING_HEXADECIMAL);
+        performTest("pbkdf2", null);
+    }
+
+    @org.junit.Test
+    public void testCheckPasswordBCrypt() throws Exception {
+        performTest("bcrypt", EncryptionService.ENCODING_BASE64);
+        performTest("bcrypt", EncryptionService.ENCODING_HEXADECIMAL);
+        performTest("bcrypt", null);
+    }
+
+    @org.junit.Test
+    public void testCheckPasswordSCrypt() throws Exception {
+        performTest("scrypt", EncryptionService.ENCODING_BASE64);
+        performTest("scrypt", EncryptionService.ENCODING_HEXADECIMAL);
+        performTest("scrypt", null);
+    }
+
+    @org.junit.Test
+    public void testCheckPasswordArgon2() throws Exception {
+        performTest("argon2", EncryptionService.ENCODING_BASE64);
+        performTest("argon2", EncryptionService.ENCODING_HEXADECIMAL);
+    }
+
+    private void performTest(String algorithm, String encoding) throws Exception {
+        Map<String,String> props = new HashMap<>();
+        props.put(EncryptionService.ALGORITHM, algorithm);
+        props.put(EncryptionService.ENCODING, encoding);
+        SpringSecurityCryptoEncryption encryption = new SpringSecurityCryptoEncryption(props);
+        String password = encryption.encryptPassword("test");
+        org.junit.Assert.assertEquals(true, encryption.checkPassword("test", password));
+    }
+
+}

--- a/jaas/spring-security-crypto/src/test/resources/log4j.properties
+++ b/jaas/spring-security-crypto/src/test/resources/log4j.properties
@@ -1,0 +1,34 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+#
+# The logging properties used during tests..
+#
+log4j.rootLogger=INFO, console, file
+
+# Console will only display warnnings
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+#log4j.appender.console.threshold=WARN
+
+# File appender will contain all info messages
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d | %-5p | %m | %c | %t%n
+log4j.appender.file.file=target/test.log
+log4j.appender.file.append=true


### PR DESCRIPTION
Some points to note:
 * In jaas/spring-security-crypto/pom.xml it just depends on a servicemix bundle, I wasn't sure whether to just depend on the normal spring jar here.
 * The feature I added could be reworked to remove dependency on a set version of Spring.
 * scrypt, bcrypt, pbkdf2, argon2 work well.
 * Remaining work: Update the default jaas file comments to show how to use it, and update the documentation.