### PR TITLE
[KARAF-6877] Allow executing aliases in itests

### DIFF
--- a/itests/test/src/test/java/org/apache/karaf/itests/BundleTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/BundleTest.java
@@ -51,6 +51,13 @@ public class BundleTest extends BaseTest {
     }
 
     @Test
+    public void laAlias() throws Exception {
+        String laOutput = executeAlias("la", ADMIN_ROLES);
+        System.out.println(laOutput);
+        assertFalse(laOutput.isEmpty());
+    }
+
+    @Test
     public void listViaMBean() throws Exception {
         MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
             ObjectName name = new ObjectName("org.apache.karaf:type=bundle,name=root");

--- a/itests/test/src/test/java/org/apache/karaf/itests/ConfigTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/ConfigTest.java
@@ -46,6 +46,13 @@ public class ConfigTest extends BaseTest {
     }
 
     @Test
+    public void clAlias() throws Exception {
+        String configListOutput = executeAlias("cl org.apache.karaf.features");
+        System.out.println(configListOutput);
+        assertFalse(configListOutput.isEmpty());
+    }
+
+    @Test
     public void listShortCommand() throws Exception {
         String configListOutput = executeCommand("config:list -s");
         System.out.println(configListOutput);

--- a/itests/test/src/test/java/org/apache/karaf/itests/FeatureTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/FeatureTest.java
@@ -90,6 +90,14 @@ public class FeatureTest extends BaseTest {
     }
 
     @Test
+    public void upgradeUninstallCommand() throws Exception {
+        System.out.println(executeAlias("feature:upgrade -v -r wrapper", new RolePrincipal("admin")));
+        assertFeatureInstalled("wrapper");
+        System.out.println(executeCommand("feature:uninstall -r wrapper", new RolePrincipal("admin")));
+        assertFeatureNotInstalled("wrapper");
+    }
+
+    @Test
     public void installUninstallViaMBean() throws Exception {
         MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
         ObjectName name = new ObjectName("org.apache.karaf:type=feature,name=root");

--- a/itests/test/src/test/java/org/apache/karaf/itests/LogTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/LogTest.java
@@ -44,6 +44,13 @@ public class LogTest extends BaseTest {
     }
 
     @Test
+    public void setDebugAndDisplayAlias() throws Exception {
+        assertSetLevel("DEBUG");
+        LOGGER.debug("Making sure there is DEBUG level output");
+        assertContains("DEBUG", executeAlias("ld -n 200"));
+    }
+
+    @Test
     public void setDebugViaMBean() throws Exception {
         assertSetLevel("INFO");
         MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
@@ -62,10 +69,20 @@ public class LogTest extends BaseTest {
         String displayOutput = executeCommand("log:display").trim();
         assertTrue("Should be empty but was: " + displayOutput, displayOutput.trim().isEmpty());
     }
+
+    @Test
+    public void setGetDebugAndClearAlias() throws Exception {
+        assertSetLevel("DEBUG");
+        assertSetLevel("INFO");
+        System.out.println(executeCommand("log:clear"));
+        String displayOutput = executeAlias("ld").trim();
+        assertTrue("Should be empty but was: " + displayOutput, displayOutput.trim().isEmpty());
+    }
     
     public void assertSetLevel(String level) throws InterruptedException {
         System.out.println(executeCommand("log:set " + level));
         assertContains(level, executeCommand("log:get"));
+        assertContains(level, executeAlias("log:list"));
         Thread.sleep(100);
     }
 

--- a/itests/test/src/test/java/org/apache/karaf/itests/ServiceTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/ServiceTest.java
@@ -40,6 +40,13 @@ public class ServiceTest extends BaseTest {
     }
 
     @Test
+    public void lsAlias() throws Exception {
+        String listOutput = executeAlias("ls");
+        System.out.println(listOutput);
+        assertFalse(listOutput.isEmpty());
+    }
+
+    @Test
     public void listViaMBean() throws Exception {
         MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
         ObjectName name = new ObjectName("org.apache.karaf:type=service,name=root");

--- a/itests/test/src/test/java/org/apache/karaf/itests/SystemShutdownTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/SystemShutdownTest.java
@@ -35,6 +35,11 @@ public class SystemShutdownTest extends BaseTest {
     }
 
     @Test
+    public void haltAlias() throws Exception {
+        System.out.println(executeAlias("halt", new RolePrincipal("admin")));
+    }
+
+    @Test
     public void shutdownViaMBean() throws Exception {
         MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
         ObjectName name = new ObjectName("org.apache.karaf:type=system,name=root");


### PR DESCRIPTION
As per https://issues.apache.org/jira/browse/KARAF-6877 , added the functionality to load the shell.init.script in the itest session, thus making aliases available to the tests.

By default waiting for the alias command service is disabled (1ms) as the aliases are never in the registry (as far as I checked?). Added the possibility to set a bigger timeout in case a test manually installs a feature/bundle containing custom commands.