### PR TITLE
KARAF-6992: maven-release-plugin: Only append config settings if config file exist

### DIFF
--- a/profile/src/main/java/org/apache/karaf/profile/assembly/ConfigInstaller.java
+++ b/profile/src/main/java/org/apache/karaf/profile/assembly/ConfigInstaller.java
@@ -65,7 +65,8 @@ public class ConfigInstaller {
             for (Config config : content.getConfig()) {
                 if (pidMatching(config.getName())) {
                     Path configFile = etcDirectory.resolve(config.getName() + ".cfg");
-                    if (!config.isAppend() && Files.exists(configFile)) {
+                    boolean configFileExist = Files.exists(configFile);
+                    if (!config.isAppend() && configFileExist) {
                         LOGGER.info("      not changing existing config file: {}", homeDirectory.relativize(configFile));
                         continue;
                     }
@@ -84,8 +85,13 @@ public class ConfigInstaller {
                         });
                     } else {
                         if (config.isAppend()) {
-                            LOGGER.info("      appending to config file: {}", homeDirectory.relativize(configFile));
-                            Files.write(configFile, config.getValue().getBytes(), StandardOpenOption.APPEND);
+                            if (configFileExist) {
+                                LOGGER.info("      appending to config file: {}", homeDirectory.relativize(configFile));
+                                Files.write(configFile, config.getValue().getBytes(), StandardOpenOption.APPEND);
+                            }
+                            else
+                                LOGGER.warn("      Could not append, because config file does not exist: {}", homeDirectory.relativize(configFile));
+                            
                         } else {
                             LOGGER.info("      adding config file: {}", homeDirectory.relativize(configFile));
                             Files.write(configFile, config.getValue().getBytes());


### PR DESCRIPTION
Only append additional configuration settings (configured in **Config** element) if the config file really exist. 
Otherwise the karaf:assembly command will fail.