### PR TITLE
[KARAF-6697] Fix threads leak in karaf-maven-plugin verify goal

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
@@ -48,8 +48,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
@@ -412,6 +410,7 @@ public class VerifyMojo extends MojoSupport {
                 }
             }
         }
+        executor.shutdown();
         int nb = successes.size() + ignored.size() + failures.size();
         getLog().info("Features verified: " + nb + ", failures: " + failures.size() + ", ignored: " + ignored.size() + ", skipped: " + skipped.size());
         if (!failures.isEmpty()) {


### PR DESCRIPTION
Since we now verify ~400 features in the openHAB Addons repo, the number of threads being leaked by the verify goal causes [GitHub Actions builds to run out of memory](https://github.com/wborn/openhab-addons/actions/runs/3350846650/jobs/5554259431).

I did some investigation and found that the thread leak is caused by the VerifyMojo itself.
For some reason the threads created by the executor are never garbage collected.

---

The goal leaks 8 threads each time it is executed. So if you verify 400 features in a build it causes 3200 threads to be leaked:

![before](https://user-images.githubusercontent.com/12213581/199851563-751c3ad6-d9ec-49c0-9560-1d1bcb54749d.png)

---

When the executor is shutdown the verify goal no longer leaks threads. :slightly_smiling_face: 

![after](https://user-images.githubusercontent.com/12213581/199851572-bac84c95-8b94-4014-95b8-d36b9de44316.png)

---

It would also be nice when the fix is cherry-picked to 4.3.x.