### PR TITLE
auto-link to ASF Jira

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,3 +17,6 @@
 
 notifications:
   pullrequests: commits@karaf.apache.org
+github:
+  autolink_jira:
+    - KARAF


### PR DESCRIPTION
see infra documentation on the feature https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=127405038#Git.asf.yamlfeatures-AutolinksforJira