### PR TITLE
[KARAF-6963] First send SIGTERM, only SIGKILL if not shutting down nicely

### DIFF
--- a/instance/src/test/java/org/apache/karaf/jpm/MainTest.java
+++ b/instance/src/test/java/org/apache/karaf/jpm/MainTest.java
@@ -19,6 +19,18 @@ package org.apache.karaf.jpm;
 public class MainTest {
 
     public static void main(String[] args) throws Exception {
+        // Added shutdown hook to block after SIGTERM
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(Long.parseLong(args[1]));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
+
         Thread.sleep(Long.parseLong(args[0]));
     }
 }

--- a/instance/src/test/java/org/apache/karaf/jpm/ProcessTest.java
+++ b/instance/src/test/java/org/apache/karaf/jpm/ProcessTest.java
@@ -39,7 +39,9 @@ public class ProcessTest extends TestCase {
         command.append(" ");
         command.append(MainTest.class.getName());
         command.append(" ");
-        command.append(60000);
+        command.append(60000); // process sleep time
+        command.append(" ");
+        command.append(11000); // shutdown sleep time, to have the SIGKILL get triggered
         System.err.println("Executing: " + command.toString());
 
         ProcessBuilder builder = new ProcessBuilderFactoryImpl().newBuilder();

--- a/util/src/main/java/org/apache/karaf/jpm/impl/ProcessImpl.java
+++ b/util/src/main/java/org/apache/karaf/jpm/impl/ProcessImpl.java
@@ -81,7 +81,27 @@ public class ProcessImpl implements Process {
             props.put("${pid}", Integer.toString(pid));
             ret = ScriptUtils.execute("destroy", props);
         } else {
-            ret = ScriptUtils.executeProcess(new java.lang.ProcessBuilder("kill", "-9", Integer.toString(pid)));
+            // Try regular SIGTERM command first
+            ret = ScriptUtils.executeProcess(new java.lang.ProcessBuilder("kill", Integer.toString(pid)));
+            if (ret == 0) {
+                boolean isRunning = true;
+                int loopCounter = 0;
+
+                // Verify in 1 second intervals whether the process is still running, so not to block too long
+                do {
+                    loopCounter++;
+                    try {
+                        Thread.sleep(1000);
+                        isRunning = isRunning();
+                    } catch (InterruptedException | IOException ignore) {
+                    }
+                } while (isRunning && loopCounter <= 10);
+
+                // Verify the process got closed nicely, if not send a SIGKILL
+                if (isRunning) {
+                    ret = ScriptUtils.executeProcess(new java.lang.ProcessBuilder("kill", "-9", Integer.toString(pid)));
+                }
+            }
         }
         if (ret != 0) {
             throw new IOException("Unable to destroy process, it may already be terminated");

--- a/util/src/main/java/org/apache/karaf/jpm/impl/ProcessImpl.java
+++ b/util/src/main/java/org/apache/karaf/jpm/impl/ProcessImpl.java
@@ -84,21 +84,10 @@ public class ProcessImpl implements Process {
             // Try regular SIGTERM command first
             ret = ScriptUtils.executeProcess(new java.lang.ProcessBuilder("kill", Integer.toString(pid)));
             if (ret == 0) {
-                boolean isRunning = true;
-                int loopCounter = 0;
-
-                // Verify in 1 second intervals whether the process is still running, so not to block too long
-                do {
-                    loopCounter++;
-                    try {
-                        Thread.sleep(1000);
-                        isRunning = isRunning();
-                    } catch (InterruptedException | IOException ignore) {
-                    }
-                } while (isRunning && loopCounter <= 10);
+                boolean isShutdown = awaitShutdown();
 
                 // Verify the process got closed nicely, if not send a SIGKILL
-                if (isRunning) {
+                if (!isShutdown) {
                     ret = ScriptUtils.executeProcess(new java.lang.ProcessBuilder("kill", "-9", Integer.toString(pid)));
                 }
             }
@@ -106,6 +95,25 @@ public class ProcessImpl implements Process {
         if (ret != 0) {
             throw new IOException("Unable to destroy process, it may already be terminated");
         }
+    }
+
+    private boolean awaitShutdown() {
+        boolean isStillRunning = true;
+        int loopCounter = 0;
+
+        // Verify in 1 second intervals whether the process is still running, so not to block too long
+        do {
+            loopCounter++;
+            try {
+                Thread.sleep(1000);
+                isStillRunning = isRunning();
+            } catch (InterruptedException | IOException e) {
+                // Restore interrupted state...
+                Thread.currentThread().interrupt();
+            }
+        } while (isStillRunning && loopCounter <= 10);
+
+        return !isStillRunning;
     }
 
     /*


### PR DESCRIPTION
PR for issue: https://issues.apache.org/jira/browse/KARAF-6963

Try first a regular `SIGTERM` to shutdown the daemon process.
If that doesn't result in the process stopping within 10 seconds, follow with the `SIGKILL` signal.

It's verifying in 1 second intervals whether the process is still running, so that the 'stop' request won't be blocking too long.