### PR TITLE
Check for annotation in ActionCommand constructor

### DIFF
--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/action/command/ActionCommand.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/action/command/ActionCommand.java
@@ -35,6 +35,10 @@ public class ActionCommand implements org.apache.karaf.shell.api.console.Command
     private final Class<? extends Action> actionClass;
 
     public ActionCommand(ManagerImpl manager, Class<? extends Action> actionClass) {
+        if (actionClass.getAnnotation(Command.class) == null) {
+            throw new IllegalArgumentException("actionClass must have an @Command annotation.");
+        }
+        
         this.manager = manager;
         this.actionClass = actionClass;
     }

--- a/shell/core/src/test/java/org/apache/karaf/shell/impl/action/command/ActionCommandTest.java
+++ b/shell/core/src/test/java/org/apache/karaf/shell/impl/action/command/ActionCommandTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.shell.impl.action.command;
+
+import org.apache.karaf.shell.api.action.Action;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+
+public class ActionCommandTest {
+
+	abstract static class ExampleClass implements Action {}
+
+	@Test
+	public void testUnannotatedActionClass() {
+		assertThrows(IllegalArgumentException.class, () -> new ActionCommand(null, ExampleClass.class));
+	}
+}


### PR DESCRIPTION
The `ActionCommand` class takes an `actionClass` parameter for its constructor, whose `@Command` annotation accessed in the other methods. Thus, if the provided `actionClass` has no such annotations, then it will throw an NPE at a later, unspecified time. This commit implements a fail-fast guard against this scenarios.