### PR TITLE
[KARAF-7220] Upgrade commons compress to 1.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <jaxb.version>2.3.3</jaxb.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-codec.version>1.15</commons-codec.version>
-        <commons-compress.version>1.20</commons-compress.version>
+        <commons-compress.version>1.21</commons-compress.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-fileupload.version>1.4</commons-fileupload.version>
         <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
Version 1.21 fixes a number of CVEs, see
https://commons.apache.org/proper/commons-compress/security-reports.html
for details.

The full release notes are at
https://commons.apache.org/proper/commons-compress/changes-report.html#a1.21

Signed-off-by: Stephen Kitt <skitt@redhat.com>