### PR TITLE
Update jackson-databind to fix CVE-2020-25649 / BDSA-2020-2965

### DIFF
--- a/features/core/pom.xml
+++ b/features/core/pom.xml
@@ -134,7 +134,7 @@
             <artifactId>tinybundles</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.5</version>
+            <version>2.10.5.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Quick update to fix a known issue with jackson-databind