### PR TITLE
Add ability to set additional non-debug JVM options

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf
@@ -273,6 +273,8 @@ run() {
             fi
         fi
         JAVA_OPTS="${JAVA_DEBUG_OPTS} ${JAVA_OPTS}"
+    else
+        JAVA_OPTS="${JAVA_NON_DEBUG_OPTS} ${JAVA_OPTS}"
     fi
 
     while true; do

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat
@@ -388,12 +388,14 @@ if "%KARAF_PROFILER%" == "" goto :RUN
 :EXECUTE_DEBUG
     if "%JAVA_DEBUG_OPTS%" == "" set JAVA_DEBUG_OPTS=%DEFAULT_JAVA_DEBUG_OPTS%
     set JAVA_OPTS=%JAVA_DEBUG_OPTS% %JAVA_OPTS%
+    set DEBUG=true
     shift
     goto :RUN_LOOP
 
 :EXECUTE_DEBUGS
     if "%JAVA_DEBUG_OPTS%" == "" set JAVA_DEBUG_OPTS=%DEFAULT_JAVA_DEBUGS_OPTS%
     set JAVA_OPTS=%JAVA_DEBUG_OPTS% %JAVA_OPTS%
+    set DEBUG=true
     shift
     goto :RUN_LOOP
 
@@ -401,6 +403,8 @@ if "%KARAF_PROFILER%" == "" goto :RUN
     SET ARGS=%1 %2 %3 %4 %5 %6 %7 %8
     rem Execute the Java Virtual Machine
     cd "%KARAF_BASE%"
+
+    if not "%DEBUG%" == "true" set JAVA_OPTS=%JAVA_NON_DEBUG_OPTS% %JAVA_OPTS%
 
     rem When users want to update the lib version of, they just need to create
     rem a lib.next directory and on the new restart, it will replace the current lib directory.

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/setenv
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/setenv
@@ -40,6 +40,7 @@
 # export JAVA_MAX_MEM # Maximum memory for the JVM
 # export JAVA_PERM_MEM # Minimum perm memory for the JVM
 # export JAVA_MAX_PERM_MEM # Maximum perm memory for the JVM
+# export JAVA_NON_DEBUG_OPTS # Additional non-debug JVM options
 # export EXTRA_JAVA_OPTS # Additional JVM options
 # export KARAF_HOME # Karaf home folder
 # export KARAF_DATA # Karaf data folder

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/setenv.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/setenv.bat
@@ -49,6 +49,8 @@ rem SET JAVA_PERM_MEM
 rem Maximum perm memory for the JVM
 rem SET JAVA_MAX_PERM_MEM
 rem Additional JVM options
+rem SET JAVA_NON_DEBUG_OPTS
+rem Additional non-debug JVM options
 rem SET EXTRA_JAVA_OPTS 
 rem Karaf home folder
 rem SET KARAF_HOME


### PR DESCRIPTION
Introduces a new environment variable to set additional JVM options only when not running in debug mode.

The current implementation only provides variables for both, running in debug mode and non-debug mode and for running in debug mode, but not for running in non-debug mode only.

The use case at openHAB is to disable the JVM performance logging when running normally as the periodic disk writing kills flash memory e.g. in raspberry PIs. But it may not be disabled when running in debug mode as it kills the ability to use VisualVM. See openhab/openhab-distro#1183 and openhab/openhab-distro#1193.