### PR TITLE
[KARAF-7133] Allow karaf commands to have return codes

### DIFF
--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/ConsoleSessionImpl.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/ConsoleSessionImpl.java
@@ -465,7 +465,7 @@ public class ConsoleSessionImpl implements Session {
     private void doExecute(CharSequence command) {
         try {
             Object result = session.execute(command);
-            if (result != null) {
+            if (result != null && !(result instanceof Integer)) {
                 session.getConsole().println(session.format(result, Converter.INSPECT));
             }
         } catch (InterruptedException e) {


### PR DESCRIPTION
only print out results if they are not integers. If they are integers,
they should are treated as exit codes.