### PR TITLE
KARAF-7639 Correct feature dependencies and documentation.

### DIFF
--- a/examples/karaf-rest-example/README.md
+++ b/examples/karaf-rest-example/README.md
@@ -56,20 +56,7 @@ On a running Karaf instance, register the features repository using:
 karaf@root()> feature:repo-add mvn:org.apache.karaf.examples/karaf-rest-example-features/LATEST/xml
 ```
 
-As prerequisite, install a HTTP service provider (like `felix-http` or `http` (Pax Web)):
-
-```
-karaf@root()> feature:install http
-karaf@root()> feature:install http-whiteboard
-```
-
-or 
-
-```
-karaf@root()> feature:install felix-http
-```
-
-Then, you can install the service blueprint provider or service SCR provider feature:
+You can install the service blueprint provider or service SCR provider feature:
 
 ```
 karaf@root()> feature:install karaf-rest-example-blueprint
@@ -117,8 +104,31 @@ karaf@root()> booking:list
 
 Instead of the CXF with blueprint `karaf-rest-example-blueprint` feature, or CXF with SCR `karaf-rest-example-scr` feature, you can use the JAXRS Whiteboard approach (with Aries implementation).
 
-Install the `karaf-rest-example-whiteboard` feature:
+Install the service blueprint provider or service SCR provider feature:
 
+```
+karaf@root()> feature:install karaf-rest-example-blueprint
+```
+
+```
+karaf@root()> feature:install karaf-rest-example-scr
+```
+
+Then install the `karaf-rest-example-whiteboard` feature:
 ```
 karaf@root()> feature:install karaf-rest-example-whiteboard
 ```
+
+Add new booking using the CURL utility
+```
+curl  --header "Content-Type: application/json" \
+ --data '{"id": 1, "customer": "John Doe", "flight": "AF520"}' \
+ -X POST http://localhost:8181/booking
+```
+
+Display all booking using the CURL utility
+```
+curl  --header "Accept: application/json" \
+ -X GET http://localhost:8181/booking
+ ```
+ 

--- a/examples/karaf-rest-example/karaf-rest-example-features/src/main/feature/feature.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-features/src/main/feature/feature.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<features name="karaf-rest-example-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0">
+<features name="karaf-rest-example-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0 http://karaf.apache.org/xmlns/features/v1.4.0">
 
     <repository>mvn:org.apache.cxf.karaf/apache-cxf/${cxf.version}/xml/features</repository>
     <repository>mvn:org.apache.aries.jax.rs/org.apache.aries.jax.rs.features/${aries.jax.rs.whiteboard.version}/xml</repository>
@@ -30,11 +30,7 @@
         <requirement>osgi.service;effective:=active;filter:=(objectClass=org.osgi.service.http.HttpService)</requirement>
         <feature dependency="true">aries-blueprint</feature>
         <feature version="${cxf.version}" dependency="true">cxf-jaxrs</feature>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson.version}</bundle>
+        <feature version="${jackson.version}" dependency="true">jackson</feature>
         <bundle>mvn:org.apache.karaf.examples/karaf-rest-example-blueprint/${project.version}</bundle>
     </feature>
 
@@ -43,21 +39,26 @@
     </feature>
     
     <feature name="karaf-rest-example-client-cxf" version="${project.version}">
+        <feature version="${cxf.version}" dependency="true">cxf-jaxrs</feature>
+        <feature version="${project.version}">karaf-rest-example-common</feature>
         <bundle>mvn:org.apache.karaf.examples/karaf-rest-example-client-cxf/${project.version}</bundle>
     </feature>
 
     <feature name="karaf-rest-example-client-jersey" version="${project.version}">
         <feature>jersey</feature>
+        <feature version="${jackson.version}" dependency="true">jackson</feature>
+        <feature version="${jackson.version}" dependency="true">jackson-jaxrs</feature>
+        <bundle>mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${jackson.version}</bundle>
+        <feature version="${project.version}">karaf-rest-example-common</feature>
         <bundle>mvn:org.apache.karaf.examples/karaf-rest-example-client-jersey/${project.version}</bundle>
     </feature>
 
     <feature name="karaf-rest-example-whiteboard" version="${project.version}">
-        <feature version="${project.version}">karaf-rest-example-common</feature>
+        <feature version="${jackson.version}" dependency="true">jackson</feature>
         <feature>pax-web-http-whiteboard</feature>
         <feature>aries-jax-rs-whiteboard</feature>
         <feature>aries-jax-rs-whiteboard-jackson</feature>
-        <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxws-api-2.2/${servicemix-spec.version}</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.3/${servicemix-spec.version}</bundle>
+        <feature version="${project.version}">karaf-rest-example-common</feature>
         <bundle>mvn:org.apache.karaf.examples/karaf-rest-example-whiteboard/${project.version}</bundle>
     </feature>
 
@@ -66,12 +67,6 @@
         <requirement>osgi.service;effective:=active;filter:=(objectClass=org.osgi.service.http.HttpService)</requirement>
         <feature dependency="true">scr</feature>
         <feature version="${cxf.version}" dependency="true">cxf-jaxrs</feature>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson.version}</bundle>
         <bundle>mvn:org.apache.karaf.examples/karaf-rest-example-scr/${project.version}</bundle>
     </feature>
 


### PR DESCRIPTION
- Use Jackson features instead of individual bundles
- Add feature dependencies dependences for clients that can be use with remote providers, i.e. CXF and http.
- Correct the schemaLocation attribute
- Add missing feature and bundle dependencies
- Remove unneeded servicemix bundle dependencies
- Remove HTTP prerequisites as they are installed by the features
- Add Whiteboard documentation