### PR TITLE
Fix version parsing

### DIFF
--- a/util/src/main/java/org/apache/karaf/util/DeployerUtils.java
+++ b/util/src/main/java/org/apache/karaf/util/DeployerUtils.java
@@ -29,7 +29,7 @@ public final class DeployerUtils {
 
     private static final String DEFAULT_VERSION = "0.0.0";
 
-    private static final Pattern ARTIFACT_MATCHER = Pattern.compile("(.+)(?:-(\\d+)(?:\\.(\\d+)(?:\\.(\\d+))?)?(?:[^a-zA-Z0-9](.*))?)(?:\\.([^\\.]+))", Pattern.DOTALL);
+    private static final Pattern ARTIFACT_MATCHER = Pattern.compile("(.+?)(?:-(\\d+)(?:\\.(\\d+)(?:\\.(\\d+))?)?(?:[^a-zA-Z0-9](.*))?)(?:\\.([^\\.]+))", Pattern.DOTALL);
     private static final Pattern FUZZY_MODIFIDER = Pattern.compile("(?:\\d+[.-])*(.*)", Pattern.DOTALL);
 
     /**

--- a/util/src/test/java/org/apache/karaf/util/DeployerUtilsTest.java
+++ b/util/src/test/java/org/apache/karaf/util/DeployerUtilsTest.java
@@ -1,0 +1,47 @@
+package org.apache.karaf.util;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+
+import static org.apache.karaf.util.DeployerUtils.extractNameVersionType;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+public class DeployerUtilsTest extends TestCase
+{
+    @Test
+    public void test()
+    {
+        assertThat(
+            extractNameVersionType("foobarbaz-1.jar"),
+            equalTo(new String[]{"foobarbaz", "1", "jar"})
+        );
+
+        assertThat(
+            extractNameVersionType("foobarbaz-1.0.jar"),
+            equalTo(new String[]{"foobarbaz", "1.0", "jar"})
+        );
+
+        assertThat(
+            extractNameVersionType("foobarbaz-1.0.0.jar"),
+            equalTo(new String[]{"foobarbaz", "1.0.0", "jar"})
+        );
+
+        assertThat(
+            extractNameVersionType("foobarbaz-1-PR-4-SNAPSHOT.jar"),
+            equalTo(new String[]{"foobarbaz", "1.0.0.PR-4-SNAPSHOT", "jar"})
+        );
+
+        assertThat(
+            extractNameVersionType("foobarbaz-1.0-PR-4-SNAPSHOT.jar"),
+            equalTo(new String[]{"foobarbaz", "1.0.0.PR-4-SNAPSHOT", "jar"})
+        );
+
+        assertThat(
+            extractNameVersionType("foobarbaz-1.0.0-PR-4-SNAPSHOT.jar"),
+            equalTo(new String[]{"foobarbaz", "1.0.0.PR-4-SNAPSHOT", "jar"})
+        );
+    }
+}


### PR DESCRIPTION
Make the first group of the regexp non-greedy to ensure it won't swallow
the build meta data part. In particular, with a greedy first group it
swallows everything up to the last dash that's followed by a
digit, something that's quite common in SNAPSHOT builds.
As a result a name like `foobar-1.0.0-PR-4-SNAPSHOT.jar` was parsed into
version `4.0.0-SNAPSHOT`.