### PR TITLE
[KARAF-7316] Support for standard maven coordinates.

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
@@ -47,6 +47,9 @@ import java.util.TreeSet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
@@ -546,7 +549,7 @@ public class VerifyMojo extends MojoSupport {
             } else {
                 String version = getVersion(distribution, "RELEASE");
                 String[] dist = distribution.split(":");
-                File distFile = resolver.resolve(dist[0], dist[1], null, "zip", version);
+                File distFile = resolveDistributionArtifact(version, dist);
                 String resolvedVersion = distFile.getName().substring(dist[1].length() + 1, distFile.getName().length() - 4);
                 String dir = distDir;
                 if (dir == null) {
@@ -589,6 +592,24 @@ public class VerifyMojo extends MojoSupport {
 
         final FakeBundleRevision resource = new FakeBundleRevision(headers, "system-bundle", 0l);
         return resource.getBundle();
+    }
+
+    private File resolveDistributionArtifact(String version, String[] dist) throws IOException {
+        // groupId:artifactId:type[:classifier]:version
+        BiFunction<String, String, String> fallback = (input, fbk) -> input == null || input.trim().isEmpty() ? fbk : input;
+        if (dist.length < 3) {
+            return resolver.resolve(dist[0], dist[1], "", "zip", version);
+        }
+        if (dist.length < 4) {
+            return resolver.resolve(dist[0], dist[1], "", fallback.apply(dist[2], "zip"), version);
+        }
+        if (dist.length < 5) {
+            return resolver.resolve(dist[0], dist[1], "", fallback.apply(dist[2], "zip"), fallback.apply(dist[3], version));
+        }
+        if (dist.length == 5) {
+            return resolver.resolve(dist[0], dist[1], fallback.apply(dist[3], ""), fallback.apply(dist[2], "zip"), fallback.apply(dist[4], version));
+        }
+        throw new IllegalArgumentException("Invalid distribution uri");
     }
 
 


### PR DESCRIPTION
This commit introduces very basic support for semi standard group:artifact:type[:classifier]:version syntax.
In case if all parts are given they take over computed values.
If version is missing - computed one is used.
If type is missing - zip is assumed.
If classifier is missing (which is common) empty string will be used.

This should simplify handling of basic feature verification projects.

Signed-off-by: Łukasz Dywicki <luke@code-house.org>