### PR TITLE
Syntax error in note block

### DIFF
--- a/manual/src/main/asciidoc/user-guide/webconsole.adoc
+++ b/manual/src/main/asciidoc/user-guide/webconsole.adoc
@@ -66,7 +66,7 @@ For security reason, by default, `karaf` user is disabled. To allow the logon, y
 karaf = karaf,_g_:admingroup
 _g_\:admingroup = group,admin,manager,viewer,systembundles,ssh
 ----
-=====
+====
 
 [NOTE]
 ====


### PR DESCRIPTION
This causes a brocken online documentation. See https://karaf.apache.org/manual/latest/#_access