### PR TITLE
Fix flaky main.src.test.java.org.apache.karaf.main.MainLockingTest.testLostMasterLockAfterThreshold

### DIFF
--- a/main/src/test/java/org/apache/karaf/main/MainLockingTest.java
+++ b/main/src/test/java/org/apache/karaf/main/MainLockingTest.java
@@ -187,7 +187,7 @@ public class MainLockingTest {
         FrameworkStartLevel sl = framework.adapt(FrameworkStartLevel.class);
 
         MockLock lock = (MockLock) main.getLock();
-
+        Thread.sleep(1000);
         Assert.assertEquals(100, sl.getStartLevel());
 
         // simulate losing a lock


### PR DESCRIPTION
### Description

#### Test failure Reproduction
We use [idflakies](https://github.com/UT-SE-Research/iDFlakies) to detect the flaky test.
```
mvn install -pl main -am -DskipTests
mvn -pl main idflakies:detect -Ddetector.detector_type=random-class-method -Ddt.randomize.rounds=10 -Ddt.detector.original_order.all_must_pass=false

```
#### Root cause and fix
This error is caused by line 140. 
```
Assert.assertEquals(100, sl.getStartLevel()); 
```
It asserted the startlevel wirh 100 which means the process got the lock.  The flaky is caused by the test didn't wait for the process to change the start level. So, sometimes the test will fail by the start level is 1 which means the process didn't have the lock. To fix this, I added
```
Thread.sleep(1000);
```
after the process gets the lock to ensure the start level has time to chang.