### PR TITLE
[KARAF-7325] Support custom properties to simplify adjustment of assemblies

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/etc/config.properties
+++ b/assemblies/features/base/src/main/filtered-resources/resources/etc/config.properties
@@ -82,7 +82,8 @@ org.osgi.framework.system.packages= \
  org.apache.karaf.jaas.boot.principal;uses:=javax.security.auth;version="@@karaf.osgi.version@@",\
  org.apache.karaf.jaas.boot;uses:="javax.security.auth,javax.security.auth.callback,javax.security.auth.login,javax.security.auth.spi,org.osgi.framework";version="@@karaf.osgi.version@@",\
  org.apache.karaf.info;version="@@karaf.osgi.version@@",\
- ${jre-${java.specification.version}}
+ ${jre-${java.specification.version}},\
+ ${custom.org.osgi.framework.system.packages}
 
 #
 # Extra packages appended after standard packages
@@ -91,12 +92,14 @@ org.osgi.framework.system.packages.extra= \
  org.apache.karaf.branding, \
  sun.misc, \
  com.sun.jmx.remote.protocol, \
- com.sun.jmx.remote.protocol.jmxmp
+ com.sun.jmx.remote.protocol.jmxmp, \
+ ${custom.org.osgi.framework.system.packages.extra}
 
 org.osgi.framework.system.capabilities= \
  ${eecap-${java.specification.version}}, \
  ${${karaf.framework}-capabilities}, \
- ${karaf-capabilities}
+ ${karaf-capabilities}, \
+ ${custom-capabilities}
 
 karaf-capabilities= \
  osgi.service;objectClass:List<String>=org.apache.karaf.info.ServerInfo
@@ -185,7 +188,8 @@ org.osgi.framework.bootdelegation=\
       jdk.nashorn.*, \
       sun.*, \
       jdk.internal.reflect, \
-      jdk.internal.reflect.*
+      jdk.internal.reflect.*, \
+      ${custom.org.osgi.framework.bootdelegation}
 
 # jVisualVM support
 # in order to use Karaf with jvisualvm, the org.osgi.framework.bootdelegation property has to contain the org.netbeans.lib.profiler.server package
@@ -195,7 +199,7 @@ org.osgi.framework.bootdelegation=\
 #
 # YourKit support
 # in order to use Karaf with YourKit, the org.osgi.framework.bootdelegation property has to contain the com.yourkit.* packages
-# and, so, it should look like:
+# and, so, it should look like:
 #
 # org.osgi.framework.bootdelegation=org.apache.karaf.jaas.boot,org.apache.karaf.jaas.boot.principal,sun.*,com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,com.yourkit.*
 #

--- a/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
+++ b/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
@@ -17,6 +17,8 @@
 #
 ################################################################################
 
+${optionals} = custom.jre.properties
+
 #
 # Java platform package export properties.
 #
@@ -182,7 +184,8 @@ jre-1.6= \
  org.w3c.dom.xpath, \
  org.xml.sax, \
  org.xml.sax.ext, \
- org.xml.sax.helpers
+ org.xml.sax.helpers, \
+ ${custom.jre-1.6}
 
 # Standard package set.  Note that:
 #   - javax.transaction* is exported with a mandatory attribute
@@ -338,7 +341,8 @@ jre-1.7= \
  org.xml.sax, \
  org.xml.sax.ext, \
  org.xml.sax.helpers, \
- com.sun.nio.sctp
+ com.sun.nio.sctp, \
+ ${custom.jre-1.7}
 
 #
 # A note about javax.transaction and javax.transaction.xa packages in JDK8 and JDK9+
@@ -571,7 +575,8 @@ jre-1.8= \
  org.xml.sax, \
  org.xml.sax.ext, \
  org.xml.sax.helpers, \
- com.sun.nio.sctp
+ com.sun.nio.sctp, \
+ ${custom.jre-8}
 
 jre-9= \
  javax.accessibility, \
@@ -734,10 +739,11 @@ jre-9= \
  com.sun.security.sasl, \
  com.sun.security.sasl.digest, \
  com.sun.security.sasl.ntlm, \
- com.sun.security.sasl.util 
+ com.sun.security.sasl.util, \
+ ${custom.jre-9}
 
-jre-10 = ${jre-9}
-jre-11 = ${jre-10}
-jre-13 = ${jre-11}
-jre-14 = ${jre-13}
-jre-15 = ${jre-14}
+jre-10 = ${jre-9}, ${custom.jre-10}
+jre-11 = ${jre-10}, ${custom.jre-11}
+jre-13 = ${jre-11}, ${custom.jre-13}
+jre-14 = ${jre-13}, ${custom.jre-14}
+jre-15 = ${jre-14}, ${custom.jre-15}

--- a/main/src/main/java/org/apache/karaf/main/ConfigProperties.java
+++ b/main/src/main/java/org/apache/karaf/main/ConfigProperties.java
@@ -28,12 +28,11 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.UUID;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.apache.felix.utils.properties.Properties;
 
 import org.apache.karaf.main.lock.SimpleFileLock;
 import org.apache.karaf.main.util.Utils;
+import org.apache.karaf.util.config.ConfigPropertyUtil;
 import org.apache.karaf.util.config.PropertiesLoader;
 import org.osgi.framework.Constants;
 
@@ -274,8 +273,7 @@ public class ConfigProperties {
     private void cleanup(Properties props, String key) {
         String propertyValue = props.get(key);
         if (propertyValue != null) {
-            String cleanedUp = propertyValue.trim().replaceAll(",\\s*", ",").replaceAll(",+", ",").replaceAll(",+$", "");
-            props.put(key, cleanedUp);
+            props.put(key, ConfigPropertyUtil.cleanupEmptyCommas(propertyValue));
         }
     }
 

--- a/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
+++ b/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
@@ -97,6 +97,7 @@ import org.apache.karaf.tools.utils.KarafPropertiesEditor;
 import org.apache.karaf.tools.utils.model.KarafPropertyEdits;
 import org.apache.karaf.util.ThreadUtils;
 import org.apache.karaf.util.Version;
+import org.apache.karaf.util.config.ConfigPropertyUtil;
 import org.apache.karaf.util.config.PropertiesLoader;
 import org.apache.karaf.util.maven.Parser;
 import org.ops4j.pax.url.mvn.MavenResolver;
@@ -2207,7 +2208,7 @@ public class Builder {
         if (configProps.containsKey(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA)) {
             exportPackages += "," + configProps.getProperty(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA);
         }
-        exportPackages = exportPackages.trim().replaceAll(",\\s*", ",").replaceAll(",+", ",").replaceAll(",+$", "");
+        exportPackages = ConfigPropertyUtil.cleanupEmptyCommas(exportPackages);
         attributes.putValue(Constants.EXPORT_PACKAGE, exportPackages);
 
         String systemCaps = configProps.getProperty(Constants.FRAMEWORK_SYSTEMCAPABILITIES, "");

--- a/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
+++ b/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
@@ -2207,7 +2207,7 @@ public class Builder {
         if (configProps.containsKey(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA)) {
             exportPackages += "," + configProps.getProperty(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA);
         }
-        exportPackages = exportPackages.replaceAll(",\\s*,", ",");
+        exportPackages = exportPackages.trim().replaceAll(",\\s*", ",").replaceAll(",+", ",").replaceAll(",+$", "");
         attributes.putValue(Constants.EXPORT_PACKAGE, exportPackages);
 
         String systemCaps = configProps.getProperty(Constants.FRAMEWORK_SYSTEMCAPABILITIES, "");

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
@@ -576,7 +576,7 @@ public class VerifyMojo extends MojoSupport {
         if (configProps.containsKey("org.osgi.framework.system.packages.extra")) {
             exportPackages += "," + configProps.getProperty("org.osgi.framework.system.packages.extra");
         }
-        exportPackages = exportPackages.replaceAll(",\\s*,", ",");
+        exportPackages = exportPackages.trim().replaceAll(",\\s*", ",").replaceAll(",+", ",").replaceAll(",+$", "");
         attributes.putValue(Constants.EXPORT_PACKAGE, exportPackages);
 
         String systemCaps = configProps.getProperty("org.osgi.framework.system.capabilities");

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
@@ -91,6 +91,7 @@ import org.apache.karaf.profile.assembly.CustomDownloadManager;
 import org.apache.karaf.tooling.utils.MavenUtil;
 import org.apache.karaf.tooling.utils.MojoSupport;
 import org.apache.karaf.tooling.utils.ReactorMavenResolver;
+import org.apache.karaf.util.config.ConfigPropertyUtil;
 import org.apache.karaf.util.config.PropertiesLoader;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -576,7 +577,7 @@ public class VerifyMojo extends MojoSupport {
         if (configProps.containsKey("org.osgi.framework.system.packages.extra")) {
             exportPackages += "," + configProps.getProperty("org.osgi.framework.system.packages.extra");
         }
-        exportPackages = exportPackages.trim().replaceAll(",\\s*", ",").replaceAll(",+", ",").replaceAll(",+$", "");
+        exportPackages = ConfigPropertyUtil.cleanupEmptyCommas(exportPackages);
         attributes.putValue(Constants.EXPORT_PACKAGE, exportPackages);
 
         String systemCaps = configProps.getProperty("org.osgi.framework.system.capabilities");

--- a/util/src/main/java/org/apache/karaf/util/config/ConfigPropertyUtil.java
+++ b/util/src/main/java/org/apache/karaf/util/config/ConfigPropertyUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.util.config;
+
+/**
+ * A small helper to cut off messy configuration properties which need to stay clean.
+ */
+public class ConfigPropertyUtil {
+
+  /**
+   * Make sure property value does not have empty values nor extra comma at the end.
+   */
+  public static String cleanupEmptyCommas(String propertyValue) {
+    if (propertyValue == null) {
+      return null;
+    }
+
+    return propertyValue.trim()
+        .replaceAll(",\\s*", ",")
+        .replaceAll(",+", ",")
+        .replaceAll(",+$", "");
+  }
+
+}


### PR DESCRIPTION
I've made a small adjustments in regular expressions, in all places I found related to it, so they work properly with additional properties mentioned in KARAF-7325.

All integration tests pass without failure meaning that change should be harmless to standardized deployments while opening window of opportunity to everyone who needs a slight adjustment of boot packages, system packages or custom capabilities. This should also allow a simpler patching of jre properties for these who need such thing.