### PR TITLE
[KARAF-7186] Optionally avoid to fail the verify goal on bundle uninstall/update

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/StaticInstallSupport.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/StaticInstallSupport.java
@@ -32,6 +32,9 @@ import org.osgi.resource.Wire;
 
 public abstract class StaticInstallSupport implements BundleInstallSupport {
 
+    protected boolean failOnUninstall = true;
+    protected boolean failOnUpdate = true;
+
     @Override
     public void print(String message, boolean verbose) {
     }
@@ -43,13 +46,17 @@ public abstract class StaticInstallSupport implements BundleInstallSupport {
     @Override
     public void updateBundle(Bundle bundle, String uri, InputStream is) throws BundleException {
         System.err.println("Update bundle is not supported in the static installer");
-        throw new UnsupportedOperationException();
+        if (failOnUpdate) {
+            throw new UnsupportedOperationException();
+        }
     }
 
     @Override
     public void uninstall(Bundle bundle) throws BundleException {
         System.err.println("Uninstall bundle is not supported in the static installer");
-        throw new UnsupportedOperationException();
+        if (failOnUninstall) {
+            throw new UnsupportedOperationException();
+        }
     }
 
     @Override

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
@@ -122,6 +122,12 @@ public class VerifyMojo extends MojoSupport {
     @Parameter(property = "featureProcessingInstructions")
     protected File featureProcessingInstructions;
 
+    @Parameter(property = "failOnUninstall")
+    protected boolean failOnUninstall = true;
+
+    @Parameter(property = "failOnUpdate")
+    protected boolean failOnUpdate = true;
+
     @Parameter(property = "features")
     protected List<String> features;
 
@@ -446,7 +452,7 @@ public class VerifyMojo extends MojoSupport {
     private void verifyResolution(DownloadManager manager, final Map<String, Features> repositories, Set<String> features, Hashtable<String, String> properties) throws MojoExecutionException {
         try {
             Bundle systemBundle = getSystemBundle(getMetadata(properties, "metadata#"));
-            DummyDeployCallback callback = new DummyDeployCallback(systemBundle, repositories.values());
+            DummyDeployCallback callback = new DummyDeployCallback(systemBundle, repositories.values(), failOnUpdate, failOnUninstall);
             Deployer deployer = new Deployer(manager, new ResolverImpl(new MavenResolverLog()), callback);
 
 
@@ -790,7 +796,11 @@ public class VerifyMojo extends MojoSupport {
         private final Deployer.DeploymentState dstate;
         private final AtomicLong nextBundleId = new AtomicLong(0);
 
-        public DummyDeployCallback(Bundle sysBundle, Collection<Features> repositories) {
+        public DummyDeployCallback(Bundle sysBundle, Collection<Features> repositories, boolean failOnUpdate, boolean failOnUninstall) {
+
+            super.failOnUpdate = failOnUpdate;
+            super.failOnUninstall = failOnUninstall;
+
             systemBundle = sysBundle;
             dstate = new Deployer.DeploymentState();
             dstate.bundles = new HashMap<>();


### PR DESCRIPTION
It would be useful for us to cherry pick this on Karaf 4.2.x line as well. Thanks