### PR TITLE
[KARAF-7758] Remove forkMode parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,6 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.1.2</version>
                     <configuration>
-                            <forkMode>once</forkMode>
                             <argLine>
                                 --add-opens java.base/java.security=ALL-UNNAMED
                                 --add-opens java.base/java.net=ALL-UNNAMED 


### PR DESCRIPTION
surefire has removed forkMode parameter, with the default being the equivalent
of forkMode=single. Remove the explicit parameter, fixing a Maven warning.
