### PR TITLE
[KARAF-7607]: careful JLine/SSHD translation

### DIFF
--- a/client/src/main/java/org/apache/karaf/client/Main.java
+++ b/client/src/main/java/org/apache/karaf/client/Main.java
@@ -220,9 +220,8 @@ public class Main {
                     try {
                         Map<PtyMode, Integer> modes = new HashMap<>();
                         // Control chars
-                        requireMode(modes, PtyMode.VINTR, attributes, ControlChar.VINTR);
-                        requireMode(modes, PtyMode.VQUIT, attributes, ControlChar.VQUIT);
-                        requireMode(modes, PtyMode.VDSUSP, attributes, ControlChar.VDSUSP);
+                        addMode(modes, PtyMode.VINTR, attributes, ControlChar.VINTR);
+                        addMode(modes, PtyMode.VQUIT, attributes, ControlChar.VQUIT);
                         addMode(modes, PtyMode.VERASE, attributes, ControlChar.VERASE);
                         addMode(modes, PtyMode.VKILL, attributes, ControlChar.VKILL);
                         addMode(modes, PtyMode.VEOF, attributes, ControlChar.VEOF);
@@ -231,6 +230,7 @@ public class Main {
                         addMode(modes, PtyMode.VSTART, attributes, ControlChar.VSTART);
                         addMode(modes, PtyMode.VSTOP, attributes, ControlChar.VSTOP);
                         addMode(modes, PtyMode.VSUSP, attributes, ControlChar.VSUSP);
+                        addMode(modes, PtyMode.VDSUSP, attributes, ControlChar.VDSUSP);
                         addMode(modes, PtyMode.VREPRINT, attributes, ControlChar.VREPRINT);
                         addMode(modes, PtyMode.VWERASE, attributes, ControlChar.VWERASE);
                         addMode(modes, PtyMode.VLNEXT, attributes, ControlChar.VLNEXT);
@@ -342,14 +342,6 @@ public class Main {
         if (value != -1) {
             modes.put(mode, value);
         }
-    }
-
-    private static void requireMode(Map<PtyMode, Integer> modes, PtyMode mode, Attributes attributes, ControlChar ctrl) {
-        final int value = attributes.getControlChar(ctrl);
-        if (value == -1) {
-            throw new IllegalStateException("Required control character " + ctrl + " is not available");
-        }
-        modes.put(mode, value);
     }
 
     private static int getFlag(Attributes attributes, InputFlag flag) {

--- a/client/src/main/java/org/apache/karaf/client/Main.java
+++ b/client/src/main/java/org/apache/karaf/client/Main.java
@@ -220,8 +220,9 @@ public class Main {
                     try {
                         Map<PtyMode, Integer> modes = new HashMap<>();
                         // Control chars
-                        addMode(modes, PtyMode.VINTR, attributes, ControlChar.VINTR);
-                        addMode(modes, PtyMode.VQUIT, attributes, ControlChar.VQUIT);
+                        requireMode(modes, PtyMode.VINTR, attributes, ControlChar.VINTR);
+                        requireMode(modes, PtyMode.VQUIT, attributes, ControlChar.VQUIT);
+                        requireMode(modes, PtyMode.VDSUSP, attributes, ControlChar.VDSUSP);
                         addMode(modes, PtyMode.VERASE, attributes, ControlChar.VERASE);
                         addMode(modes, PtyMode.VKILL, attributes, ControlChar.VKILL);
                         addMode(modes, PtyMode.VEOF, attributes, ControlChar.VEOF);
@@ -230,7 +231,6 @@ public class Main {
                         addMode(modes, PtyMode.VSTART, attributes, ControlChar.VSTART);
                         addMode(modes, PtyMode.VSTOP, attributes, ControlChar.VSTOP);
                         addMode(modes, PtyMode.VSUSP, attributes, ControlChar.VSUSP);
-                        addMode(modes, PtyMode.VDSUSP, attributes, ControlChar.VDSUSP);
                         addMode(modes, PtyMode.VREPRINT, attributes, ControlChar.VREPRINT);
                         addMode(modes, PtyMode.VWERASE, attributes, ControlChar.VWERASE);
                         addMode(modes, PtyMode.VLNEXT, attributes, ControlChar.VLNEXT);
@@ -342,6 +342,14 @@ public class Main {
         if (value != -1) {
             modes.put(mode, value);
         }
+    }
+
+    private static void requireMode(Map<PtyMode, Integer> modes, PtyMode mode, Attributes attributes, ControlChar ctrl) {
+        final int value = attributes.getControlChar(ctrl);
+        if (value == -1) {
+            throw new IllegalStateException("Required control character " + ctrl + " is not available");
+        }
+        modes.put(mode, value);
     }
 
     private static int getFlag(Attributes attributes, InputFlag flag) {

--- a/client/src/main/java/org/apache/karaf/client/Main.java
+++ b/client/src/main/java/org/apache/karaf/client/Main.java
@@ -39,7 +39,6 @@ import org.apache.sshd.agent.SshAgent;
 import org.apache.sshd.agent.local.AgentImpl;
 import org.apache.sshd.agent.local.LocalAgentFactory;
 import org.apache.sshd.client.ClientBuilder;
-import org.apache.sshd.client.ClientFactoryManager;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.auth.keyboard.UserInteraction;
 import org.apache.sshd.client.channel.ChannelExec;
@@ -221,22 +220,22 @@ public class Main {
                     try {
                         Map<PtyMode, Integer> modes = new HashMap<>();
                         // Control chars
-                        modes.put(PtyMode.VINTR, attributes.getControlChar(ControlChar.VINTR));
-                        modes.put(PtyMode.VQUIT, attributes.getControlChar(ControlChar.VQUIT));
-                        modes.put(PtyMode.VERASE, attributes.getControlChar(ControlChar.VERASE));
-                        modes.put(PtyMode.VKILL, attributes.getControlChar(ControlChar.VKILL));
-                        modes.put(PtyMode.VEOF, attributes.getControlChar(ControlChar.VEOF));
-                        modes.put(PtyMode.VEOL, attributes.getControlChar(ControlChar.VEOL));
-                        modes.put(PtyMode.VEOL2, attributes.getControlChar(ControlChar.VEOL2));
-                        modes.put(PtyMode.VSTART, attributes.getControlChar(ControlChar.VSTART));
-                        modes.put(PtyMode.VSTOP, attributes.getControlChar(ControlChar.VSTOP));
-                        modes.put(PtyMode.VSUSP, attributes.getControlChar(ControlChar.VSUSP));
-                        modes.put(PtyMode.VDSUSP, attributes.getControlChar(ControlChar.VDSUSP));
-                        modes.put(PtyMode.VREPRINT, attributes.getControlChar(ControlChar.VREPRINT));
-                        modes.put(PtyMode.VWERASE, attributes.getControlChar(ControlChar.VWERASE));
-                        modes.put(PtyMode.VLNEXT, attributes.getControlChar(ControlChar.VLNEXT));
-                        modes.put(PtyMode.VSTATUS, attributes.getControlChar(ControlChar.VSTATUS));
-                        modes.put(PtyMode.VDISCARD, attributes.getControlChar(ControlChar.VDISCARD));
+                        addMode(modes, PtyMode.VINTR, attributes, ControlChar.VINTR);
+                        addMode(modes, PtyMode.VQUIT, attributes, ControlChar.VQUIT);
+                        addMode(modes, PtyMode.VERASE, attributes, ControlChar.VERASE);
+                        addMode(modes, PtyMode.VKILL, attributes, ControlChar.VKILL);
+                        addMode(modes, PtyMode.VEOF, attributes, ControlChar.VEOF);
+                        addMode(modes, PtyMode.VEOL, attributes, ControlChar.VEOL);
+                        addMode(modes, PtyMode.VEOL2, attributes, ControlChar.VEOL2);
+                        addMode(modes, PtyMode.VSTART, attributes, ControlChar.VSTART);
+                        addMode(modes, PtyMode.VSTOP, attributes, ControlChar.VSTOP);
+                        addMode(modes, PtyMode.VSUSP, attributes, ControlChar.VSUSP);
+                        addMode(modes, PtyMode.VDSUSP, attributes, ControlChar.VDSUSP);
+                        addMode(modes, PtyMode.VREPRINT, attributes, ControlChar.VREPRINT);
+                        addMode(modes, PtyMode.VWERASE, attributes, ControlChar.VWERASE);
+                        addMode(modes, PtyMode.VLNEXT, attributes, ControlChar.VLNEXT);
+                        addMode(modes, PtyMode.VSTATUS, attributes, ControlChar.VSTATUS);
+                        addMode(modes, PtyMode.VDISCARD, attributes, ControlChar.VDISCARD);
                         // Input flags
                         modes.put(PtyMode.IGNPAR, getFlag(attributes, InputFlag.IGNPAR));
                         modes.put(PtyMode.PARMRK, getFlag(attributes, InputFlag.PARMRK));
@@ -335,6 +334,13 @@ public class Main {
                 System.err.println(t.getMessage());
             }
             System.exit(1);
+        }
+    }
+
+    private static void addMode(Map<PtyMode, Integer> modes, PtyMode mode, Attributes attributes, ControlChar ctrl) {
+        final int value = attributes.getControlChar(ctrl);
+        if (value != -1) {
+            modes.put(mode, value);
         }
     }
 

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/SshAction.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/SshAction.java
@@ -193,9 +193,8 @@ public class SshAction implements Action {
                     try {
                         Map<PtyMode, Integer> modes = new HashMap<>();
                         // Control chars
-                        requireMode(modes, PtyMode.VINTR, attributes, ControlChar.VINTR);
-                        requireMode(modes, PtyMode.VQUIT, attributes, ControlChar.VQUIT);
-                        requireMode(modes, PtyMode.VDSUSP, attributes, ControlChar.VDSUSP);
+                        addMode(modes, PtyMode.VINTR, attributes, ControlChar.VINTR);
+                        addMode(modes, PtyMode.VQUIT, attributes, ControlChar.VQUIT);
                         addMode(modes, PtyMode.VERASE, attributes, ControlChar.VERASE);
                         addMode(modes, PtyMode.VKILL, attributes, ControlChar.VKILL);
                         addMode(modes, PtyMode.VEOF, attributes, ControlChar.VEOF);
@@ -204,6 +203,7 @@ public class SshAction implements Action {
                         addMode(modes, PtyMode.VSTART, attributes, ControlChar.VSTART);
                         addMode(modes, PtyMode.VSTOP, attributes, ControlChar.VSTOP);
                         addMode(modes, PtyMode.VSUSP, attributes, ControlChar.VSUSP);
+                        addMode(modes, PtyMode.VDSUSP, attributes, ControlChar.VDSUSP);
                         addMode(modes, PtyMode.VREPRINT, attributes, ControlChar.VREPRINT);
                         addMode(modes, PtyMode.VWERASE, attributes, ControlChar.VWERASE);
                         addMode(modes, PtyMode.VLNEXT, attributes, ControlChar.VLNEXT);
@@ -313,14 +313,6 @@ public class SshAction implements Action {
         if (value != -1) {
             modes.put(mode, value);
         }
-    }
-
-    private static void requireMode(Map<PtyMode, Integer> modes, PtyMode mode, Attributes attributes, ControlChar ctrl) {
-        final int value = attributes.getControlChar(ctrl);
-        if (value == -1) {
-            throw new IllegalStateException("Required control character " + ctrl + " is not available");
-        }
-        modes.put(mode, value);
     }
 
     private static int getFlag(Attributes attributes, InputFlag flag) {

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/SshAction.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/SshAction.java
@@ -193,8 +193,9 @@ public class SshAction implements Action {
                     try {
                         Map<PtyMode, Integer> modes = new HashMap<>();
                         // Control chars
-                        addMode(modes, PtyMode.VINTR, attributes, ControlChar.VINTR);
-                        addMode(modes, PtyMode.VQUIT, attributes, ControlChar.VQUIT);
+                        requireMode(modes, PtyMode.VINTR, attributes, ControlChar.VINTR);
+                        requireMode(modes, PtyMode.VQUIT, attributes, ControlChar.VQUIT);
+                        requireMode(modes, PtyMode.VDSUSP, attributes, ControlChar.VDSUSP);
                         addMode(modes, PtyMode.VERASE, attributes, ControlChar.VERASE);
                         addMode(modes, PtyMode.VKILL, attributes, ControlChar.VKILL);
                         addMode(modes, PtyMode.VEOF, attributes, ControlChar.VEOF);
@@ -203,7 +204,6 @@ public class SshAction implements Action {
                         addMode(modes, PtyMode.VSTART, attributes, ControlChar.VSTART);
                         addMode(modes, PtyMode.VSTOP, attributes, ControlChar.VSTOP);
                         addMode(modes, PtyMode.VSUSP, attributes, ControlChar.VSUSP);
-                        addMode(modes, PtyMode.VDSUSP, attributes, ControlChar.VDSUSP);
                         addMode(modes, PtyMode.VREPRINT, attributes, ControlChar.VREPRINT);
                         addMode(modes, PtyMode.VWERASE, attributes, ControlChar.VWERASE);
                         addMode(modes, PtyMode.VLNEXT, attributes, ControlChar.VLNEXT);
@@ -313,6 +313,14 @@ public class SshAction implements Action {
         if (value != -1) {
             modes.put(mode, value);
         }
+    }
+
+    private static void requireMode(Map<PtyMode, Integer> modes, PtyMode mode, Attributes attributes, ControlChar ctrl) {
+        final int value = attributes.getControlChar(ctrl);
+        if (value == -1) {
+            throw new IllegalStateException("Required control character " + ctrl + " is not available");
+        }
+        modes.put(mode, value);
     }
 
     private static int getFlag(Attributes attributes, InputFlag flag) {

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/SshAction.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/SshAction.java
@@ -37,13 +37,13 @@ import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.apache.karaf.shell.api.console.Session;
 import org.apache.karaf.shell.api.console.Terminal;
 import org.apache.sshd.agent.SshAgent;
-import org.apache.sshd.client.channel.ClientChannelEvent;
-import org.apache.sshd.client.keyverifier.ServerKeyVerifier;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.auth.keyboard.UserInteraction;
 import org.apache.sshd.client.channel.ChannelShell;
 import org.apache.sshd.client.channel.ClientChannel;
+import org.apache.sshd.client.channel.ClientChannelEvent;
 import org.apache.sshd.client.future.ConnectFuture;
+import org.apache.sshd.client.keyverifier.ServerKeyVerifier;
 import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.common.channel.PtyMode;
 import org.apache.sshd.common.keyprovider.FileKeyPairProvider;
@@ -193,22 +193,22 @@ public class SshAction implements Action {
                     try {
                         Map<PtyMode, Integer> modes = new HashMap<>();
                         // Control chars
-                        modes.put(PtyMode.VINTR, attributes.getControlChar(ControlChar.VINTR));
-                        modes.put(PtyMode.VQUIT, attributes.getControlChar(ControlChar.VQUIT));
-                        modes.put(PtyMode.VERASE, attributes.getControlChar(ControlChar.VERASE));
-                        modes.put(PtyMode.VKILL, attributes.getControlChar(ControlChar.VKILL));
-                        modes.put(PtyMode.VEOF, attributes.getControlChar(ControlChar.VEOF));
-                        modes.put(PtyMode.VEOL, attributes.getControlChar(ControlChar.VEOL));
-                        modes.put(PtyMode.VEOL2, attributes.getControlChar(ControlChar.VEOL2));
-                        modes.put(PtyMode.VSTART, attributes.getControlChar(ControlChar.VSTART));
-                        modes.put(PtyMode.VSTOP, attributes.getControlChar(ControlChar.VSTOP));
-                        modes.put(PtyMode.VSUSP, attributes.getControlChar(ControlChar.VSUSP));
-                        modes.put(PtyMode.VDSUSP, attributes.getControlChar(ControlChar.VDSUSP));
-                        modes.put(PtyMode.VREPRINT, attributes.getControlChar(ControlChar.VREPRINT));
-                        modes.put(PtyMode.VWERASE, attributes.getControlChar(ControlChar.VWERASE));
-                        modes.put(PtyMode.VLNEXT, attributes.getControlChar(ControlChar.VLNEXT));
-                        modes.put(PtyMode.VSTATUS, attributes.getControlChar(ControlChar.VSTATUS));
-                        modes.put(PtyMode.VDISCARD, attributes.getControlChar(ControlChar.VDISCARD));
+                        addMode(modes, PtyMode.VINTR, attributes, ControlChar.VINTR);
+                        addMode(modes, PtyMode.VQUIT, attributes, ControlChar.VQUIT);
+                        addMode(modes, PtyMode.VERASE, attributes, ControlChar.VERASE);
+                        addMode(modes, PtyMode.VKILL, attributes, ControlChar.VKILL);
+                        addMode(modes, PtyMode.VEOF, attributes, ControlChar.VEOF);
+                        addMode(modes, PtyMode.VEOL, attributes, ControlChar.VEOL);
+                        addMode(modes, PtyMode.VEOL2, attributes, ControlChar.VEOL2);
+                        addMode(modes, PtyMode.VSTART, attributes, ControlChar.VSTART);
+                        addMode(modes, PtyMode.VSTOP, attributes, ControlChar.VSTOP);
+                        addMode(modes, PtyMode.VSUSP, attributes, ControlChar.VSUSP);
+                        addMode(modes, PtyMode.VDSUSP, attributes, ControlChar.VDSUSP);
+                        addMode(modes, PtyMode.VREPRINT, attributes, ControlChar.VREPRINT);
+                        addMode(modes, PtyMode.VWERASE, attributes, ControlChar.VWERASE);
+                        addMode(modes, PtyMode.VLNEXT, attributes, ControlChar.VLNEXT);
+                        addMode(modes, PtyMode.VSTATUS, attributes, ControlChar.VSTATUS);
+                        addMode(modes, PtyMode.VDISCARD, attributes, ControlChar.VDISCARD);
                         // Input flags
                         modes.put(PtyMode.IGNPAR, getFlag(attributes, InputFlag.IGNPAR));
                         modes.put(PtyMode.PARMRK, getFlag(attributes, InputFlag.PARMRK));
@@ -306,6 +306,13 @@ public class SshAction implements Action {
         }
 
         return null;
+    }
+
+    private static void addMode(Map<PtyMode, Integer> modes, PtyMode mode, Attributes attributes, ControlChar ctrl) {
+        final int value = attributes.getControlChar(ctrl);
+        if (value != -1) {
+            modes.put(mode, value);
+        }
     }
 
     private static int getFlag(Attributes attributes, InputFlag flag) {


### PR DESCRIPTION
JLine returns -1 for control characters it does not find. SSHD requires modes' values to be unsigned integers. Mind this difference when populating SSHD PtyModes.