### PR TITLE
[KARAF-7389] Prevent two threads (feature installer, CM Event Dispatc…

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
@@ -137,10 +137,10 @@ public class FeatureConfigInstaller {
                     cfg = createConfiguration(configAdmin, cid);
                     cfgProps.put(CONFIG_KEY, cid.pid);
                     properties.put(CONFIG_KEY, cid.pid);
+                    cfg.update(cfgProps);
                     if (storage != null && configCfgStore) {
                         cfgProps.put(FILEINSTALL_FILE_NAME, cfgFile.getAbsoluteFile().toURI().toString());
                     }
-                    cfg.update(cfgProps);
                     try {
                         updateStorage(cid, properties, false, jsonFormat);
                     } catch (Exception e) {
@@ -325,11 +325,13 @@ public class FeatureConfigInstaller {
         if (storage != null && configCfgStore) {
             File cfgFile = getConfigFile(cid, jsonFormat);
             if (!cfgFile.exists()) {
+                File tmpCfgFile = File.createTempFile(cfgFile.getName(), ".tmp", cfgFile.getParentFile());
                 if (jsonFormat) {
-                    Configurations.buildWriter().build(new FileWriter(cfgFile)).writeConfiguration(convertToDict(props));
+                    Configurations.buildWriter().build(new FileWriter(tmpCfgFile)).writeConfiguration(convertToDict(props));
                 } else {
-                    props.save(cfgFile);
+                    props.save(tmpCfgFile);
                 }
+                tmpCfgFile.renameTo(cfgFile);
             } else {
                 updateExistingConfig(props, append, cfgFile, jsonFormat);
             }


### PR DESCRIPTION
…her through fileinstall) writing the same config file.

This works for my case, however it's very hard to provide unit test for this.

1. CM update happens without `felix.fileinstall.filename`, so FileInstall won't try to read and write the file in CM_UPDATED listener when `org.osgi.service.cm.Configuration#update()` is called
2. `updateStorage()` is called with tmp file, highly minimizing the risk that FileInstall's `org.apache.felix.fileinstall.internal.DirectoryWatcher#install()` will be called with empty (or partial) file