### PR TITLE
fix a typo in javadoc

### DIFF
--- a/shell/core/src/main/java/org/apache/karaf/shell/api/action/lifecycle/Reference.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/api/action/lifecycle/Reference.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 
 /**
  * A class annotated with {@link Service} can have fields
- * annotated with <code>@Service</code> in which case matching
+ * annotated with <code>@Reference</code> in which case matching
  * services will be retrieved from the
  * {@link org.apache.karaf.shell.api.console.Registry} and
  * injected.


### PR DESCRIPTION
This same change was made by @Brimstedt in #127 years ago, but was reverted by @jbonofre arguing it was correct before.

However I tripped over this recently so I glanced over the implementation and saw that [CommandExtension](https://github.com/apache/karaf/blob/karaf-4.4.4/shell/core/src/main/java/org/apache/karaf/shell/impl/action/osgi/CommandExtension.java#L181-L194) only looks for fields annotated with `@Reference`, so I don't see how anything would be injected into a field that has been annotated with `@Service`. Also (as Brimstedt mentioned) `@Service` isn't even applicable to fields, only to types.

All things considered, I still think this is a typo, so I'd like this change to be considered once more.