### PR TITLE
[KARAF-7317] Support spaces in boot features path

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/BootFeaturesInstaller.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/BootFeaturesInstaller.java
@@ -16,21 +16,15 @@
  */
 package org.apache.karaf.features.internal.service;
 
-import java.io.File;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.Hashtable;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.StringTokenizer;
-
 import org.apache.karaf.features.BootFinished;
 import org.apache.karaf.features.FeaturesService;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URI;
+import java.util.*;
 
 public class BootFeaturesInstaller {
 
@@ -119,6 +113,7 @@ public class BootFeaturesInstaller {
             repo = repo.trim();
             if (!repo.isEmpty()) {
                 repo = separatorsToUnix(repo);
+                repo = encodePath(repo);
                 try {
                     featuresService.addRepository(URI.create(repo));
                 } catch (Exception e) {
@@ -191,5 +186,19 @@ public class BootFeaturesInstaller {
             LOGGER.debug("Converted path to unix separators: {}", path);
         }
         return path;
+    }
+
+    /**
+     * Converts all invalid characters in a path to a format supported by {@link URI#create(String)}.
+     *
+     * @param path the path to encode, null ignored
+     * @return the encoded path
+     */
+    private String encodePath(String path) {
+        if (path == null) {
+            return null;
+        }
+
+        return path.replace(" ", "%20");
     }
 }


### PR DESCRIPTION
`URI.create(String)` throws a `URISyntaxException` if any of the resolved URIs from `featuresRepositories` contains a space.

This is common if customizing the boot features via the `karaf-maven-plugin`, then running the assembly from within a path containing spaces.

For example:

```xml
<plugin>
    <groupId>org.apache.karaf.tooling</groupId>
    <artifactId>karaf-maven-plugin</artifactId>
    <version>${karaf.version}</version>
    <configuration>
        <bootFeatures>
            <feature>standard</feature>
            <feature>my-feature</feature>
        </bootFeatures>
        ...
    </configuration>
</plugin>
```

will result in a new feature in `etc` as well as an entry in `etc/org.apache.karaf.features.cfg`:

```
featuresRepositories = file:${karaf.etc}/2b260482-45bc-427c-af65-8909c1f2f7a3.xml
```

However, if `karaf.etc` contains a space at runtime, Karaf fails to start because the URI cannot be parsed.

This PR simply replaces all spaces with `%20` before passing the path to `URI.create(String)`. The `encodePath` method can be further enhanced if other characters prove to be problematic.