### PR TITLE
Switch from AdoptOpenJDK to successor Eclipse Temurin

### DIFF
--- a/assemblies/docker/Dockerfile
+++ b/assemblies/docker/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre
 
 # Karaf environment variables
 ENV KARAF_INSTALL_PATH /opt

--- a/assemblies/docker/README.md
+++ b/assemblies/docker/README.md
@@ -32,7 +32,7 @@ On macOS, an easy way to install `buildx` is to install [Docker Desktop Edge](ht
 
 ## Build
 
-Images are based on the Docker official [AdoptOpenJDK 11 JRE Hotspot](https://hub.docker.com/_/adoptopenjdk?tab=tags&page=1&name=11-jre-hotspot) image. If you want to
+Images are based on the Docker official [Eclipse Temurin 11 JRE](https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=11-jre) image. If you want to
 build the Karaf image you have the following choices:
 
 1. Create the docker image from a local distribution package
@@ -50,13 +50,13 @@ Usage:
 
   If the --image-name flag is not used the built image name will be 'karaf'.
   Check the supported build platforms; you can verify with this command: docker buildx ls
-  The supported platforms (OS/Arch) depend on the build's base image, in this case [adoptopenjdk:11-jre-hotspot](https://hub.docker.com/_/adoptopenjdk?tab=tags&page=1&name=11-jre-hotspot).
+  The supported platforms (OS/Arch) depend on the build's base image, in this case [eclipse-temurin:11-jre](https://hub.docker.com/_/eclipse-temurin).
 ```
 
-To create the docker image from local distribution) you can execute the command 
-below. Remember that before you can successfully run this command, you must build 
-the project (for example with the command `mvn clean install -DskipTests`). 
-For more info you can read: 
+To create the docker image from local distribution) you can execute the command
+below. Remember that before you can successfully run this command, you must build
+the project (for example with the command `mvn clean install -DskipTests`).
+For more info you can read:
 [Building Apache Karaf](https://github.com/apache/karaf/blob/master/BUILDING.md#building-apache-karaf)
 
 ```bash
@@ -64,7 +64,7 @@ For more info you can read:
 ```
 
 For create the docker image from the local dist version but with the archive,
-you can execute the below command. Remember that before you can successfully run 
+you can execute the below command. Remember that before you can successfully run
 this command.
 
 ```bash
@@ -79,7 +79,7 @@ You can also specify the image name with the `--image-name` flag, for example
 ```
 
 If you want to build the docker image for a specific version of Karaf
-you can run `build.sh` command in this way (replacing the version, image name, 
+you can run `build.sh` command in this way (replacing the version, image name,
 and targets as appropriate):
 
 ```bash
@@ -143,7 +143,7 @@ Starting build of the docker image for the platform linux/arm64,linux/arm/v7,lin
 docker-compose run karaf karaf
 ```
 
-or 
+or
 
 ```
 docker run --name karaf karaf karaf
@@ -155,7 +155,7 @@ docker run --name karaf karaf karaf
 docker-compose up
 ```
 
-or 
+or
 
 ```
 docker run --name karaf

--- a/assemblies/docker/build.sh
+++ b/assemblies/docker/build.sh
@@ -27,8 +27,8 @@ Usage:
 
   If the --image-name flag is not used the built image name will be 'karaf'.
   Check the supported build platforms; you can verify with this command: docker buildx ls
-  The supported platforms (OS/Arch) depend on the build's base image, in this case [adoptopenjdk:11-jre-hotspot](https://hub.docker.com/_/adoptopenjdk?tab=tags&page=1&name=11-jre-hotspot).
-  
+  The supported platforms (OS/Arch) depend on the build's base image, in this case [eclipse-temurin:11-jre](https://hub.docker.com/_/eclipse-temurin).
+
 HERE
   exit 1
 }
@@ -99,7 +99,7 @@ elif [ -n "${FROM_LOCAL}" ]; then
 
   if [ -n "${ARCHIVE}" ]; then
      DIST_DIR=${ARCHIVE}
-  else 
+  else
      DIST_DIR="../apache-karaf/target/apache-karaf-*.tar.gz"
   fi
   KARAF_DIST=${TMPDIR}/apache-karaf.tar.gz
@@ -119,7 +119,7 @@ if [ -n "${BUILD_MULTI_PLATFORM}" ]; then
   if [ $? -eq 0 ]; then
     echo "Found buildx {${VERSION_BUILD_X}} on your docker system"
     echo "Starting build of the docker image for the platform ${BUILD_MULTI_PLATFORM}"
-    
+
     BUILD_X="buildx"
     BUILD_X_FLAG="--push"
     BUILD_X_PLATFORM="--platform ${BUILD_MULTI_PLATFORM}"

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/DockerfileMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/DockerfileMojo.java
@@ -46,7 +46,7 @@ public class DockerfileMojo extends MojoSupport {
         File dockerFile = new File(destDir, "Dockerfile");
         try {
             StringBuilder buffer = new StringBuilder();
-            buffer.append("FROM adoptopenjdk:11-jre-hotspot").append("\n");
+            buffer.append("FROM eclipse-temurin:11-jre").append("\n");
             buffer.append("ENV KARAF_INSTALL_PATH /opt").append("\n");
             buffer.append("ENV KARAF_HOME $KARAF_INSTALL_PATH/apache-karaf").append("\n");
             buffer.append("ENV KARAF_EXEC exec").append("\n");


### PR DESCRIPTION
This PR updates the base image from  AdoptOpenJDK to its successor Eclipse Temurin