### PR TITLE
Bump Spring52 and Spring53 to mitigate CVE-2022-22965 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,7 @@
         <spring.osgi.version>1.2.1</spring.osgi.version>
         <spring31.version>3.1.4.RELEASE</spring31.version>
         <spring43.version>4.3.30.RELEASE_1</spring43.version>
-        <spring52.version>5.2.13.RELEASE_1</spring52.version>
+        <spring52.version>5.2.20.RELEASE_1</spring52.version>
         <spring53.version>5.3.18_1</spring53.version>
         <spring.security31.version>3.1.4.RELEASE</spring.security31.version>
         <spring.security42.version>4.2.4.RELEASE_1</spring.security42.version>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
         <spring31.version>3.1.4.RELEASE</spring31.version>
         <spring43.version>4.3.30.RELEASE_1</spring43.version>
         <spring52.version>5.2.13.RELEASE_1</spring52.version>
-        <spring53.version>5.3.14_1</spring53.version>
+        <spring53.version>5.3.18_1</spring53.version>
         <spring.security31.version>3.1.4.RELEASE</spring.security31.version>
         <spring.security42.version>4.2.4.RELEASE_1</spring.security42.version>
         <spring.security51.version>5.1.5.RELEASE_1</spring.security51.version>


### PR DESCRIPTION
Updating Spring53 and Spring52 due to CVE-2022-22965 

See details: https://tanzu.vmware.com/security/cve-2022-22965