### PR TITLE
[KARAF-7682] Changed handling of the TCP connection to send the stop command 

### DIFF
--- a/main/src/main/java/org/apache/karaf/main/Stop.java
+++ b/main/src/main/java/org/apache/karaf/main/Stop.java
@@ -56,11 +56,13 @@ public class Stop {
         if (config.shutdownPort > 0) {
             try (Socket s = new Socket(config.shutdownHost, config.shutdownPort)) {
                 s.getOutputStream().write(config.shutdownCommand.getBytes());
-                System.exit(0);
+                s.getOutputStream().write('\n');
+                s.getOutputStream().flush();
             } catch (ConnectException connectException) {
                 System.err.println("Can't connect to the container. The container is not running.");
                 System.exit(1);
             }
+            System.exit(0);
         } else {
             // using the pid file
             int pid = getPidFromPidFile(config.pidFile);


### PR DESCRIPTION
The karaf stop command does not always stop the karaf  4.3.6 framework using the loopback stop option.

After research a number of things stand out:

·         There is always a 'java.net.SocketException' in the logging when the karaf framework is stopped
·         The try with resource statement is used on the Socket 
·         A System.exit(0) call is used inside the try block.

Analysis of these findings shows the following issues:

·         The send stopCommand does not include al EOL or EOF character. This results in the read loop ShutdownSocketThread  not exiting, and ultimately throwing a 'java.net.SocketException: Connection Reset'  in the logging.
·         The mechanism try-with-resource closes the socket, but this does not guaranty the flushing of the sockets Outputstream. Because this is done asynchronous and after this statement a System.exit() call is made effectively terminating the JVM.
·         The call to System.exit(0) Terminates the proces without calling the implicit finally clause (which is generated by the java compiler see https://docs.oracle.com/javase/specs/jls/se16/html/jls-14.html#jls-14.20.3  and https://docs.oracle.com/javase/tutorial/essential/exceptions/finally.html ). Because of this calling the close on the Socket is not guaranteed.

Suggested changes:

·         Add EOL to the stopcommand before sending
·         add flush on the outputstream before calling System.exit(0) 
·         Move the System.exit(0) call out of the try block 

 