### PR TITLE
[KARAF-7766] Require Java 11 at runtime

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/inc
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/inc
@@ -243,9 +243,9 @@ checkJvmVersion() {
 
     VERSION=`"${JAVA}" -version 2>&1 | ${AWK} -F '"' '/version/ {print $2}' | sed -e 's/_.*//g; s/^1\.//g; s/\..*//g; s/-.*//g;s/-.*//g; s/^[A-Za-z].*//'`
 
-    # java must be at least version 8
-    if [ "${VERSION}" -lt "8" ]; then
-        die "JVM must be version 1.8 or greater"
+    # java must be at least version 11
+    if [ "${VERSION}" -lt "11" ]; then
+        die "JVM must be version 11 or greater"
     fi
 }
 

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf
@@ -160,7 +160,7 @@ init() {
     # Determine the JVM vendor
     detectJVM
 
-    # Determine the JVM version >= 1.6
+    # Determine and enforce the JVM version
     checkJvmVersion
 
     # Check if a root instance is already running
@@ -300,62 +300,42 @@ run() {
         fi
 
         if [ "${ROOT_INSTANCE_RUNNING}" = "false" ] || [ "${CHECK_ROOT_INSTANCE_RUNNING}" = "false" ] ; then
-            if [ "${VERSION}" -gt "8" ]; then
-                ${KARAF_EXEC} "${JAVA}" ${JAVA_OPTS} \
-                    --add-reads=java.xml=java.logging \
-                    --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED \
-                    --patch-module java.base="${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.locator-@@project.version@@.jar" \
-                    --patch-module java.xml="${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.java.xml-@@project.version@@.jar" \
-                    --add-opens java.base/java.security=ALL-UNNAMED \
-                    --add-opens java.base/java.net=ALL-UNNAMED \
-                    --add-opens java.base/java.lang=ALL-UNNAMED \
-                    --add-opens java.base/java.util=ALL-UNNAMED \
-                    --add-opens java.naming/javax.naming.spi=ALL-UNNAMED \
-                    --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED \
-                    --add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED \
-                    --add-exports=java.base/sun.net.www.protocol.ftp=ALL-UNNAMED \
-                    --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED \
-                    --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED \
-                    --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED \
-                    --add-exports=java.base/sun.net.www.content.text=ALL-UNNAMED \
-                    --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED \
-                    --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED \
-                    --add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED \
-                    --add-exports=java.security.sasl/com.sun.security.sasl=ALL-UNNAMED \
-                    --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED \
-                    -Dkaraf.instances="${KARAF_HOME}/instances" \
-                    -Dkaraf.home="${KARAF_HOME}" \
-                    -Dkaraf.base="${KARAF_BASE}" \
-                    -Dkaraf.data="${KARAF_DATA}" \
-                    -Dkaraf.etc="${KARAF_ETC}" \
-                    -Dkaraf.log="${KARAF_LOG}" \
-                    -Dkaraf.restart.jvm.supported=true \
-                    -Djava.io.tmpdir="${KARAF_DATA}/tmp" \
-                    -Djava.util.logging.config.file="${KARAF_BASE}/etc/java.util.logging.properties" \
-                    ${KARAF_SYSTEM_OPTS} \
-                    ${KARAF_OPTS} \
-                    ${OPTS} \
-                    -classpath "${CLASSPATH}" \
-                    ${MAIN} "$@"
-            else
-                ${KARAF_EXEC} "${JAVA}" ${JAVA_OPTS} \
-                    -Djava.endorsed.dirs="${JAVA_ENDORSED_DIRS}" \
-                    -Djava.ext.dirs="${JAVA_EXT_DIRS}" \
-                    -Dkaraf.instances="${KARAF_HOME}/instances" \
-                    -Dkaraf.home="${KARAF_HOME}" \
-                    -Dkaraf.base="${KARAF_BASE}" \
-                    -Dkaraf.data="${KARAF_DATA}" \
-                    -Dkaraf.etc="${KARAF_ETC}" \
-                    -Dkaraf.log="${KARAF_LOG}" \
-                    -Dkaraf.restart.jvm.supported=true \
-                    -Djava.io.tmpdir="${KARAF_DATA}/tmp" \
-                    -Djava.util.logging.config.file="${KARAF_BASE}/etc/java.util.logging.properties" \
-                    ${KARAF_SYSTEM_OPTS} \
-                    ${KARAF_OPTS} \
-                    ${OPTS} \
-                    -classpath "${CLASSPATH}" \
-                    ${MAIN} "$@"
-            fi
+            ${KARAF_EXEC} "${JAVA}" ${JAVA_OPTS} \
+                --add-reads=java.xml=java.logging \
+                --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED \
+                --patch-module java.base="${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.locator-@@project.version@@.jar" \
+                --patch-module java.xml="${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.java.xml-@@project.version@@.jar" \
+                --add-opens java.base/java.security=ALL-UNNAMED \
+                --add-opens java.base/java.net=ALL-UNNAMED \
+                --add-opens java.base/java.lang=ALL-UNNAMED \
+                --add-opens java.base/java.util=ALL-UNNAMED \
+                --add-opens java.naming/javax.naming.spi=ALL-UNNAMED \
+                --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED \
+                --add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED \
+                --add-exports=java.base/sun.net.www.protocol.ftp=ALL-UNNAMED \
+                --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED \
+                --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED \
+                --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED \
+                --add-exports=java.base/sun.net.www.content.text=ALL-UNNAMED \
+                --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED \
+                --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED \
+                --add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED \
+                --add-exports=java.security.sasl/com.sun.security.sasl=ALL-UNNAMED \
+                --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED \
+                -Dkaraf.instances="${KARAF_HOME}/instances" \
+                -Dkaraf.home="${KARAF_HOME}" \
+                -Dkaraf.base="${KARAF_BASE}" \
+                -Dkaraf.data="${KARAF_DATA}" \
+                -Dkaraf.etc="${KARAF_ETC}" \
+                -Dkaraf.log="${KARAF_LOG}" \
+                -Dkaraf.restart.jvm.supported=true \
+                -Djava.io.tmpdir="${KARAF_DATA}/tmp" \
+                -Djava.util.logging.config.file="${KARAF_BASE}/etc/java.util.logging.properties" \
+                ${KARAF_SYSTEM_OPTS} \
+                ${KARAF_OPTS} \
+                ${OPTS} \
+                -classpath "${CLASSPATH}" \
+                ${MAIN} "$@"
         else
             die "There is a Root instance already running with name ${ROOT_INSTANCE_NAME} and pid ${ROOT_INSTANCE_PID}. If you know what you are doing and want to force the run anyway, export CHECK_ROOT_INSTANCE_RUNNING=false and re run the command."
         fi

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat
@@ -418,56 +418,39 @@ if "%KARAF_PROFILER%" == "" goto :RUN
     if "%IS_RUNNABLE%" == "true" (
         rem If major version is greater than 1 (meaning Java 9 or 10), we don't use endorsed lib but module
         rem If major version is 1 (meaning Java 1.6, 1.7, 1.8), we use endorsed lib
-        if %JAVA_VERSION% GTR 8 (
-            "%JAVA%" %JAVA_OPTS% %OPTS% ^
-                --add-reads=java.xml=java.logging ^
-                --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED ^
-                --patch-module java.base="%KARAF_HOME%\lib\endorsed\org.apache.karaf.specs.locator-@@project.version@@.jar" ^
-                --patch-module java.xml="%KARAF_HOME%\lib\endorsed\org.apache.karaf.specs.java.xml-@@project.version@@.jar" ^
-                --add-opens java.base/java.security=ALL-UNNAMED ^
-                --add-opens java.base/java.net=ALL-UNNAMED ^
-                --add-opens java.base/java.lang=ALL-UNNAMED ^
-                --add-opens java.base/java.util=ALL-UNNAMED ^
-                --add-opens java.naming/javax.naming.spi=ALL-UNNAMED ^
-                --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED ^
-                --add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED ^
-                --add-exports=java.base/sun.net.www.protocol.ftp=ALL-UNNAMED ^
-                --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED ^
-                --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED ^
-                --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED ^
-                --add-exports=java.base/sun.net.www.content.text=ALL-UNNAMED ^
-                --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED ^
-                --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED ^
-                --add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED ^
-                --add-exports=java.security.sasl/com.sun.security.sasl=ALL-UNNAMED ^
-                --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED ^
-                -classpath "%CLASSPATH%" ^
-                -Dkaraf.instances="%KARAF_HOME%\instances" ^
-                -Dkaraf.home="%KARAF_HOME%" ^
-                -Dkaraf.base="%KARAF_BASE%" ^
-                -Dkaraf.etc="%KARAF_ETC%" ^
-                -Dkaraf.log="%KARAF_LOG%" ^
-                -Dkaraf.restart.jvm.supported=true ^
-                -Djava.io.tmpdir="%KARAF_DATA%\tmp" ^
-                -Dkaraf.data="%KARAF_DATA%" ^
-                -Djava.util.logging.config.file="%KARAF_BASE%\etc\java.util.logging.properties" ^
-                %KARAF_SYSTEM_OPTS% %KARAF_OPTS% %MAIN% %ARGS%
-        ) else (
-            "%JAVA%" %JAVA_OPTS% %OPTS% ^
-                -classpath "%CLASSPATH%" ^
-                -Djava.endorsed.dirs="%JAVA_HOME%\jre\lib\endorsed;%JAVA_HOME%\lib\endorsed;%KARAF_HOME%\lib\endorsed" ^
-                -Djava.ext.dirs="%JAVA_HOME%\jre\lib\ext;%JAVA_HOME%\lib\ext;%KARAF_HOME%\lib\ext" ^
-                -Dkaraf.instances="%KARAF_HOME%\instances" ^
-                -Dkaraf.home="%KARAF_HOME%" ^
-                -Dkaraf.base="%KARAF_BASE%" ^
-                -Dkaraf.etc="%KARAF_ETC%" ^
-                -Dkaraf.log="%KARAF_LOG%" ^
-                -Dkaraf.restart.jvm.supported=true ^
-                -Djava.io.tmpdir="%KARAF_DATA%\tmp" ^
-                -Dkaraf.data="%KARAF_DATA%" ^
-                -Djava.util.logging.config.file="%KARAF_BASE%\etc\java.util.logging.properties" ^
-                %KARAF_SYSTEM_OPTS% %KARAF_OPTS% %MAIN% %ARGS%
-        )
+        "%JAVA%" %JAVA_OPTS% %OPTS% ^
+        --add-reads=java.xml=java.logging ^
+        --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED ^
+        --patch-module java.base="%KARAF_HOME%\lib\endorsed\org.apache.karaf.specs.locator-@@project.version@@.jar" ^
+        --patch-module java.xml="%KARAF_HOME%\lib\endorsed\org.apache.karaf.specs.java.xml-@@project.version@@.jar" ^
+        --add-opens java.base/java.security=ALL-UNNAMED ^
+        --add-opens java.base/java.net=ALL-UNNAMED ^
+        --add-opens java.base/java.lang=ALL-UNNAMED ^
+        --add-opens java.base/java.util=ALL-UNNAMED ^
+        --add-opens java.naming/javax.naming.spi=ALL-UNNAMED ^
+        --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED ^
+        --add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED ^
+        --add-exports=java.base/sun.net.www.protocol.ftp=ALL-UNNAMED ^
+        --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED ^
+        --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED ^
+        --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED ^
+        --add-exports=java.base/sun.net.www.content.text=ALL-UNNAMED ^
+        --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED ^
+        --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED ^
+        --add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED ^
+        --add-exports=java.security.sasl/com.sun.security.sasl=ALL-UNNAMED ^
+        --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED ^
+        -classpath "%CLASSPATH%" ^
+        -Dkaraf.instances="%KARAF_HOME%\instances" ^
+        -Dkaraf.home="%KARAF_HOME%" ^
+        -Dkaraf.base="%KARAF_BASE%" ^
+        -Dkaraf.etc="%KARAF_ETC%" ^
+        -Dkaraf.log="%KARAF_LOG%" ^
+        -Dkaraf.restart.jvm.supported=true ^
+        -Djava.io.tmpdir="%KARAF_DATA%\tmp" ^
+        -Dkaraf.data="%KARAF_DATA%" ^
+        -Djava.util.logging.config.file="%KARAF_BASE%\etc\java.util.logging.properties" ^
+        %KARAF_SYSTEM_OPTS% %KARAF_OPTS% %MAIN% %ARGS%
     ) else (
         echo There is a Root instance already running with name %ROOT_INSTANCE_NAME% and pid %ROOT_INSTANCE_PID%. If you know what you are doing and want to force the run anyway, SET CHECK_ROOT_INSTANCE_RUNNING=false and re run the command.
         goto :END

--- a/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat
+++ b/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat
@@ -416,8 +416,6 @@ if "%KARAF_PROFILER%" == "" goto :RUN
     if "%ROOT_INSTANCE_RUNNING%" == "false" SET IS_RUNNABLE=true
     if "%CHECK_ROOT_INSTANCE_RUNNING%" == "false" SET IS_RUNNABLE=true
     if "%IS_RUNNABLE%" == "true" (
-        rem If major version is greater than 1 (meaning Java 9 or 10), we don't use endorsed lib but module
-        rem If major version is 1 (meaning Java 1.6, 1.7, 1.8), we use endorsed lib
         "%JAVA%" %JAVA_OPTS% %OPTS% ^
         --add-reads=java.xml=java.logging ^
         --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED ^


### PR DESCRIPTION
Enforce JVM version 11 on startup. Also simplify ./bin/karaf(.bat).

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
