### PR TITLE
[KARAF-7222] Upgrade commons io to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-logging.version>1.2</commons-logging.version>
         <commons-pool2.version>2.6.2</commons-pool2.version>
-        <commons-io.version>2.10.0</commons-io.version>
+        <commons-io.version>2.11.0</commons-io.version>
         <eclipselink.version>2.7.8</eclipselink.version>
         <jasypt.bundle.version>1.9.3_1</jasypt.bundle.version>
         <jolokia.version>1.6.2</jolokia.version>


### PR DESCRIPTION
The full release notes are at
https://commons.apache.org/proper/commons-io/changes-report.html#a2.11.0

Signed-off-by: Stephen Kitt <skitt@redhat.com>