### PR TITLE
[KARAF-1381] - store karaf command history separately for each instance

### DIFF
--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/ConsoleSessionImpl.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/ConsoleSessionImpl.java
@@ -299,7 +299,12 @@ public class ConsoleSessionImpl implements Session {
      * @return the history file
      */
     protected Path getHistoryFile() {
-        String defaultHistoryPath = new File(System.getProperty("user.home"), ".karaf/karaf.history").toString();
+        String instanceName = System.getProperty("karaf.name", "root");
+        String historyFilePath = ".karaf/karaf.history";
+        if (!instanceName.equals("root")) {
+            historyFilePath += ("." + instanceName);
+        }
+        String defaultHistoryPath = new File(System.getProperty("user.home"), historyFilePath).toString();
         return Paths.get(System.getProperty("karaf.history", defaultHistoryPath));
     }
 


### PR DESCRIPTION
With this change (unless overriden via system properties for a given instance): 
- `/home/user/.karaf/karaf.history` becomes `/home/user/.karaf/karaf.history.root`,
- then each instance has its own history stored in `/home/user/.karaf/karaf.history.{instanceName}`.