### PR TITLE
KARAF-7165 - config:meta doesn't work for factory PIDs

### DIFF
--- a/config/src/main/java/org/apache/karaf/config/command/ConfigCommandSupport.java
+++ b/config/src/main/java/org/apache/karaf/config/command/ConfigCommandSupport.java
@@ -51,7 +51,6 @@ public abstract class ConfigCommandSupport implements Action {
 
     protected abstract Object doExecute() throws Exception;
 
-    @SuppressWarnings("rawtypes")
     protected TypedProperties getEditedProps() throws Exception {
         return (TypedProperties) this.session.get(PROPERTY_CONFIG_PROPS);
     }

--- a/config/src/main/java/org/apache/karaf/config/command/EditCommand.java
+++ b/config/src/main/java/org/apache/karaf/config/command/EditCommand.java
@@ -45,8 +45,7 @@ public class EditCommand extends ConfigCommandSupport {
     @Option(name = "--type", aliases = {}, description = "Specifies the configuration storage type (cfg or json).", required = false, multiValued = false)
     String suffix;
 
-    @Override
-    @SuppressWarnings("rawtypes")
+    @Override    
     protected Object doExecute() throws Exception {
         String oldPid = (String) this.session.get(PROPERTY_CONFIG_PID);
         if (oldPid != null && !oldPid.equals(pid) && !force) {

--- a/config/src/main/java/org/apache/karaf/config/command/UpdateCommand.java
+++ b/config/src/main/java/org/apache/karaf/config/command/UpdateCommand.java
@@ -25,7 +25,6 @@ import org.apache.karaf.shell.api.action.lifecycle.Service;
 public class UpdateCommand extends ConfigCommandSupport {
 
     @Override
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Object doExecute() throws Exception {
         TypedProperties props = getEditedProps();
         if (props == null) {


### PR DESCRIPTION
Fixes MetaCommand.getMetatype to also search for the desired PID in the
list of factory pids of MetaTypeInformation. The command is now able to
create default configurations for factory PIDs.

Removes a few unnecessary @SuppressWarnings in config:* commands