### PR TITLE
allow using `overrides.properties` while generating repositories

### DIFF
--- a/manual/src/main/asciidoc/developer-guide/karaf-maven-plugin.adoc
+++ b/manual/src/main/asciidoc/developer-guide/karaf-maven-plugin.adoc
@@ -378,6 +378,10 @@ into the `target/features-repo` directory.
 |`File`
 |The directory where the bundles will be copied by the plugin goal
 
+|`overridesURI`
+|`String`
+|The location of an overrides.properties file to use while generating the repository.  Properties will _not_ be interpolated.
+
 |`timestampedSnapshot`
 |`boolean`
 |For SNAPSHOT artifacts, if false we use the base version (foo-1.0-SNAPSHOT), else we use the timestamped version (foo-1.0-2019xxxx). Default value: false

--- a/tooling/karaf-maven-plugin/pom.xml
+++ b/tooling/karaf-maven-plugin/pom.xml
@@ -268,6 +268,11 @@
             <artifactId>biz.aQute.bndlib</artifactId>
             <version>6.3.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.equinox.region</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-a-1.0.8/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-a-1.0.8/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>test-add-to-repository</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>test</groupId>
+    <artifactId>dependency-bundle-a</artifactId>
+    <version>1.0.8-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-a-1.0.8/src/main/java/test/A.java
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-a-1.0.8/src/main/java/test/A.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test.a;
+
+public class A
+{
+    public static String ASTRING = "A-string";
+}

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-a-1.0/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-a-1.0/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>test-add-to-repository</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>test</groupId>
+    <artifactId>dependency-bundle-a</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-a-1.0/src/main/java/test/A.java
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-a-1.0/src/main/java/test/A.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test.a;
+
+public class A
+{
+    public static String ASTRING = "A-string";
+}

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-a-1.2/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-a-1.2/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>test-add-to-repository</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>test</groupId>
+    <artifactId>dependency-bundle-a</artifactId>
+    <version>1.2-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-a-1.2/src/main/java/test/A.java
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-a-1.2/src/main/java/test/A.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test.a;
+
+public class A
+{
+    public static String ASTRING = "A-string";
+}

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-b-0.9/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-b-0.9/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>test-add-to-repository</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>test</groupId>
+    <artifactId>dependency-bundle-b</artifactId>
+    <version>0.9-SNAPSHOT</version>
+
+    <packaging>bundle</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-b-0.9/src/main/java/test/B.java
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-b-0.9/src/main/java/test/B.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test.b;
+
+public class B
+{
+    public static String BSTRING = "B-string";
+}

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-b-1.0/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-b-1.0/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>test-add-to-repository</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>test</groupId>
+    <artifactId>dependency-bundle-b</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <packaging>bundle</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-b-1.0/src/main/java/test/B.java
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/dependency-bundle-b-1.0/src/main/java/test/B.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test.b;
+
+public class B
+{
+    public static String BSTRING = "B-string";
+}

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>test-add-to-repository</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>dependency-bundle-a-1.0</module>
+        <module>dependency-bundle-a-1.0.8</module>
+        <module>dependency-bundle-a-1.2</module>
+        <module>dependency-bundle-b-0.9</module>
+        <module>dependency-bundle-b-1.0</module>
+        <module>repository</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <maxmem>256M</maxmem>
+                    <fork>${compiler.fork}</fork>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/repository/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/repository/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>test-add-to-repository</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>test</groupId>
+    <artifactId>repository</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>test</groupId>
+            <artifactId>dependency-bundle-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>test</groupId>
+            <artifactId>dependency-bundle-b</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+                <version>@pom.version@</version>
+                <executions>
+                    <execution>
+                        <id>features-add-to-repository-no-overrides</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>features-add-to-repository</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>file://${project.basedir}/src/main/resources/control.xml</descriptor>
+                            </descriptors>
+                            <features>
+                                <feature>dependency-feature-a/1.0.0.SNAPSHOT</feature>
+                                <feature>dependency-feature-a/1.0.8.SNAPSHOT</feature>
+                                <feature>dependency-feature-a/1.2.0.SNAPSHOT</feature>
+                                <feature>dependency-feature-b/0.9.0.SNAPSHOT</feature>
+                                <feature>dependency-feature-b/1.0.0.SNAPSHOT</feature>
+                            </features>
+                            <repository>${project.build.directory}/repository-no-overrides</repository>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>features-add-to-repository-with-overrides</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>features-add-to-repository</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>file://${project.basedir}/src/main/resources/control.xml</descriptor>
+                            </descriptors>
+                            <features>
+                                <feature>dependency-feature-a/1.0.0.SNAPSHOT</feature>
+                                <feature>dependency-feature-a/1.0.8.SNAPSHOT</feature>
+                                <feature>dependency-feature-a/1.2.0.SNAPSHOT</feature>
+                                <feature>dependency-feature-b/0.9.0.SNAPSHOT</feature>
+                                <feature>dependency-feature-b/1.0.0.SNAPSHOT</feature>
+                            </features>
+                            <repository>${project.build.directory}/repository-with-overrides</repository>
+                            <overridesURI>file://${project.basedir}/src/main/resources/overrides.properties</overridesURI>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/repository/src/main/resources/control.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/repository/src/main/resources/control.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="dependency-feature">
+    <feature name="dependency-feature-a" description="dependency-feature-a" version="1.0.0.SNAPSHOT">
+        <bundle>mvn:test/dependency-bundle-a/1.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="dependency-feature-a" description="dependency-feature-a" version="1.0.8.SNAPSHOT">
+        <bundle>mvn:test/dependency-bundle-a/1.0.8-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="dependency-feature-a" description="dependency-feature-a 1.2" version="1.2.0.SNAPSHOT">
+        <bundle>mvn:test/dependency-bundle-a/1.2-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="dependency-feature-b" description="dependency-feature-b" version="0.9.0.SNAPSHOT">
+        <bundle>mvn:test/dependency-bundle-b/0.9-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="dependency-feature-b" description="dependency-feature-b" version="1.0.0.SNAPSHOT">
+        <bundle>mvn:test/dependency-bundle-b/1.0-SNAPSHOT</bundle>
+    </feature>
+</features>

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/repository/src/main/resources/overrides.properties
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/repository/src/main/resources/overrides.properties
@@ -1,3 +1,22 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
 # this will upgrade 1.0.x but _not_ anything higher (1.1, 1.2, etc.)
 mvn:test/dependency-bundle-a/1.0.8-SNAPSHOT
 

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/repository/src/main/resources/overrides.properties
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/repository/src/main/resources/overrides.properties
@@ -1,0 +1,5 @@
+# this will upgrade 1.0.x but _not_ anything higher (1.1, 1.2, etc.)
+mvn:test/dependency-bundle-a/1.0.8-SNAPSHOT
+
+# upgrade any old 0.x version to 1.0
+mvn:test/dependency-bundle-b/1.0-SNAPSHOT;range=[0,1)

--- a/tooling/karaf-maven-plugin/src/it/test-add-to-repository/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-add-to-repository/verify.bsh
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.custommonkey.xmlunit.*;
+import java.io.*;
+import java.lang.*;
+
+File targetDir = new File(basedir, "repository/target");
+
+File noOverridesTestDir = new File(targetDir, "repository-no-overrides");
+
+for (String expected : new String[] {
+    "test/dependency-bundle-a/1.0-SNAPSHOT/dependency-bundle-a-1.0-SNAPSHOT.jar",
+    "test/dependency-bundle-a/1.0.8-SNAPSHOT/dependency-bundle-a-1.0.8-SNAPSHOT.jar",
+    "test/dependency-bundle-a/1.2-SNAPSHOT/dependency-bundle-a-1.2-SNAPSHOT.jar",
+    "test/dependency-bundle-b/0.9-SNAPSHOT/dependency-bundle-b-0.9-SNAPSHOT.jar",
+    "test/dependency-bundle-b/1.0-SNAPSHOT/dependency-bundle-b-1.0-SNAPSHOT.jar"
+}) {
+    File copied = new File(noOverridesTestDir, expected);
+    if (!copied.exists()) {
+        throw new FileNotFoundException("repository-no-overrides is missing expected file: " + expected);
+    }
+}
+
+File overridesTestDir = new File(targetDir, "repository-with-overrides");
+
+for (String expected : new String[] {
+    "test/dependency-bundle-a/1.0.8-SNAPSHOT/dependency-bundle-a-1.0.8-SNAPSHOT.jar",
+    "test/dependency-bundle-a/1.2-SNAPSHOT/dependency-bundle-a-1.2-SNAPSHOT.jar",
+    "test/dependency-bundle-b/1.0-SNAPSHOT/dependency-bundle-b-1.0-SNAPSHOT.jar"
+}) {
+    File copied = new File(overridesTestDir, expected);
+    if (!copied.exists()) {
+        throw new FileNotFoundException("repository-with-overrides is missing expected file: " + expected);
+    }
+}
+
+for (String unexpected : new String[] {
+    "test/dependency-bundle-a/1.0-SNAPSHOT/dependency-bundle-a-1.0-SNAPSHOT.jar",
+    "test/dependency-bundle-b/0.9-SNAPSHOT/dependency-bundle-b-0.9-SNAPSHOT.jar",
+}) {
+    File copied = new File(overridesTestDir, unexpected);
+    if (copied.exists()) {
+        throw new FileNotFoundException("repository-with-overrides contains unexpected file: " + unexpected);
+    }
+}

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/AddToRepositoryMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/AddToRepositoryMojo.java
@@ -17,15 +17,28 @@
  */
 package org.apache.karaf.tooling.features;
 
-import java.io.File;
-import java.util.List;
-import java.util.Set;
+import static org.apache.karaf.features.internal.service.Overrides.OVERRIDE_RANGE;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.felix.utils.manifest.Clause;
+import org.apache.felix.utils.manifest.Parser;
+import org.apache.felix.utils.version.VersionCleaner;
+import org.apache.felix.utils.version.VersionRange;
 import org.apache.karaf.features.BundleInfo;
 import org.apache.karaf.features.Conditional;
+import org.apache.karaf.features.LocationPattern;
 import org.apache.karaf.features.internal.model.Bundle;
 import org.apache.karaf.features.internal.model.ConfigFile;
 import org.apache.karaf.features.internal.model.Feature;
+import org.apache.karaf.features.internal.service.Overrides;
 import org.apache.karaf.tooling.utils.MavenUtil;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -34,6 +47,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.osgi.framework.Version;
 
 /**
  * Add features to a repository directory
@@ -57,17 +71,35 @@ public class AddToRepositoryMojo extends AbstractFeatureMojo {
     @Parameter(defaultValue = "false")
     private boolean timestampedSnapshot;
 
+    /**
+     * Location of <code>overrides.properties</code> file.
+     */
+    @Parameter
+    protected String overridesURI;
+
     public void execute() throws MojoExecutionException, MojoFailureException {
         Set<Feature> featuresSet = resolveFeatures();
-        
+
+        Set<String> overrideLines = Overrides.loadOverrides(overridesURI);
+        Map<String,Override> overrides = new HashMap<>();
+        overrideLines.forEach((String overrideLine) -> {
+            Override override = new Override(overrideLine);
+            try {
+                overrides.put(override.getMatchLocation(), override);
+            } catch (MalformedURLException e) {
+                getLog().warn("unable to parse overrides.properties entry: " + overrideLine, e);
+            }
+        });
+        getLog().debug(String.format("found %d overrides in %s: %s", overrides.size(), overridesURI, String.join(", ", overrides.keySet())));
+
         for (Artifact descriptor : descriptorArtifacts) {
             copy(descriptor, repository);
         }
 
         for (Feature feature : featuresSet) {
-            copyBundlesToDestRepository(feature.getBundle());
+            copyBundlesToDestRepository(feature.getBundle().stream().map(bundle -> this.override(bundle, overrides)).collect(Collectors.toList()));
             for(Conditional conditional : feature.getConditional()) {
-                copyBundlesConditionalToDestRepository(conditional.getBundles());
+                copyBundlesConditionalToDestRepository(conditional.getBundles().stream().map(bundle -> this.override(bundle, overrides)).collect(Collectors.toList()));
             }
             copyConfigFilesToDestRepository(feature.getConfigfile());
         }
@@ -78,7 +110,7 @@ public class AddToRepositoryMojo extends AbstractFeatureMojo {
 
     private void copyBundlesConditionalToDestRepository(List<? extends BundleInfo> artifactRefsConditional) throws MojoExecutionException {
         for (BundleInfo artifactRef : artifactRefsConditional) {
-            if (ignoreDependencyFlag || (!ignoreDependencyFlag && !artifactRef.isDependency())) {
+            if (ignoreDependencyFlag || !artifactRef.isDependency()) {
                 Artifact artifact = resourceToArtifact(artifactRef.getLocation(), skipNonMavenProtocols);
                 // Avoid getting NPE on artifact.getFile in some cases 
                 resolveArtifact(artifact, remoteRepos);
@@ -146,4 +178,141 @@ public class AddToRepositoryMojo extends AbstractFeatureMojo {
         }
     }
 
+    private <T extends BundleInfo> T override(T bundle, Map<String, Override> overrides) {
+        try {
+            String bundleLocation = Override.parseMatchLocation(bundle.getLocation());
+            if (overrides.containsKey(bundleLocation)) {
+                Override override = overrides.get(bundleLocation);
+                getLog().debug("checking bundle " + bundle.getLocation() + " for overrides.properties clause " + override.location);
+                if (shouldOverride(bundle, override)) {
+                    getLog().debug("overrides.properties overriding " + bundle.getLocation() + " to " + override.location);
+                    return override.getBundle();
+                }
+            } else {
+                getLog().debug("no overrides.properties entry matching bundle " + bundleLocation);
+            }
+        } catch (MalformedURLException e) {
+            getLog().warn("unable to parse groupId and artifactId for bundle " + bundle.getLocation(), e);
+        }
+        return bundle;
+    }
+
+    boolean shouldOverride(BundleInfo bundle, Override override) {
+        String bundleLocationString = bundle.getLocation();
+
+        try {
+            if (!override.matchesLocation(bundleLocationString)) {
+                getLog().debug(override.getMatchLocation() + " does not match " + Override.parseMatchLocation(bundleLocationString) + " from " + bundleLocationString);
+                return false;
+            }
+        } catch (MalformedURLException e) {
+            getLog().warn("failed while trying to parse bundle location " + bundleLocationString, e);
+            return false;
+        }
+
+        LocationPattern bundleLocation = new LocationPattern(bundleLocationString);
+        Version bundleVersion = new Version(VersionCleaner.clean(bundleLocation.getVersionString()));
+        Version overrideVersion = override.getBundleVersion();
+
+        VersionRange overrideRange = override.getVersionRange();
+
+        return overrideRange.contains(bundleVersion) && bundleVersion.compareTo(overrideVersion) < 0;
+    }
+
+    public static Clause parseClause(String override) {
+        Clause[] cs = Parser.parseClauses(new String[]{override});
+        if (cs.length != 1) {
+            throw new IllegalStateException("Override contains more than one clause: " + override);
+        }
+        return cs[0];
+    }
+
+    static class Override {
+        private String location;
+        private String range;
+
+        /*
+         * cache objects for when we iterate
+         */
+        private Bundle bundle;
+        private Version bundleVersion;
+        private VersionRange versionRange;
+        private String matchLocation;
+        private LocationPattern locationPattern;
+
+        public Override(String override) {
+            init(parseClause(override));
+        }
+
+        protected void init(Clause clause) {
+            this.location = clause.getName();
+            this.range = clause.getAttribute(OVERRIDE_RANGE);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <T extends BundleInfo> T getBundle() {
+            if (this.bundle == null) {
+                this.bundle = new Bundle(this.location);
+            }
+            return (T)this.bundle;
+        }
+
+        public Version getBundleVersion() {
+            if (this.bundleVersion == null) {
+                LocationPattern bundleLocation = this.getLocationPattern();
+                this.bundleVersion = new Version(VersionCleaner.clean(bundleLocation.getVersionString()));
+            }
+            return this.bundleVersion;
+        }
+
+        public LocationPattern getLocationPattern() {
+            if (this.locationPattern == null) {
+                this.locationPattern = new LocationPattern(this.location);
+            }
+            return this.locationPattern;
+        }
+
+        public VersionRange getVersionRange() {
+            if (this.versionRange == null) {
+                if (this.range == null) {
+                    /**
+                     * In the runtime {@link Overrides} code, this uses the bundle compatibility inside
+                     * the resource, which is usually looser (matching major.minor.0), so I'm doing
+                     * this slightly differently than the code in Overrides and explicitly making the
+                     * range include all micro versions.
+                     */
+                    Version mavenBundleVersion = this.getBundleVersion();
+                    Version v1 = new Version(mavenBundleVersion.getMajor(), mavenBundleVersion.getMinor(), 0);
+                    Version v2 = new Version(mavenBundleVersion.getMajor(), mavenBundleVersion.getMinor() + 1, 0);
+                    this.versionRange = new VersionRange(false, v1, v2, true);
+                } else {
+                    this.versionRange = new VersionRange(this.range);
+                }
+            }
+            return this.versionRange;
+        }
+
+        public boolean matchesLocation(String locationString) throws MalformedURLException {
+            if (locationString == null) return false;
+
+            return parseMatchLocation(locationString).equals(getMatchLocation());
+        }
+
+        private static String parseMatchLocation(String location) throws MalformedURLException {
+            if (location == null) return null;
+
+            String locationString = location.startsWith("mvn:") ? location.substring(4) : location;
+            org.apache.karaf.util.maven.Parser parser = new org.apache.karaf.util.maven.Parser(locationString);
+            return parser.getGroup() + "/" + parser.getArtifact();
+        }
+
+        private String getMatchLocation() throws MalformedURLException {
+            if (this.matchLocation == null) {
+                this.matchLocation = parseMatchLocation(location);
+            }
+
+            return this.matchLocation;
+        }
+
+    }
 }


### PR DESCRIPTION
This PR adds support for using `overrides.properties` when using the `features-add-to-repository` mojo. This allows you to generate a repository that doesn't contain extraneous bundles that won't be used anyway.

I have provided test coverage for the different cases I ran into while working on this, it should be fairly complete. That said, I'd appreciate feedback on anything I can change or improve.