### PR TITLE
K8s static-dist.yaml has leftovers

### DIFF
--- a/examples/karaf-docker-example/karaf-docker-example-static-dist/k8s/karaf-docker-example-static-dist.yaml
+++ b/examples/karaf-docker-example/karaf-docker-example-static-dist/k8s/karaf-docker-example-static-dist.yaml
@@ -28,4 +28,3 @@ spec:
         requests:
           memory: "250Mi"
       command: ["karaf", "run"]
-      args: ["--vm", "1", "--vm-bytes", "250M", "--vm-hang", "1"]


### PR DESCRIPTION
The arguments line seems to be from a test container using the “polinux/stress” container, they have no meaning for Karaf.

It would probably be possible to move “run” to the args array, but since I am not sure if it still uses /bin/sh -c in that case, I did not modify it.