### PR TITLE
Upgrade to eclipselink 2.7.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <commons-logging.version>1.2</commons-logging.version>
         <commons-pool2.version>2.11.1</commons-pool2.version>
         <commons-io.version>2.11.0</commons-io.version>
-        <eclipselink.version>2.7.8</eclipselink.version>
+        <eclipselink.version>2.7.11</eclipselink.version>
         <jasypt.bundle.version>1.9.3_1</jasypt.bundle.version>
         <jolokia.version>1.7.1</jolokia.version>
         <servlet.spec.groupId>javax.servlet</servlet.spec.groupId>


### PR DESCRIPTION
eclipselink 2.7.11 is the latest in the 2.x series, released on August 15th 2022.