### PR TITLE
[KARAF-7580] Prevent StringIndexOutOfBoundsException on help with new…

### DIFF
--- a/shell/core/src/main/java/org/apache/karaf/shell/support/table/Row.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/support/table/Row.java
@@ -81,7 +81,7 @@ public class Row {
                     st2.append(StringUtil.repeat(" ", cols.get(col).getSize()));
                 }
             }
-            while (st2.charAt(st2.length() - 1) == ' ') {
+            while (st2.length() > 0 && st2.charAt(st2.length() - 1) == ' ') {
                 st2.setLength(st2.length() - 1);
             }
             st.append(st2);


### PR DESCRIPTION
…lines

Avoids
java.lang.StringIndexOutOfBoundsException: index -1, length 0
    at java.lang.String.checkIndex(String.java:4563) ~[?:?]
    at java.lang.AbstractStringBuilder.charAt(AbstractStringBuilder.java:351) ~[?:?]
    at java.lang.StringBuilder.charAt(StringBuilder.java:91) ~[?:?]
    at org.apache.karaf.shell.support.table.Row.getContent(Row.java:84) ~[?:?]
    at org.apache.karaf.shell.support.table.ShellTable.print(ShellTable.java:151) ~[?:?]
    at org.apache.karaf.shell.support.table.ShellTable.print(ShellTable.java:111) ~[?:?]
    at org.apache.karaf.shell.impl.console.commands.help.CommandListHelpProvider.printMethodList(CommandListHelpProvider.java:167) ~[?:?]