### PR TITLE
KARAF-7713 - Update SSHD to 2.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
         <spring.security57.version>5.7.3_1</spring.security57.version>
 
         <sling.commons.johnzon.version>1.2.14</sling.commons.johnzon.version>
-        <sshd.version>2.9.2</sshd.version>
+        <sshd.version>2.10.0</sshd.version>
         <struts.bundle.version>1.3.10_1</struts.bundle.version>
         <xbean.version>4.22</xbean.version>
         <javax.mail.version>1.4.7</javax.mail.version>


### PR DESCRIPTION
sshd-sftp-2.9.2.jar (pkg:maven/org.apache.sshd/sshd-sftp@2.9.2, cpe:2.3:a:apache:sshd:2.9.2:*:*:*:*:*:*:*) : CVE-2023-35887