### PR TITLE
Refactor assertTrue(!equals()) using assertNotEquals & @Test(excepted) using assertThrows

### DIFF
--- a/event/src/test/java/org/apache/karaf/event/command/EventSendCommandTest.java
+++ b/event/src/test/java/org/apache/karaf/event/command/EventSendCommandTest.java
@@ -25,6 +25,7 @@ import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -77,14 +78,19 @@ public class EventSendCommandTest {
         assertThat(props.size(), equalTo(0));
     }
     
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testParseNoKeyValue() {
-        EventSendCommand.parse(Collections.singletonList("="));
+        assertThrows(IllegalArgumentException.class, () -> {
+            EventSendCommand.parse(Collections.singletonList("="));
+        });
     }
     
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testParseNoKey() {
-        EventSendCommand.parse(Collections.singletonList("=b"));
+        assertThrows(IllegalArgumentException.class, () -> {
+            EventSendCommand.parse(Collections.singletonList("=b"));
+        });
+
     }
     
     @Test

--- a/service/guard/src/test/java/org/apache/karaf/service/guard/impl/GuardProxyCatalogTest.java
+++ b/service/guard/src/test/java/org/apache/karaf/service/guard/impl/GuardProxyCatalogTest.java
@@ -19,6 +19,7 @@ package org.apache.karaf.service.guard.impl;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -715,7 +716,7 @@ public class GuardProxyCatalogTest {
         Thread.enumerate(tarray);
         for (Thread t : tarray) {
             if (t != null) {
-                assertTrue(!GuardProxyCatalog.PROXY_CREATOR_THREAD_NAME.equals(t.getName()));
+                assertNotEquals(GuardProxyCatalog.PROXY_CREATOR_THREAD_NAME, t.getName());
             }
         }
 
@@ -762,7 +763,7 @@ public class GuardProxyCatalogTest {
         Thread.enumerate(tarray4);
         for (Thread t : tarray4) {
             if (t != null) {
-                assertTrue(!GuardProxyCatalog.PROXY_CREATOR_THREAD_NAME.equals(t.getName()));
+                assertNotEquals(GuardProxyCatalog.PROXY_CREATOR_THREAD_NAME, t.getName());
             }
         }
     }


### PR DESCRIPTION
I am working on research that investigates test smell refactoring in which we identify alternative implementations of test cases, study how commonly used these refactorings are, and assess how acceptable they are in practice.

The first smell is when inappropriate assertions are used, while there exist better alternatives. For example, in [GuardProxyCatalogTest.java](https://github.com/apache/karaf/commit/d0456624885a9bff8d4418614b1e8469981c26c3#diff-de2cfbdc07af433a0de11f25b23069dabd16eba9eb4e3157701fbd89562c10b7), I refactored `assertTrue(!GuardProxyCatalog.PROXY_CREATOR_THREAD_NAME.equals(t.getName()));` using `assertNotEquals(GuardProxyCatalog.PROXY_CREATOR_THREAD_NAME, t.getName());`.

The second smell is when exception handling can alternatively be implemented using assertion rather than annotation. For example, in [EventSendCommandTest.java](https://github.com/apache/karaf/commit/100420f757c2bd6fe00a8d28c14a1388d665b8fe#diff-80c4f1284affb61c43d9458dcb2580b0c7d770415291e34238bfc238a7cf6451), I used `assertThrows(IllegalArgumentException.class, () -> {...});` instead of `@Test(expected=IllegalArgumentException.class)`.

While there could be several cases like this, we aim in this pull request to get your feedback on these particular test smells and their refactorings. Thanks in advance for your input.