### PR TITLE
[KARAF-6017] - added cache facade

### DIFF
--- a/assemblies/features/standard/pom.xml
+++ b/assemblies/features/standard/pom.xml
@@ -367,6 +367,23 @@
             <scope>provided</scope>
         </dependency>
 
+         <!-- cache deps -->
+        <dependency>
+            <groupId>org.apache.karaf.cache</groupId>
+            <artifactId>org.apache.karaf.cache.api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+         <dependency>
+            <groupId>org.apache.karaf.cache</groupId>
+            <artifactId>org.apache.karaf.cache.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+         <dependency>
+            <groupId>org.apache.karaf.cache</groupId>
+            <artifactId>org.apache.karaf.cache.commands</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- eventadmin deps -->
         <dependency>
             <groupId>org.apache.karaf.services</groupId>

--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -1671,6 +1671,18 @@ jul.layout.type = simple
         </config>
     </feature>
 
+    <feature name="cache" description="Provides a simple JSR107 based caching facade" version="${project.version}">
+        <feature>scr</feature>
+        <bundle>mvn:javax.cache/cache-api/${spec.javax.cache-api.version}</bundle>
+        <bundle>mvn:org.ehcache/ehcache/${ehcache.version}</bundle>
+        <bundle>mvn:org.apache.karaf.cache/org.apache.karaf.cache.api/${project.version}</bundle>
+        <bundle>mvn:org.apache.karaf.cache/org.apache.karaf.cache.core/${project.version}</bundle>
+        <conditional>
+            <condition>shell</condition>
+            <bundle>mvn:org.apache.karaf.cache/org.apache.karaf.cache.commands/${project.version}</bundle>
+        </conditional>
+    </feature>
+
     <feature name="documentation" description="Documentation of Karaf project in HTML" version="${project.version}">
         <feature>pax-web-war</feature>
         <bundle>mvn:org.apache.karaf/manual/${project.version}</bundle>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -435,6 +435,22 @@
                 <version>${project.version}</version>
             </dependency>
 
+             <dependency>
+                <groupId>org.apache.karaf.cache</groupId>
+                <artifactId>org.apache.karaf.cache.api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+             <dependency>
+                <groupId>org.apache.karaf.cache</groupId>
+                <artifactId>org.apache.karaf.cache.core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+             <dependency>
+                <groupId>org.apache.karaf.cache</groupId>
+                <artifactId>org.apache.karaf.cache.commands</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.apache.karaf.services</groupId>
                 <artifactId>org.apache.karaf.services.staticcm</artifactId>
@@ -1599,6 +1615,11 @@
                 <artifactId>istack-commons-runtime</artifactId>
                 <version>3.0.10</version>
             </dependency>
+             <dependency>
+                <groupId>org.ehcache</groupId>
+                <artifactId>ehcache</artifactId>
+                <version>${ehcache.version}</version>
+            </dependency>
 
             <!-- specs -->
             <dependency>
@@ -1641,6 +1662,12 @@
                 <artifactId>jakarta.mail-api</artifactId>
                 <version>${spec.mail.version}</version>
             </dependency>
+             <dependency>
+                <groupId>javax.cache</groupId>
+                <artifactId>cache-api</artifactId>
+                <version>${spec.javax.cache-api.version}</version>
+            </dependency>
+            
         </dependencies>
     </dependencyManagement>
 

--- a/cache/api/pom.xml
+++ b/cache/api/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <!--
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <parent>
+        <artifactId>cache</artifactId>
+        <groupId>org.apache.karaf.cache</groupId>
+        <version>4.4.3-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.apache.karaf.cache.api</artifactId>
+    <name>Apache Karaf :: Cache :: API</name>
+
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/cache/api/src/main/java/org/apache/karaf/cache/api/CacheService.java
+++ b/cache/api/src/main/java/org/apache/karaf/cache/api/CacheService.java
@@ -1,0 +1,89 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.api;
+
+import javax.cache.Cache;
+import javax.cache.configuration.Configuration;
+import java.net.URL;
+import java.util.List;
+
+/**
+ * A simple caching facade that lets use caching using JSR 107 APIs.
+ */
+public interface CacheService {
+
+    /**
+     * Creates a new cache.
+     * @param name name of the cache to create
+     * @param configuration cache configuration, such as its key and value type.
+     *                      Specific configurations (such as max size and caching duration)
+     *                      will depend on the cache provider.
+     * @param <K> type of cache keys, e.g. Long or String
+     * @param <V> type of cache values, e.g. Long or String
+     */
+    <K, V> void createCache(String name, Configuration<K, V> configuration);
+
+    /**
+     * Creates a new cache from a configuration file (located in Karaf's etc directory).
+     * @param configFile config file
+     * @param classLoader class loader can be passed in case the cache complex custom keys and/or values
+     */
+    void createCache(URL configFile, ClassLoader classLoader);
+
+    /**
+     * Get a single cached value by providing cache's name and a key.
+     * @param name name of the cache to get the value from
+     * @param key key of the cached item
+     * @param <K> cache key type
+     * @param <V> cache value type
+     * @return
+     */
+    <K, V> V get(String name, K key);
+
+    /**
+     * Store a new value in a cache.
+     * @param name name of the cache to put new value into
+     * @param key key under which the value will be cached
+     * @param value value to cache
+     * @param <K> cache key type
+     * @param <V> cache value type
+     */
+    <K, V> void put(String name, K key, V value);
+
+    /**
+     * Get the cache object directly.
+     * @param name name of the cache
+     * @param <K> cache key type
+     * @param <V> cache value type
+     * @return
+     */
+    <K, V> Cache<K, V> getCache(String name);
+
+    /**
+     * Invalidates a cache.
+     * @param name name of the cache to invalidate
+     */
+    void invalidateCache(String name);
+
+    /**
+     * Lists all available caches by their names.
+     * @return list of cache names
+     */
+    List<String> listCaches();
+}

--- a/cache/commands/pom.xml
+++ b/cache/commands/pom.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <!--
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+    <!--
         Licensed to the Apache Software Foundation (ASF) under one or more
         contributor license agreements.  See the NOTICE file distributed with
         this work for additional information regarding copyright ownership.
@@ -17,54 +19,45 @@
         See the License for the specific language governing permissions and
         limitations under the License.
     -->
-
-    <modelVersion>4.0.0</modelVersion>
-
     <parent>
-        <groupId>org.apache.karaf.examples</groupId>
-        <artifactId>karaf-graphql-example</artifactId>
+        <artifactId>cache</artifactId>
+        <groupId>org.apache.karaf.cache</groupId>
         <version>4.4.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <name>Apache Karaf :: Cache :: Commands</name>
 
-    <artifactId>karaf-graphql-example-commands</artifactId>
-    <name>Apache Karaf :: Examples :: GraphQL :: Shell Commands</name>
+    <artifactId>org.apache.karaf.cache.commands</artifactId>
+
     <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.cache</groupId>
+            <artifactId>org.apache.karaf.cache.api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.graphql-java</groupId>
-            <artifactId>graphql-java</artifactId>
-            <version>19.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.service.component.annotations</artifactId>
-            <version>1.4.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.karaf.examples</groupId>
-            <artifactId>karaf-graphql-example-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.annotation</artifactId>
-            <version>8.0.0</version>
-            <scope>provided</scope>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-services-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
                 <configuration>
                     <instructions>
                         <Karaf-Commands>*</Karaf-Commands>
@@ -73,5 +66,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/CacheCommandSupport.java
+++ b/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/CacheCommandSupport.java
@@ -1,0 +1,76 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.core.commands;
+
+import org.apache.karaf.cache.api.CacheService;
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+
+import javax.cache.Cache;
+import javax.cache.configuration.Configuration;
+
+public abstract class CacheCommandSupport implements Action
+{
+
+    @Reference
+    private CacheService cacheService;
+
+    @Override
+    public Object execute() throws Exception
+    {
+        if (cacheService == null) {
+            throw new IllegalStateException("CacheService not found");
+        }
+        return doExecute(cacheService);
+    }
+
+    protected abstract Object doExecute(CacheService cacheService) throws Exception;
+
+    @SuppressWarnings("unchecked")
+    protected Object castKey(String cacheName, Object key) {
+        Cache cache = cacheService.getCache(cacheName);
+        if (cache == null) {
+            throw new IllegalArgumentException("Cache " + cacheName + " not found!");
+        }
+        return cast(key, cacheService.getCache(cacheName).getConfiguration(Configuration.class).getKeyType());
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Object castValue(String cacheName, Object value) {
+        return cast(value, cacheService.getCache(cacheName).getConfiguration(Configuration.class).getValueType());
+    }
+
+    private Object cast(Object argument, Class type)
+    {
+        if (type.equals(Short.class)) {
+            return Short.parseShort((String) argument);
+        }
+        if (type.equals(Integer.class)) {
+            return Integer.parseInt((String) argument);
+        }
+        if (type.equals(Long.class)) {
+            return Long.parseLong((String) argument);
+        }
+        if (type.equals(Boolean.class)) {
+            return Boolean.parseBoolean((String) argument);
+        }
+
+        return argument;
+    }
+}

--- a/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/Create.java
+++ b/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/Create.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.core.commands;
+
+import org.apache.karaf.cache.api.CacheService;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Paths;
+
+@Service
+@Command(scope = "cache",
+        name = "create",
+        description = "Create a new cache from XML config.")
+public class Create extends CacheCommandSupport {
+    @Argument(index = 0,
+            required = true,
+            description = "Path to ehcache xml configuration file in Karaf's etc directory")
+    String configPath;
+
+    @Override
+    protected Object doExecute(CacheService cacheService) {
+        try {
+            URL configUrl = Paths.get(System.getProperty("karaf.etc"), configPath).toUri().toURL();
+            cacheService.createCache(configUrl, this.getClass().getClassLoader());
+        } catch (MalformedURLException e) {
+            System.err.println(e);
+        }
+
+        return null;
+    }
+}

--- a/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/Get.java
+++ b/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/Get.java
@@ -1,0 +1,43 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.core.commands;
+
+import org.apache.karaf.cache.api.CacheService;
+import org.apache.karaf.cache.core.commands.completers.CacheNameCompleter;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Completion;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+
+@Service
+@Command(scope = "cache", name = "get", description = "Get a single value from a given cache.")
+public class Get extends CacheCommandSupport {
+
+    @Argument(index = 0, required = true, description = "Name of the cache to access.")
+    @Completion(CacheNameCompleter.class)
+    String cacheName;
+
+    @Argument(index = 1, required = true, description = "Key storing the value that we wish to check.")
+    Object key;
+
+    @Override
+    public Object doExecute(CacheService cacheService) throws Exception {
+        return "" + cacheService.get(cacheName, castKey(cacheName, key));
+    }
+}

--- a/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/Invalidate.java
+++ b/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/Invalidate.java
@@ -1,0 +1,41 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.core.commands;
+
+import org.apache.karaf.cache.api.CacheService;
+import org.apache.karaf.cache.core.commands.completers.CacheNameCompleter;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Completion;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+
+@Service
+@Command(scope = "cache", name = "invalidate", description = "Invalidates a cache identified by the provided name.")
+public class Invalidate extends CacheCommandSupport {
+
+    @Argument(index = 0, required = true)
+    @Completion(CacheNameCompleter.class)
+    String cacheName;
+
+    @Override
+    public Object doExecute(CacheService cacheService) throws Exception {
+        cacheService.invalidateCache(cacheName);
+        return cacheName + " invalidated";
+    }
+}

--- a/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/ListCaches.java
+++ b/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/ListCaches.java
@@ -1,0 +1,33 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.core.commands;
+
+import org.apache.karaf.cache.api.CacheService;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+
+@Service
+@Command(scope = "cache", name = "list", description = "Lists all available cache names.")
+public class ListCaches extends CacheCommandSupport {
+
+    @Override
+    public Object doExecute(CacheService cacheService) throws Exception {
+        return cacheService.listCaches();
+    }
+}

--- a/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/Put.java
+++ b/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/Put.java
@@ -1,0 +1,47 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.core.commands;
+
+import org.apache.karaf.cache.api.CacheService;
+import org.apache.karaf.cache.core.commands.completers.CacheNameCompleter;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Completion;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+
+@Service
+@Command(scope = "cache", name = "put", description = "Stores a new value in a cache.")
+public class Put extends CacheCommandSupport {
+
+    @Argument(index = 0, required = true, description = "Name of the cache.")
+    @Completion(CacheNameCompleter.class)
+    String cacheName;
+
+    @Argument(index = 1, required = true, description = "Key under which the value will be stored.")
+    Object key;
+
+    @Argument(index = 2, required = true, description = "Value to cache.")
+    Object value;
+
+    @Override
+    public Object doExecute(CacheService cacheService) throws Exception {
+        cacheService.put(cacheName, castKey(cacheName, key), castValue(cacheName, value));
+        return null;
+    }
+}

--- a/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/completers/CacheNameCompleter.java
+++ b/cache/commands/src/main/java/org/apache/karaf/cache/core/commands/completers/CacheNameCompleter.java
@@ -1,0 +1,50 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.core.commands.completers;
+
+import org.apache.karaf.cache.api.CacheService;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.api.console.CommandLine;
+import org.apache.karaf.shell.api.console.Completer;
+import org.apache.karaf.shell.api.console.Session;
+import org.apache.karaf.shell.support.completers.StringsCompleter;
+
+import java.util.List;
+
+@Service
+public class CacheNameCompleter implements Completer {
+
+    @Reference
+    CacheService cacheService;
+
+    @Override
+    public int complete(Session session, CommandLine commandLine, List<String> candidates) {
+        StringsCompleter delegate = new StringsCompleter();
+        try {
+            for (String cache : cacheService.listCaches()) {
+                delegate.getStrings().add(cache);
+            }
+        } catch (Exception e) {
+            // nothing to do
+        }
+
+        return delegate.complete(session, commandLine, candidates);
+    }
+}

--- a/cache/core/pom.xml
+++ b/cache/core/pom.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <!--
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+    <!--
         Licensed to the Apache Software Foundation (ASF) under one or more
         contributor license agreements.  See the NOTICE file distributed with
         this work for additional information regarding copyright ownership.
@@ -17,45 +19,45 @@
         See the License for the specific language governing permissions and
         limitations under the License.
     -->
-
-    <modelVersion>4.0.0</modelVersion>
-
     <parent>
-        <groupId>org.apache.karaf.examples</groupId>
-        <artifactId>karaf-graphql-example</artifactId>
+        <artifactId>cache</artifactId>
+        <groupId>org.apache.karaf.cache</groupId>
         <version>4.4.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <name>Apache Karaf :: Cache :: Core</name>
 
-    <artifactId>karaf-graphql-example-commands</artifactId>
-    <name>Apache Karaf :: Examples :: GraphQL :: Shell Commands</name>
     <packaging>bundle</packaging>
+
+    <artifactId>org.apache.karaf.cache.core</artifactId>
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.karaf.shell</groupId>
-            <artifactId>org.apache.karaf.shell.core</artifactId>
+            <groupId>org.apache.karaf.cache</groupId>
+            <artifactId>org.apache.karaf.cache.api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.graphql-java</groupId>
-            <artifactId>graphql-java</artifactId>
-            <version>19.2</version>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.service.component.annotations</artifactId>
-            <version>1.4.0</version>
+            <artifactId>osgi.core</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.karaf.examples</groupId>
-            <artifactId>karaf-graphql-example-api</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.apache.karaf</groupId>
+            <artifactId>org.apache.karaf.util</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.annotation</artifactId>
-            <version>8.0.0</version>
+            <artifactId>org.osgi.service.cm</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -63,15 +65,23 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-services-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Karaf-Commands>*</Karaf-Commands>
+                        <Private-Package>
+                            org.apache.karaf.util.tracker,
+                            org.apache.karaf.util,
+                            org.apache.karaf.util.tracker.annotation
+                        </Private-Package>
                     </instructions>
                 </configuration>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/cache/core/src/main/java/org/apache/karaf/cache/core/Activator.java
+++ b/cache/core/src/main/java/org/apache/karaf/cache/core/Activator.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.core;
+
+import org.apache.karaf.cache.api.CacheService;
+import org.apache.karaf.util.tracker.BaseActivator;
+import org.apache.karaf.util.tracker.annotation.ProvideService;
+import org.apache.karaf.util.tracker.annotation.Services;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.service.cm.ManagedService;
+
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Services(provides = @ProvideService(CacheService.class))
+public class Activator extends BaseActivator implements ManagedService {
+
+    private EhcacheService ehcacheService;
+
+    @Override
+    protected void doStart() {
+        logger.info("Cache bundle starting..");
+        setUpEhcacheClassloading();
+        CachingProvider provider = Caching.getCachingProvider();
+        ehcacheService = new EhcacheService(provider.getCacheManager());
+        register(CacheService.class, ehcacheService);
+        logger.info("Cache bundle started!");
+    }
+
+    /**
+     * Tells JSR 107 where the implementation by its classloader to the ehcache bundle,
+     * otherwise Caching.getCachingProvider() throws an exception saying that it couldn't find any providers
+     *
+     */
+    private void setUpEhcacheClassloading() {
+        logger.debug("Replacing JSR 107 classloader with the ehcache bundle");
+        Optional<Bundle> ehcacheBundleOpt = Arrays.asList(bundleContext.getBundles()).stream()
+                .filter(bundle -> bundle.getSymbolicName().equals("org.ehcache"))
+                .findFirst();
+        if (ehcacheBundleOpt.isPresent()) {
+            Bundle ehcacheBundle = ehcacheBundleOpt.get();
+            BundleWiring bundleWiring = ehcacheBundle.adapt(BundleWiring.class);
+            ClassLoader classLoader = bundleWiring.getClassLoader();
+            Caching.setDefaultClassLoader(classLoader);
+        } else {
+            throw new IllegalStateException("No ehcache bundle found!");
+        }
+    }
+
+    @Override
+    protected void doStop() {
+        super.doStop();
+        ehcacheService = null;
+    }
+}

--- a/cache/core/src/main/java/org/apache/karaf/cache/core/EhcacheService.java
+++ b/cache/core/src/main/java/org/apache/karaf/cache/core/EhcacheService.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.core;
+
+import org.apache.karaf.cache.api.CacheService;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.ehcache.xml.XmlConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.Configuration;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of CacheService based on Ehcache.
+ */
+public class EhcacheService implements CacheService {
+
+    private final CacheManager cacheManager;
+    private final Logger logger = LoggerFactory.getLogger(EhcacheService.class);
+
+    public EhcacheService(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    @Override
+    public <K, V> void createCache(String name, Configuration<K, V> configuration) {
+        cacheManager.createCache(name, configuration);
+    }
+
+    @Override
+    public void createCache(URL configFile, ClassLoader classLoader) {
+        XmlConfiguration xmlConfiguration = new XmlConfiguration(configFile, classLoader);
+        Map<String, CacheConfiguration<?, ?>> configurationMap = xmlConfiguration.getCacheConfigurations();
+        configurationMap.forEach(
+                (name, config) -> createCache(name, Eh107Configuration.fromEhcacheCacheConfiguration(config)));
+        logger.info("Loaded ehcache xml configuration from " + configFile);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K, V> V get(String name, K key) {
+        return (V) getCache(name).get(key);
+    }
+
+    @Override
+    public <K, V> void put(String name, K key, V value) {
+        cacheManager.getCache(name).put(key, value);
+    }
+
+    @Override
+    public <K, V> Cache<K, V> getCache(String name) {
+        return cacheManager.getCache(name);
+    }
+
+    @Override
+    public void invalidateCache(String name) {
+        cacheManager.destroyCache(name);
+    }
+
+    @Override
+    public List<String> listCaches() {
+        List<String> cacheNames = new ArrayList<>();
+        cacheManager.getCacheNames().iterator().forEachRemaining(cacheNames::add);
+        return cacheNames;
+    }
+}

--- a/cache/core/src/test/java/org/apache/karaf/cache/core/EhcacheServiceTest.java
+++ b/cache/core/src/test/java/org/apache/karaf/cache/core/EhcacheServiceTest.java
@@ -1,0 +1,159 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.core;
+
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.ehcache.config.ResourcePools;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.Configuration;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(EasyMockRunner.class)
+public class EhcacheServiceTest {
+
+    @Mock
+    private CacheManager cacheManager;
+
+    @Test
+    public void testCreateCacheWithConfigurationObject() {
+        String cacheName = "Test";
+        Cache<String, Long> cache = mock(Cache.class);
+
+        ResourcePools pools = ResourcePoolsBuilder.heap(100).build();
+        Configuration<String, Long> configuration = Eh107Configuration.fromEhcacheCacheConfiguration(
+                CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, Long.class, pools).build());
+        expect(cacheManager.createCache(cacheName, configuration)).andReturn(cache);
+
+        replay(cacheManager, cache);
+
+        EhcacheService ehcacheService = new EhcacheService(cacheManager);
+
+        ehcacheService.createCache(cacheName, configuration);
+
+        verify(cacheManager, cache);
+    }
+
+    @Test
+    public void testCreateCacheWithConfigurationUrl() {
+        String cacheName = "TestCache";
+        URL configFile = getClass().getResource("/test-cache-config.xml");
+
+        Cache<Object, Object> cache = mock(Cache.class);
+        expect(cacheManager.createCache(eq(cacheName), anyObject(Configuration.class)))
+                .andReturn(cache);
+
+        replay(cacheManager, cache);
+
+        EhcacheService ehcacheService = new EhcacheService(cacheManager);
+
+        ehcacheService.createCache(configFile, this.getClass().getClassLoader());
+
+        verify(cacheManager);
+    }
+
+    @Test
+    public void testListCaches() {
+        List<String> cacheNames = Arrays.asList("C1", "C2");
+        expect(cacheManager.getCacheNames()).andReturn(cacheNames);
+
+        replay(cacheManager);
+
+        EhcacheService ehcacheService = new EhcacheService(cacheManager);
+        List<String> caches = ehcacheService.listCaches();
+        assertEquals(cacheNames, caches);
+    }
+
+    @Test
+    public void testInvalidateCache() {
+        String cacheName = "Test";
+        cacheManager.destroyCache(cacheName);
+        expectLastCall();
+
+        replay(cacheManager);
+
+        EhcacheService ehcacheService = new EhcacheService(cacheManager);
+        ehcacheService.invalidateCache(cacheName);
+        verify(cacheManager);
+    }
+
+    @Test
+    public void testGetCache() {
+        String cacheName = "Test";
+        Cache<Object, Object> objCache = mock(Cache.class);
+        expect(cacheManager.getCache(cacheName)).andReturn(objCache);
+
+        replay(cacheManager);
+
+        EhcacheService ehcacheService = new EhcacheService(cacheManager);
+
+        ehcacheService.getCache(cacheName);
+
+        verify(cacheManager);
+    }
+
+    @Test
+    public void testGet() {
+        String cacheName = "Test";
+        String key = "k";
+        String value = "v";
+
+        Cache<Object, Object> cache = mock(Cache.class);
+        expect(cacheManager.getCache(cacheName)).andReturn(cache);
+        expect(cache.get(key)).andReturn(value);
+
+        replay(cacheManager, cache);
+
+        EhcacheService ehcacheService = new EhcacheService(cacheManager);
+
+        Object result = ehcacheService.get(cacheName, key);
+        assertEquals(value, result);
+        verify(cacheManager);
+    }
+
+    @Test
+    public void testPut() {
+        String cacheName = "Test";
+        String key = "k";
+        String value = "v";
+
+        Cache<Object, Object> cache = mock(Cache.class);
+        expect(cacheManager.getCache(cacheName)).andReturn(cache);
+        cache.put(key, value);
+        expectLastCall();
+
+        replay(cacheManager, cache);
+
+        EhcacheService ehcacheService = new EhcacheService(cacheManager);
+
+        ehcacheService.put(cacheName, key, value);
+        verify(cacheManager);
+    }
+}

--- a/cache/core/src/test/resources/test-cache-config.xml
+++ b/cache/core/src/test/resources/test-cache-config.xml
@@ -1,0 +1,28 @@
+<ehcache:config xmlns:ehcache="http://www.ehcache.org/v3">
+    <!--
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <ehcache:cache alias="TestCache">
+        <ehcache:key-type>java.lang.String</ehcache:key-type>
+        <ehcache:value-type>java.lang.String</ehcache:value-type>
+
+        <ehcache:expiry>
+            <ehcache:tti unit="minutes">2</ehcache:tti>
+        </ehcache:expiry>
+        <ehcache:heap unit="entries">200</ehcache:heap>
+    </ehcache:cache>
+</ehcache:config>

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+    <modules>
+        <module>api</module>
+        <module>core</module>
+        <module>commands</module>
+    </modules>
+
+    <parent>
+        <groupId>org.apache.karaf</groupId>
+        <artifactId>karaf</artifactId>
+        <version>4.4.3-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.karaf.cache</groupId>
+    <artifactId>cache</artifactId>
+    <packaging>pom</packaging>
+    <name>Apache Karaf :: Cache :: Core Parent POM</name>
+    <description>Cache Facade</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>karaf-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.cache</groupId>
+                <artifactId>cache-api</artifactId>
+                <version>${spec.javax.cache-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ehcache</groupId>
+                <artifactId>ehcache</artifactId>
+                <version>${ehcache.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.utils</artifactId>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>org.apache.karaf.util</artifactId>
+                <scope>provided</scope>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/karaf-cache-example/README.md
+++ b/examples/karaf-cache-example/README.md
@@ -1,0 +1,87 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+# Apache Karaf Cache example
+
+## Abstract
+
+This example shows how to use a simple cache facade provided by Karaf.
+
+## Build
+The build uses Apache Maven. Simply use:
+
+```
+mvn clean install
+```
+
+## Deployment
+On a running Karaf instance, add a feature repository and then the feature:
+```
+karaf@root()> feature:repo-add mvn:org.apache.karaf.examples/karaf-cache-example-feature/LATEST/xml
+karaf@root()> feature:install karaf-cache-example
+```
+
+## Usage
+Check the source code of karaf-cache-example-client to see how to programmatically use Karaf's *CacheService* by creating a cache with Ehcache configuration builders or by providing XML configuration file. When using XML config files, a *ClassLoader* needs to be passed so Ehcache can load keys and values other than standard Java types like String and Long, otherwise it won't work in OSGi environment. It can also be passed in the *Configuration* object.
+
+*CacheService* can be obtained via standard OSGi practices such as *ServiceTracker*, Blueprint or Declarative Services.
+
+
+You can try out the *cache* commands:
+```
+karaf@root()> cache:list
+ExampleCache
+BookCache
+
+karaf@root()> cache:get BookCache 1
+Book{title='Apache Karaf Cookbook', numOfPages=789}
+karaf@root()> cache:invalidate BookCache
+BookCache invalidated
+karaf@root()> cache:get BookCache 1
+Error executing command: Cache BookCache not found!
+
+```
+To create a new cache via a command, put an Ehcache XML configuration file in your Karaf's etc directory, for example:
+```
+<ehcache:config xmlns:ehcache="http://www.ehcache.org/v3">
+    <ehcache:cache alias="TestCache">
+        <ehcache:key-type>java.lang.Long</ehcache:key-type>
+        <ehcache:value-type>java.lang.String</ehcache:value-type>
+
+        <ehcache:expiry>
+            <ehcache:tti unit="minutes">2</ehcache:tti>
+        </ehcache:expiry>
+
+        <ehcache:heap unit="entries">200</ehcache:heap>
+    </ehcache:cache>
+</ehcache:config>
+
+```
+In this case the file name is `config.xml`.
+```
+karaf@root()> cache:create config.xml
+karaf@root()> cache:put TestCache 1 Hello
+karaf@root()> cache:put TestCache 2 World
+karaf@root()> cache:get TestCache 1
+Hello
+karaf@root()> cache:get TestCache 2
+World
+```
+
+
+

--- a/examples/karaf-cache-example/karaf-cache-example-client/pom.xml
+++ b/examples/karaf-cache-example/karaf-cache-example-client/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <!--
-
         Licensed to the Apache Software Foundation (ASF) under one or more
         contributor license agreements.  See the NOTICE file distributed with
         this work for additional information regarding copyright ownership.
@@ -17,61 +18,72 @@
         See the License for the specific language governing permissions and
         limitations under the License.
     -->
-
-    <modelVersion>4.0.0</modelVersion>
-
     <parent>
+        <artifactId>karaf-cache-example</artifactId>
         <groupId>org.apache.karaf.examples</groupId>
-        <artifactId>karaf-graphql-example</artifactId>
         <version>4.4.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>karaf-graphql-example-commands</artifactId>
-    <name>Apache Karaf :: Examples :: GraphQL :: Shell Commands</name>
+    <name>Apache Karaf :: Examples :: Cache :: Client</name>
+    <artifactId>karaf-cache-example-client</artifactId>
+
+    <modelVersion>4.0.0</modelVersion>
+
     <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.karaf.shell</groupId>
-            <artifactId>org.apache.karaf.shell.core</artifactId>
+            <groupId>org.apache.karaf.cache</groupId>
+            <artifactId>org.apache.karaf.cache.api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.graphql-java</groupId>
-            <artifactId>graphql-java</artifactId>
-            <version>19.2</version>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+            <version>${ehcache.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+            <version>${osgi.version}</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.component.annotations</artifactId>
-            <version>1.4.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.karaf.examples</groupId>
-            <artifactId>karaf-graphql-example-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.annotation</artifactId>
-            <version>8.0.0</version>
+            <version>${org.osgi.service.component.annotations.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </resource>
+        </resources>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Karaf-Commands>*</Karaf-Commands>
-                    </instructions>
-                </configuration>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/examples/karaf-cache-example/karaf-cache-example-client/src/main/java/org/apache/karaf/cache/example/client/Book.java
+++ b/examples/karaf-cache-example/karaf-cache-example-client/src/main/java/org/apache/karaf/cache/example/client/Book.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.example.client;
+
+/**
+ * This is to showcase caching of a more complex object, rather than something like String or Long.
+ */
+public class Book {
+    private final String title;
+    private final int numOfPages;
+
+    public Book(String title, int numOfPages) {
+        this.title = title;
+        this.numOfPages = numOfPages;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getNumOfPages() {
+        return numOfPages;
+    }
+
+    @Override
+    public String toString() {
+        return "Book{" + "title='" + title + '\'' + ", numOfPages=" + numOfPages + '}';
+    }
+}

--- a/examples/karaf-cache-example/karaf-cache-example-client/src/main/java/org/apache/karaf/cache/example/client/CacheInitializer.java
+++ b/examples/karaf-cache-example/karaf-cache-example-client/src/main/java/org/apache/karaf/cache/example/client/CacheInitializer.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.karaf.cache.example.client;
+
+import org.apache.karaf.cache.api.CacheService;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.time.Duration;
+
+@Component(immediate = true)
+public class CacheInitializer {
+
+    private final Logger logger = LoggerFactory.getLogger(CacheInitializer.class);
+
+    @Reference
+    private CacheService cacheService;
+
+    @Activate
+    public void activate() {
+        initCaches();
+    }
+
+    private void initCaches() {
+        initConfigBuilderCache();
+        initXmlConfigCache();
+    }
+
+    private void initConfigBuilderCache() {
+        String cacheName = "ExampleCache";
+        logger.info("Creating " + cacheName + " and populating it with some values..");
+
+        CacheConfiguration<Long, Book> cacheConfiguration = CacheConfigurationBuilder
+                .newCacheConfigurationBuilder(Long.class, Book.class, ResourcePoolsBuilder.heap(50))
+                .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofMinutes(1)))
+                .build();
+        cacheService.createCache(cacheName, Eh107Configuration.fromEhcacheCacheConfiguration(cacheConfiguration));
+        cacheService.put(cacheName, 1L, new Book("Effective Java", 123));
+        cacheService.put(cacheName, 2L, new Book("OSGi in Action", 456));
+        logger.info("Cache value under key 1: " + cacheService.get(cacheName, 1L));
+        logger.info("Cache value under key 2: " + cacheService.get(cacheName, 2L));
+    }
+
+    private void initXmlConfigCache() {
+        String cacheName = "BookCache";
+        logger.info("Creating " + cacheName + " and populating it with some values..");
+
+        URL url = FrameworkUtil.getBundle(this.getClass()).getEntry("/book-cache.xml");
+        cacheService.createCache(url, this.getClass().getClassLoader());
+        cacheService.put(cacheName, 1L, new Book("Apache Karaf Cookbook", 789));
+
+        logger.info("Cache value under key 1: " + cacheService.get(cacheName, 1L));
+    }
+}

--- a/examples/karaf-cache-example/karaf-cache-example-client/src/main/resources/book-cache.xml
+++ b/examples/karaf-cache-example/karaf-cache-example-client/src/main/resources/book-cache.xml
@@ -1,0 +1,31 @@
+<ehcache:config
+        xmlns:ehcache="http://www.ehcache.org/v3"
+>
+    <!--
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <ehcache:cache alias="BookCache">
+        <ehcache:key-type>java.lang.Long</ehcache:key-type>
+        <ehcache:value-type>org.apache.karaf.cache.example.client.Book</ehcache:value-type>
+
+        <ehcache:expiry>
+            <ehcache:tti unit="minutes">2</ehcache:tti>
+        </ehcache:expiry>
+
+        <ehcache:heap unit="entries">200</ehcache:heap>
+    </ehcache:cache>
+</ehcache:config>

--- a/examples/karaf-cache-example/karaf-cache-example-feature/pom.xml
+++ b/examples/karaf-cache-example/karaf-cache-example-feature/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <!--
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <parent>
+        <artifactId>karaf-cache-example</artifactId>
+        <groupId>org.apache.karaf.examples</groupId>
+        <version>4.4.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <name>Apache Karaf :: Examples :: Cache :: Features</name>
+
+    <artifactId>karaf-cache-example-feature</artifactId>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/feature</directory>
+                <filtering>true</filtering>
+                <targetPath>${project.build.directory}/feature</targetPath>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>resources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/feature/feature.xml</file>
+                                    <type>xml</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/karaf-cache-example/karaf-cache-example-feature/src/main/feature/feature.xml
+++ b/examples/karaf-cache-example/karaf-cache-example-feature/src/main/feature/feature.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<features name="karaf-cache-example" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0">
+
+    <feature name="karaf-cache-example" version="${project.version}">
+        <feature prerequisite="true">cache</feature>
+        <bundle>mvn:org.apache.karaf.examples/karaf-cache-example-client/${project.version}</bundle>
+    </feature>
+
+</features>

--- a/examples/karaf-cache-example/pom.xml
+++ b/examples/karaf-cache-example/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.karaf.examples</groupId>
+        <artifactId>apache-karaf-examples</artifactId>
+        <version>4.4.3-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>karaf-cache-example</artifactId>
+    <name>Apache Karaf :: Examples :: Cache</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>karaf-cache-example-feature</module>
+        <module>karaf-cache-example-client</module>
+    </modules>
+
+</project>

--- a/examples/karaf-maven-example/karaf-maven-example-assembly/pom.xml
+++ b/examples/karaf-maven-example/karaf-maven-example-assembly/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-maven-example</artifactId>
-        <version>4.4.2-SNAPSHOT</version>
+        <version>4.4.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -68,6 +68,7 @@
         <module>karaf-websocket-example</module>
         <module>karaf-war-example</module>
         <module>karaf-graphql-example</module>
+        <module>karaf-cache-example</module>
     </modules>
 
 </project>

--- a/itests/test/pom.xml
+++ b/itests/test/pom.xml
@@ -249,6 +249,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.karaf.examples</groupId>
+            <artifactId>karaf-cache-example-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.karaf.diagnostic</groupId>
             <artifactId>org.apache.karaf.diagnostic.boot</artifactId>
             <version>${project.version}</version>

--- a/itests/test/src/test/filtered-resources/etc/feature.xml
+++ b/itests/test/src/test/filtered-resources/etc/feature.xml
@@ -867,6 +867,19 @@
         <bundle start-level="30">mvn:org.apache.karaf.scheduler/org.apache.karaf.scheduler.core/${project.version}</bundle>
     </feature>
 
+
+    <feature name="cache" description="Provides a simple JSR107 based caching facade" version="${project.version}">
+        <feature>scr</feature>
+        <bundle>mvn:javax.cache/cache-api/${spec.javax.cache-api.version}</bundle>
+        <bundle>mvn:org.ehcache/ehcache/${ehcache.version}</bundle>
+        <bundle>mvn:org.apache.karaf.cache/org.apache.karaf.cache.api/${project.version}</bundle>
+        <bundle>mvn:org.apache.karaf.cache/org.apache.karaf.cache.core/${project.version}</bundle>
+        <conditional>
+            <condition>shell</condition>
+            <bundle>mvn:org.apache.karaf.cache/org.apache.karaf.cache.commands/${project.version}</bundle>
+        </conditional>
+    </feature>
+
     <feature name="eventadmin" description="OSGi Event Admin service specification for event-based communication" version="${project.version}">
         <config name="org.apache.felix.eventadmin.impl.EventAdmin">
             org.apache.felix.eventadmin.AddTimestamp=true

--- a/itests/test/src/test/java/org/apache/karaf/itests/CacheTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/CacheTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.itests;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.karaf.options.KarafDistributionOption;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import java.util.stream.Stream;
+
+import static org.junit.Assert.fail;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class CacheTest extends BaseTest
+{
+
+    @Configuration
+    public Option[] config()
+    {
+        Option cacheConfigOption = KarafDistributionOption.replaceConfigurationFile("etc/test-cache-config.xml",
+                getConfigFile("/etc/test-cache-config.xml"));
+        return Stream.of(super.config(), new Option[] { cacheConfigOption })
+                .flatMap(Stream::of)
+                .toArray(Option[]::new);
+    }
+
+    @Before
+    public void setUp() throws Exception
+    {
+        installAndAssertFeature("cache");
+    }
+
+    @Test
+    public void testCommands() throws Exception
+    {
+        executeCommand("cache:create test-cache-config.xml");
+        String list = executeCommand("cache:list");
+        assertContains("TestCache", list);
+        executeCommand("cache:put TestCache key value");
+        String cachedValue = executeCommand("cache:get TestCache key");
+        assertContains("value", cachedValue);
+        executeCommand("cache:invalidate TestCache");
+
+        try
+        {
+            executeCommand("cache:get TestCache key");
+            fail("cache:get worked even though the cache was invalidated!");
+        }
+        catch (Exception e)
+        {
+            // expected
+        }
+    }
+}

--- a/itests/test/src/test/java/org/apache/karaf/itests/examples/CacheExampleTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/examples/CacheExampleTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.itests.examples;
+
+import org.apache.karaf.itests.BaseTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+public class CacheExampleTest extends BaseTest
+{
+
+    private void setUp() throws Exception
+    {
+        addFeaturesRepository(
+                "mvn:org.apache.karaf.examples/karaf-cache-example-feature/" + System.getProperty("karaf.version")
+                        + "/xml");
+        installAndAssertFeature("karaf-cache-example");
+    }
+
+    @Test
+    public void testCachesGetCreated() throws Exception
+    {
+        setUp();
+        String caches = executeCommand("cache:list");
+        assertContains("BookCache", caches);
+        assertContains("ExampleCache", caches);
+    }
+}

--- a/itests/test/src/test/resources/etc/test-cache-config.xml
+++ b/itests/test/src/test/resources/etc/test-cache-config.xml
@@ -1,0 +1,28 @@
+<ehcache:config xmlns:ehcache="http://www.ehcache.org/v3">
+    <!--
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <ehcache:cache alias="TestCache">
+        <ehcache:key-type>java.lang.String</ehcache:key-type>
+        <ehcache:value-type>java.lang.String</ehcache:value-type>
+
+        <ehcache:expiry>
+            <ehcache:tti unit="minutes">2</ehcache:tti>
+        </ehcache:expiry>
+        <ehcache:heap unit="entries">200</ehcache:heap>
+    </ehcache:cache>
+</ehcache:config>

--- a/manual/src/main/asciidoc/index.adoc
+++ b/manual/src/main/asciidoc/index.adoc
@@ -92,6 +92,8 @@ include::user-guide/scheduler.adoc[]
 
 include::user-guide/tuning.adoc[]
 
+include::user-guide/cache.adoc[]
+
 == Developer Guide
 
 include::developer-guide/developer-commands.adoc[]

--- a/manual/src/main/asciidoc/user-guide/cache.adoc
+++ b/manual/src/main/asciidoc/user-guide/cache.adoc
@@ -1,0 +1,210 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+=== Caching
+
+Apache Karaf provides an optional caching module which offers a simple caching service based on JSR 107 APIs. 
+The implementation uses Ehcache but other providers can also be used.
+
+==== Installation
+
+To enable the Apache Karaf Cache, you just have to install the `cache` feature:
+
+----
+karaf@root()> feature:install cache
+----
+
+The `cache` feature automatically installs the `cache` command group, too:
+
+----
+cache:list
+cache:get
+cache:put
+cache:create
+cache:invalidate
+----
+
+==== Configuration
+The caches can be created from Ehcache XML configurations.
+These can be put for example in your bundle's resources or in Karaf's etc directory.
+
+
+==== Using the CacheService
+This example uses Declarative Services to get an instance of CacheService from your bundle, and then showcases the available methods.
+```
+import org.apache.karaf.cache.api.CacheService;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+
+@Component(immediate = true)
+public class CacheInitializer {
+
+    private final Logger logger = LoggerFactory.getLogger(CacheInitializer.class);
+
+    @Reference
+    private CacheService cacheService;
+
+    @Activate
+    public void activate() {
+        String cacheName = "ExampleCache";
+        CacheConfiguration<Long, Book> cacheConfiguration = CacheConfigurationBuilder
+                .newCacheConfigurationBuilder(Long.class, Book.class, ResourcePoolsBuilder.heap(50))
+                .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofMinutes(1)))
+                .build();
+        List<String> caches = cacheService.listCaches(); // [ExampleCache]
+        cacheService.createCache(cacheName, Eh107Configuration.fromEhcacheCacheConfiguration(cacheConfiguration));
+        cacheService.put(cacheName, 1L, new Book("Effective Java", 123));
+        cacheService.invalidateCache(cacheName);
+        caches = cacheService.listCaches(); // []
+    }
+}
+
+```
+
+==== Create cache via Karaf shell
+This assumes that there is an Ehcache 3 compliant cache-config.xml file in Karaf's etc directory with, like the following:
+----
+<ehcache:config xmlns:ehcache="http://www.ehcache.org/v3">
+    <ehcache:cache alias="TestCache">
+        <ehcache:key-type>java.lang.String</ehcache:key-type>
+        <ehcache:value-type>java.lang.String</ehcache:value-type>
+
+        <ehcache:expiry>
+            <ehcache:tti unit="minutes">2</ehcache:tti>
+        </ehcache:expiry>
+        <ehcache:heap unit="entries">200</ehcache:heap>
+    </ehcache:cache>
+</ehcache:config>
+----
+
+----
+karaf@root()> cache:create --help
+DESCRIPTION
+        cache:create
+
+        Create a new cache from XML config.
+
+SYNTAX
+        cache:create configPath 
+
+ARGUMENTS
+        configPath
+                Path to ehcache xml configuration file in Karaf's etc directory
+                (required)
+
+karaf@root()> cache:create cache-config.xml
+----
+
+==== List all cache names
+----
+karaf@root()> cache:list --help
+DESCRIPTION
+        cache:list
+
+        Lists all available cache names.
+
+SYNTAX
+        cache:list
+
+karaf@root()> cache:list
+ExampleCache
+BookCache
+----
+
+==== Put values into the cache
+While Ehcache normally allows using POJOs as keys and values, this will not work via Karaf shell, only simple types (String, Long, Integer, Short, Boolean) can be used. This is because the cache command bundle will probably not
+ have this POJO in its classloader.
+Recommendation: if using POJOs as cache keys or values, test them programmatically and not via Shell.
+
+----
+karaf@root()> cache:put --help
+DESCRIPTION
+        cache:put
+
+        Stores a new value in a cache.
+
+SYNTAX
+        cache:put cacheName key value 
+
+ARGUMENTS
+        cacheName
+                Name of the cache.
+                (required)
+        key
+                Key under which the value will be stored.
+                (required)
+        value
+                Value to cache.
+                (required)
+
+karaf@root()> cache:put TestCache hello world
+karaf@root()> cache:get TestCache hello
+world
+----
+
+==== Get values in the cache
+If the cache uses POJOs as values, its `toString()` representation will be displayed.
+----
+karaf@root()> cache:get --help
+DESCRIPTION
+        cache:get
+
+        Get a single value from a given cache.
+
+SYNTAX
+        cache:get cacheName key 
+
+ARGUMENTS
+        cacheName
+                Name of the cache to access.
+                (required)
+        key
+                Key storing the value that we wish to check.
+                (required)
+
+karaf@root()> cache:get BookCache 1
+Book{title='Apache Karaf Cookbook', numOfPages=789}
+----
+
+==== Invalidate the cache
+
+----
+karaf@root()> cache:invalidate --help
+DESCRIPTION
+        cache:invalidate
+
+        Invalidates a cache identified by the provided name.
+
+SYNTAX
+        cache:invalidate cacheName 
+
+ARGUMENTS
+        cacheName
+
+                (required)
+
+karaf@root()> cache:invalidate BookCache
+BookCache invalidated
+----

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <module>tooling</module>
         <module>manual</module>
         <module>specs</module>
+        <module>cache</module>
         <module>assemblies</module>
         <module>examples</module>
         <module>archetypes</module>
@@ -321,6 +322,8 @@
         <plexus-utils.version>3.4.2</plexus-utils.version>
         <slf4j.version>1.7.32</slf4j.version>
 
+        <ehcache.version>3.10.0</ehcache.version>
+
         <spec.activation.version>1.2.2</spec.activation.version>
         <spec.annotation.version>1.3.5</spec.annotation.version>
         <spec.jaxb.version>2.3.2_3</spec.jaxb.version>
@@ -328,7 +331,8 @@
         <spec.jaxws.version>2.3</spec.jaxws.version>
         <spec.jws.version>1.1.1</spec.jws.version>
         <spec.mail.version>1.6.5</spec.mail.version>
-	<spec.xjc.version>2.3.2_2</spec.xjc.version>
+	    <spec.xjc.version>2.3.2_2</spec.xjc.version>
+        <spec.javax.cache-api.version>1.1.0</spec.javax.cache-api.version>
 
         <spring.osgi.version>1.2.1</spring.osgi.version>
         <spring31.version>3.1.4.RELEASE</spring31.version>


### PR DESCRIPTION
Draft phase (it works but it's not a proper component yet).

I'm opening a pr already so it can be reviewed before putting more work into it.

Some features:
- it uses ehcache with JSR 107 API
- the api does not depend on ehcache, so other providers could be added
- possible to load ehcache configuration from xml
- some karaf commands for debugging/playing around with the caches

Some open points:
- how should the interface (`CacheService`) look like
- is anything important not possible because of the facade (see the docs: https://www.ehcache.org/documentation/3.0/index.html) 