### PR TITLE
update pax logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
 
         <pax.cdi.version>1.1.4</pax.cdi.version>
         <pax.exam.version>4.13.4</pax.exam.version>
-        <pax.logging.version>1.11.13</pax.logging.version>
+        <pax.logging.version>1.11.15</pax.logging.version>
         <pax.base.version>1.5.1</pax.base.version>
         <pax.swissbox.version>1.8.4</pax.swissbox.version>
         <pax.url.version>2.6.10</pax.url.version>


### PR DESCRIPTION
To fix Vulnerabilities from dependencies: 
[CVE-2022-23305](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23305)
[CVE-2022-23302](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23302)
[CVE-2021-4104](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4104)
[CVE-2019-17571](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17571)
