### PR TITLE
[KARAF-7692]: Use pax-web-8.0.21

### DIFF
--- a/examples/karaf-graphql-example/karaf-graphql-example-features/src/main/feature/feature.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-features/src/main/feature/feature.xml
@@ -41,7 +41,7 @@
         <bundle dependency="true">mvn:com.graphql-java-kickstart/graphql-java-servlet/14.0.0</bundle>
 
         <bundle dependency="true">mvn:io.reactivex.rxjava3/rxjava/3.1.5</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.websocket/websocket-server/9.4.49.v20220914</bundle>
+        <bundle dependency="true">mvn:org.eclipse.jetty.websocket/websocket-server/9.4.52.v20230823</bundle>
 
         <bundle>mvn:org.apache.karaf.examples/karaf-graphql-example-api/${project.version}</bundle>
         <bundle>mvn:org.apache.karaf.examples/karaf-graphql-example-core/${project.version}</bundle>

--- a/examples/karaf-graphql-example/karaf-graphql-example-websocket/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-websocket/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-servlet</artifactId>
-            <version>9.4.48.v20220622</version>
+            <version>9.4.52.v20230823</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/examples/karaf-websocket-example/pom.xml
+++ b/examples/karaf-websocket-example/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-servlet</artifactId>
-            <version>9.4.49.v20220914</version>
+            <version>9.4.52.v20230823</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/itests/test/pom.xml
+++ b/itests/test/pom.xml
@@ -206,13 +206,13 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-client</artifactId>
-            <version>9.4.31.v20200723</version>
+            <version>9.4.52.v20230823</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.31.v20200723</version>
+            <version>9.4.52.v20230823</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
         <pax.base.version>1.5.1</pax.base.version>
         <pax.swissbox.version>1.8.5</pax.swissbox.version>
         <pax.url.version>2.6.12</pax.url.version>
-        <pax.web.version>8.0.15</pax.web.version>
+        <pax.web.version>8.0.21</pax.web.version>
         <pax.tinybundle.version>3.0.0</pax.tinybundle.version>
         <pax.jdbc.version>1.5.6</pax.jdbc.version>
         <pax.jms.version>1.1.3</pax.jms.version>


### PR DESCRIPTION
https://github.com/ops4j/org.ops4j.pax.web/milestone/238?closed=1 https://github.com/ops4j/org.ops4j.pax.web/milestone/239?closed=1 https://github.com/ops4j/org.ops4j.pax.web/milestone/241?closed=1 https://github.com/ops4j/org.ops4j.pax.web/milestone/243?closed=1 https://github.com/ops4j/org.ops4j.pax.web/milestone/245?closed=1 https://github.com/ops4j/org.ops4j.pax.web/milestone/247?closed=1

Also pick up Jetty 9.4.51.v20230217.