### PR TITLE
Update Johnzon to 1.2.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
         <spring.security56.version>5.6.3_1</spring.security56.version>
         <spring.security57.version>5.7.3_1</spring.security57.version>
 
-        <sling.commons.johnzon.version>1.2.14</sling.commons.johnzon.version>
+        <sling.commons.johnzon.version>1.2.16</sling.commons.johnzon.version>
         <sshd.version>2.10.0</sshd.version>
         <struts.bundle.version>1.3.10_1</struts.bundle.version>
         <xbean.version>4.22</xbean.version>


### PR DESCRIPTION
A fix for https://nvd.nist.gov/vuln/detail/CVE-2023-33008