### PR TITLE
Fix typo in the blacklisted repository tag

### DIFF
--- a/assemblies/features/base/src/main/resources/resources/etc/org.apache.karaf.features.xml
+++ b/assemblies/features/base/src/main/resources/resources/etc/org.apache.karaf.features.xml
@@ -17,6 +17,6 @@
     -->
 
     <!-- you can eventually blacklist features repositories, features, or even bundle here, to exclude from resolution -->
-    <!-- <blacklistRepositories/> -->
+    <!-- <blacklistedRepositories/> -->
 
 </featuresProcessing>


### PR DESCRIPTION
## Motivation

The configuration file `org.apache.karaf.features.xml` proposed OOTB contains a typo in the blacklisted repository tag name which can be error-prone if it is used to create a new tag.

## Modifications:

* Use the proper tag name