### PR TITLE
[KARAF-6998] Avoid broken equals of OrderDictionary

### DIFF
--- a/config/src/main/java/org/apache/karaf/config/core/impl/JsonConfigInstaller.java
+++ b/config/src/main/java/org/apache/karaf/config/core/impl/JsonConfigInstaller.java
@@ -80,7 +80,8 @@ public class JsonConfigInstaller implements ArtifactInstaller, ConfigurationList
             old.remove(Constants.SERVICE_PID);
             old.remove(ConfigurationAdmin.SERVICE_FACTORYPID);
         }
-        if (!properties.equals(old)) {
+        // KARAF-6998: Call equals on 'old' because 'properties' is an OrderDictionary with broken equals
+        if (old == null || !old.equals(properties)) {
             properties.put(DirectoryWatcher.FILENAME, toConfigKey(artifact));
             if (old == null) {
                 LOGGER.info("Creating configuration from " + pid[0] + (pid[1] == null ? "" : "-" + pid[1]) + ".json");


### PR DESCRIPTION
If you think my [comment](https://issues.apache.org/jira/browse/KARAF-6998?focusedCommentId=17301118&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17301118) makes sense then you can apply the fix with this PR. :slightly_smiling_face: 