### PR TITLE
Propose docker run commands with clean up tag in manual

### DIFF
--- a/manual/src/main/asciidoc/user-guide/docker.adoc
+++ b/manual/src/main/asciidoc/user-guide/docker.adoc
@@ -68,14 +68,13 @@ docker build --build-arg KARAF_VERSION=4.2.0 -t "karaf:4.2.0" karaf
 * Run Karaf in interactive mode (using Karaf official docker image):
 
 ----
-docker run -i -t --name karaf apache/karaf:latest karaf
+docker run -it --rm --name karaf apache/karaf:latest karaf
 ----
-
 
 * Run Karaf without interaction but log displayed (using Karaf official docker image):
 
 ----
-docker run --name karaf apache/karaf:latest
+docker run --rm --name karaf apache/karaf:latest
 ----
 
 * Kill Karaf


### PR DESCRIPTION
## Motivation

When working with Docker it is important to ensure that once over everything is properly cleaned up otherwise it quickly gets space consuming

## Modification

* Add the clean up flag to the docker run commands in the manual