### PR TITLE
[KARAF-7544] Clean up Jetty/servlet-api use

### DIFF
--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -910,7 +910,7 @@ org.osgi.service.http.port=8181
         <feature>pax-web-http-war</feature>
     </feature>
 
-    <feature name="jetty" description="Transition feature for backward compatibility" version="9.4.52.v20230823">
+    <feature name="jetty" description="Transition feature for backward compatibility" version="${jetty.version}">
         <feature>pax-web-jetty</feature>
     </feature>
 

--- a/examples/karaf-docker-example/karaf-docker-example-app/pom.xml
+++ b/examples/karaf-docker-example/karaf-docker-example-app/pom.xml
@@ -56,9 +56,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <groupId>${servlet.spec.groupId}</groupId>
+            <artifactId>${servlet.spec.artifactId}</artifactId>
+            <version>${servlet.spec.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/examples/karaf-graphql-example/karaf-graphql-example-features/src/main/feature/feature.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-features/src/main/feature/feature.xml
@@ -41,7 +41,7 @@
         <bundle dependency="true">mvn:com.graphql-java-kickstart/graphql-java-servlet/14.0.0</bundle>
 
         <bundle dependency="true">mvn:io.reactivex.rxjava3/rxjava/3.1.5</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.websocket/websocket-server/9.4.52.v20230823</bundle>
+        <bundle dependency="true">mvn:org.eclipse.jetty.websocket/websocket-server/${jetty.version}</bundle>
 
         <bundle>mvn:org.apache.karaf.examples/karaf-graphql-example-api/${project.version}</bundle>
         <bundle>mvn:org.apache.karaf.examples/karaf-graphql-example-core/${project.version}</bundle>

--- a/examples/karaf-graphql-example/karaf-graphql-example-websocket/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-websocket/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-servlet</artifactId>
-            <version>9.4.52.v20230823</version>
+            <version>${jetty.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/examples/karaf-jaas-example/karaf-jaas-example-wab/pom.xml
+++ b/examples/karaf-jaas-example/karaf-jaas-example-wab/pom.xml
@@ -34,9 +34,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <groupId>${servlet.spec.groupId}</groupId>
+            <artifactId>${servlet.spec.artifactId}</artifactId>
+            <version>${servlet.spec.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/examples/karaf-servlet-example/karaf-servlet-example-annotation/pom.xml
+++ b/examples/karaf-servlet-example/karaf-servlet-example-annotation/pom.xml
@@ -34,9 +34,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <groupId>${servlet.spec.groupId}</groupId>
+            <artifactId>${servlet.spec.artifactId}</artifactId>
+            <version>${servlet.spec.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/examples/karaf-servlet-example/karaf-servlet-example-blueprint/pom.xml
+++ b/examples/karaf-servlet-example/karaf-servlet-example-blueprint/pom.xml
@@ -34,9 +34,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
+            <groupId>${servlet.spec.groupId}</groupId>
+            <artifactId>${servlet.spec.artifactId}</artifactId>
+            <version>${servlet.spec.version}</version>
         </dependency>
     </dependencies>
 

--- a/examples/karaf-servlet-example/karaf-servlet-example-registration/pom.xml
+++ b/examples/karaf-servlet-example/karaf-servlet-example-registration/pom.xml
@@ -34,9 +34,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
+            <groupId>${servlet.spec.groupId}</groupId>
+            <artifactId>${servlet.spec.artifactId}</artifactId>
+            <version>${servlet.spec.version}</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/examples/karaf-servlet-example/karaf-servlet-example-scr/pom.xml
+++ b/examples/karaf-servlet-example/karaf-servlet-example-scr/pom.xml
@@ -40,9 +40,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
+            <groupId>${servlet.spec.groupId}</groupId>
+            <artifactId>${servlet.spec.artifactId}</artifactId>
+            <version>${servlet.spec.version}</version>
         </dependency>
     </dependencies>
 

--- a/examples/karaf-servlet-example/karaf-servlet-example-upload/pom.xml
+++ b/examples/karaf-servlet-example/karaf-servlet-example-upload/pom.xml
@@ -46,9 +46,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
+            <groupId>${servlet.spec.groupId}</groupId>
+            <artifactId>${servlet.spec.artifactId}</artifactId>
+            <version>${servlet.spec.version}</version>
         </dependency>
     </dependencies>
 

--- a/examples/karaf-websocket-example/pom.xml
+++ b/examples/karaf-websocket-example/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-servlet</artifactId>
-            <version>9.4.52.v20230823</version>
+            <version>${jetty.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/itests/test/pom.xml
+++ b/itests/test/pom.xml
@@ -206,13 +206,13 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-client</artifactId>
-            <version>9.4.52.v20230823</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.52.v20230823</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,7 @@
         <pax.swissbox.version>1.8.5</pax.swissbox.version>
         <pax.url.version>2.6.14</pax.url.version>
         <pax.web.version>8.0.22</pax.web.version>
+        <jetty.version>9.4.52.v20230823</jetty.version>
         <pax.tinybundle.version>3.0.0</pax.tinybundle.version>
         <pax.jdbc.version>1.5.6</pax.jdbc.version>
         <pax.jms.version>1.1.3</pax.jms.version>


### PR DESCRIPTION
Centralize Jetty version in a property and clean up references to servlet-api, making future upgrades easier.
