### PR TITLE
KARAF-7289 - Provide config property name completion using MetaType info

### DIFF
--- a/config/src/main/java/org/apache/karaf/config/core/impl/MetaServiceCaller.java
+++ b/config/src/main/java/org/apache/karaf/config/core/impl/MetaServiceCaller.java
@@ -21,10 +21,12 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.metatype.MetaTypeInformation;
 import org.osgi.service.metatype.MetaTypeService;
+import org.osgi.service.metatype.ObjectClassDefinition;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -65,5 +67,69 @@ public class MetaServiceCaller {
             }
             return pids1;
         });
+    }
+    
+    /**
+     * Attempts to find MetaType information for the specified PID and 
+     * invokes the supplied callback with the result of the search   
+     */
+    public static <T> T doWithMetaType(BundleContext context, String pid, Function<Optional<MetaInfo>, T> function) {
+        ServiceReference<MetaTypeService> ref = context.getServiceReference(MetaTypeService.class);
+        if (ref != null) {
+            try {
+                MetaTypeService metaService = context.getService(ref);
+                MetaInfo metaInfo = getMetatype(context, metaService, pid);
+                return function.apply(Optional.ofNullable(metaInfo));
+            } finally {
+                context.ungetService(ref);
+            }
+        }
+        return null;
+    }
+    
+    private static MetaInfo getMetatype(BundleContext context, MetaTypeService metaTypeService, String pid) {
+        if (metaTypeService != null) {
+            for (Bundle bundle : context.getBundles()) {
+                MetaTypeInformation info = metaTypeService.getMetaTypeInformation(bundle);
+                if (info == null) {
+                    continue;
+                }
+                String[] pids = info.getPids();
+                for (String cPid : pids) {
+                    if (cPid.equals(pid)) {
+                        return new MetaInfo(info.getObjectClassDefinition(cPid, null), false);
+                    }
+                }
+                pids = info.getFactoryPids();
+                for (String cPid : pids) {
+                    if (cPid.equals(pid)) {
+                        return new MetaInfo(info.getObjectClassDefinition(cPid, null), true);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+    
+    public static class MetaInfo {
+        private final ObjectClassDefinition definition;
+        private final boolean factory;
+        
+        MetaInfo(ObjectClassDefinition definition, boolean factory) {
+
+            this.definition = definition;
+            this.factory = factory;
+        }
+        
+        public ObjectClassDefinition getDefinition() {
+
+            return definition;
+        }
+        
+        public boolean isFactory() {
+
+            return factory;
+        }
+        
     }
 }


### PR DESCRIPTION
ConfigurationPropertyCompleter now uses the MetaType service to retrieve
configuration property names in addition to the ones already defined in
the configuration.

Adds an utility method in MetaServiceCaller to find MetaType info for a
specified PID. This method accepts a function to do something with the
result. MetaCommand is refactored to use this function.