### PR TITLE
WIP: [KARAF-7780] Draft feature for Jakarta specs using capability/requirement

### DIFF
--- a/assemblies/features/jakarta/pom.xml
+++ b/assemblies/features/jakarta/pom.xml
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.karaf.assemblies.features</groupId>
+        <artifactId>features</artifactId>
+        <version>4.5.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.karaf.features</groupId>
+    <artifactId>jakarta</artifactId>
+    <packaging>pom</packaging>
+    <name>Apache Karaf :: Assemblies :: Features :: Jakarta</name>
+
+    <properties>
+        <appendedResourcesDirectory>${basedir}/../../../etc/appended-resources</appendedResourcesDirectory>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>karaf-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- Framework distribution -->
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>framework</artifactId>
+            <type>kar</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- transaction deps -->
+        <dependency>
+            <groupId>org.apache.aries.transaction</groupId>
+            <artifactId>org.apache.aries.transaction.blueprint</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- jpa deps -->
+        <dependency>
+            <groupId>org.apache.aries</groupId>
+            <artifactId>org.apache.aries.util</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jpa</groupId>
+            <artifactId>org.apache.aries.jpa.api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jpa</groupId>
+            <artifactId>org.apache.aries.jpa.blueprint.aries</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jpa</groupId>
+            <artifactId>org.apache.aries.jpa.container</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jpa</groupId>
+            <artifactId>org.apache.aries.jpa.container.context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- jndi deps -->
+        <dependency>
+            <groupId>org.apache.aries.jndi</groupId>
+            <artifactId>org.apache.aries.jndi.api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jndi</groupId>
+            <artifactId>org.apache.aries.jndi.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jndi</groupId>
+            <artifactId>org.apache.aries.jndi.rmi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jndi</groupId>
+            <artifactId>org.apache.aries.jndi.url</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jndi</groupId>
+            <artifactId>org.apache.aries.jndi.legacy.support</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- application-without-isolation deps -->
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>standard</artifactId>
+            <classifier>features</classifier>
+            <type>xml</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.application</groupId>
+            <artifactId>org.apache.aries.application.resolver.obr</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.application</groupId>
+            <artifactId>org.apache.aries.application.install</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.application</groupId>
+            <artifactId>org.apache.aries.application.api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.application</groupId>
+            <artifactId>org.apache.aries.application.management</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.application</groupId>
+            <artifactId>org.apache.aries.application.utils</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.application</groupId>
+            <artifactId>org.apache.aries.application.modeller</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.application</groupId>
+            <artifactId>org.apache.aries.application.default.local.platform</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.application</groupId>
+            <artifactId>org.apache.aries.application.deployment.management</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- without isolation -->
+        <dependency>
+            <groupId>org.apache.aries.application</groupId>
+            <artifactId>org.apache.aries.application.runtime</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- subsystems -->
+        <dependency>
+            <groupId>org.apache.karaf.services</groupId>
+            <artifactId>org.apache.karaf.services.coordinator</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.subsystem</groupId>
+            <artifactId>org.apache.karaf.subsystem.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.cdi</groupId>
+            <artifactId>pax-cdi-features</artifactId>
+            <version>${pax.cdi.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- hibernate deps -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-osgi</artifactId>
+            <version>${hibernate.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/feature</directory>
+                <filtering>true</filtering>
+                <targetPath>${project.build.directory}/feature</targetPath>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>resources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>verify</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>mvn:org.apache.karaf.features/framework/${project.version}/xml/features</descriptor>
+                                <descriptor>mvn:org.apache.karaf.features/specs/${project.version}/xml/features</descriptor>
+                                <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
+                            </descriptors>
+                            <distribution>org.apache.karaf.features:framework</distribution>
+                            <javase>1.8</javase>
+                            <framework>
+                                <feature>framework</feature>
+                            </framework>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/feature/feature.xml</file>
+                                    <classifier>features</classifier>
+                                    <type>xml</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.karaf.tooling</groupId>
+                        <artifactId>karaf-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>verify</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/assemblies/features/jakarta/src/main/feature/feature-activemq.xml
+++ b/assemblies/features/jakarta/src/main/feature/feature-activemq.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<features name="activemq" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
+
+  <feature name="activemq-client" description="ActiveMQ client libraries" version="6.0.0">
+    <feature version="[5,7)">spring</feature>
+    <bundle>mvn:org.apache.commons/commons-pool2/2.12.0</bundle>
+    <bundle>mvn:org.apache.activemq/activemq-osgi/6.0.0</bundle>
+    <capability>
+      jakarta-jms;provider:=activemq
+    </capability>
+    <requirement>
+      jakarta-jms-api
+    </requirement>
+  </feature>
+
+</features>

--- a/assemblies/features/jakarta/src/main/feature/feature-cxf.xml
+++ b/assemblies/features/jakarta/src/main/feature/feature-cxf.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<features name="cxf" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
+
+  <feature name="cxf-ws-rs" version="3.6.2">
+    <feature version="3.6.2">cxf-core</feature>
+    <feature version="3.6.2">cxf-http</feature>
+    <feature version="3.6.2">cxf-jackson</feature>
+    <feature version="3.6.2">cxf-rt-security</feature>
+    <bundle start-level="30" dependency="true">mvn:org.codehaus.jettison/jettison/1.5.4</bundle>
+    <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-rs-extension-providers/3.6.2</bundle>
+    <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-rs-extension-search/3.6.2</bundle>
+    <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-rs-json-basic/3.6.2</bundle><bundle start-level="40">mvn:org.apache.cxf/cxf-rt-rs-service-description/3.6.2</bundle>
+    <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-frontend-jaxrs/3.6.2</bundle>
+    <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-rs-client/3.6.2</bundle>
+    <capability>
+      jakarta-ws-rs;provider:=cxf-ws-rs-server
+    </capability>
+    <requirement>
+      jakarta-ws-rs-api
+    </requirement>
+  </feature>
+</features>

--- a/assemblies/features/jakarta/src/main/feature/feature-eclipse-angus.xml
+++ b/assemblies/features/jakarta/src/main/feature/feature-eclipse-angus.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<features name="eclipse-angus" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
+
+  <feature name="eclipse-angus-activation" version="2.1">
+    <bundle dependency="true">org.eclipse.angus/angus-activation/2.0.1</bundle>
+    <requirement>
+      jakarta-activation-api
+    </requirement>
+     <capability>
+      jakarta-activation;provider:=eclipse-angus
+    </capability>
+  </feature>
+
+  <feature name="eclipse-angus-mail" version="2.1">
+    <bundle dependency="true">org.eclipse.angus/angus-mail/2.0.2</bundle>
+    <requirement>
+      jakarta-mail-api
+    </requirement>
+     <capability>
+      jakarta-mail;provider:=eclipse-angus
+    </capability>
+  </feature>
+
+</features>

--- a/assemblies/features/jakarta/src/main/feature/feature-glassfish-jaxb.xml
+++ b/assemblies/features/jakarta/src/main/feature/feature-glassfish-jaxb.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<features name="glassfish-jaxb" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
+
+  <feature name="glassfish-jaxb" version="4.0.4">
+    <bundle dependency="true">com.sun.istack/istack-commons-runtime/4.1.2</bundle>
+    <bundle dependency="true">org.glassfish.jaxb/jaxb-core/4.0.4</bundle>
+    <bundle dependency="true">org.glassfish.jaxb/tw2/4.0.4</bundle>
+    <requirement>
+      jakarta-activation-api
+    </requirement>
+    <requirement>
+      jakarta-jaxb-api
+    </requirement>
+     <capability>
+      jakarta-jaxb;provider:=glassfish-jaxb
+    </capability>
+  </feature>
+
+</features>

--- a/assemblies/features/jakarta/src/main/feature/feature.xml
+++ b/assemblies/features/jakarta/src/main/feature/feature.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<features name="jakarta-10-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
+
+  <feature name="jakarta-activation-api" version="2.1">
+    <bundle dependency="true">jakarta.activation/jakarta.activation-api/2.1.2</bundle>
+     <capability>
+      jakarta-activation-api;provider:=jakarta
+    </capability>
+  </feature>
+
+  <feature name="jakarta-annotation-api" version="2.1">
+    <bundle dependency="true">mvn:jakarta.annotation/jakarta.annotation-api/2.1.1</bundle>
+    <capability>
+      jakarta-annotation-api;provider:=jakarta
+    </capability>
+  </feature>
+
+  <feature name="jakarta-jms-api" version="3.1">
+    <bundle dependency="true">mvn:jakarta.jms/jakarta.jms-api/3.1.0</bundle>
+    <capability>
+      jakarta-jms-api;provider:=jakarta
+    </capability>
+  </feature>
+
+  <feature name="jakarta-mail-api" version="3.1">
+    <bundle dependency="true">mvn:jakarta.mail/jakarta.mail-api/2.1.2</bundle>
+    <capability>
+      jakarta-mail-api;provider:=jakarta
+    </capability>
+    <requirement>
+      jakarta-activation-api
+    </requirement>
+  </feature>
+
+  <feature name="jakarta-xml-bind-api" version="3.1">
+    <bundle dependency="true">mvn:jakarta.xml.bind/jakarta.xml.bind-api/4.0.1</bundle>
+    <capability>
+      jakarta-xml-bind-api;provider:=jakarta
+    </capability>
+    <requirement>
+      jakarta-activation-api
+    </requirement>
+  </feature>
+
+</features>

--- a/assemblies/features/pom.xml
+++ b/assemblies/features/pom.xml
@@ -42,6 +42,7 @@
         <module>spring</module>
         <module>spring-legacy</module>
         <module>enterprise</module>
+        <module>jakarta</module>
     </modules>
 
 </project>


### PR DESCRIPTION
- [ ] Move to using BOMs for version numbers
- [ ] Add version ranges to <requirement .. />

Benefits:
- Independent api/impl features
- Support Jakarta EE version(s) (9, 10, 11, etc)
- Easy for users to create custom assemblies where impls are upgraded across the stack (ie.. upgrade JAXB 4.0.2 -> 4.0.4) without having to modify all the downstream implementation features