### PR TITLE
Add null guard to MavenDownloadTask

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/download/impl/MavenDownloadTask.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/download/impl/MavenDownloadTask.java
@@ -19,6 +19,7 @@ package org.apache.karaf.features.internal.download.impl;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.Objects;
 
 import org.apache.karaf.util.maven.Parser;
 import org.ops4j.pax.url.mvn.MavenResolver;
@@ -29,7 +30,7 @@ public class MavenDownloadTask extends AbstractRetryableDownloadTask {
 
     public MavenDownloadTask(ScheduledExecutorService executor, MavenResolver resolver, String url) {
         super(executor, url);
-        this.resolver = resolver;
+        this.resolver = Objects.requireNonNull(resolver, "resolver");
     }
 
     @Override

--- a/features/core/src/test/java/org/apache/karaf/features/internal/download/impl/MavenDownloadTaskTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/download/impl/MavenDownloadTaskTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.features.internal.download.impl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+
+public class MavenDownloadTaskTest {
+
+    @Test
+    public void testNullResolver(){
+        assertThrows(NullPointerException.class, () -> {
+            new MavenDownloadTask(null, null, "");
+        });
+    }
+}


### PR DESCRIPTION
`resolver` is a private property of the class `MavenDownloadTask` that has no corresponding setter method.
As such, if `null` is provided as the `resolver` to the constructor, it cannot be changed elsewhere and is bound to throw a NullPointerException at a later time.
For debugging purposes, however, a fail-fast guard is preferable, which this commit implements.