### PR TITLE
KARAF-7829 Override org.slf4j to 2.0.12

### DIFF
--- a/examples/karaf-graphql-example/karaf-graphql-example-api/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-api/pom.xml
@@ -32,6 +32,18 @@
     <name>Apache Karaf :: Examples :: GraphQL :: API</name>
     <packaging>bundle</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>karaf-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.graphql-java</groupId>

--- a/examples/karaf-graphql-example/karaf-graphql-example-commands/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-commands/pom.xml
@@ -32,6 +32,18 @@
     <name>Apache Karaf :: Examples :: GraphQL :: Shell Commands</name>
     <packaging>bundle</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>karaf-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>

--- a/examples/karaf-graphql-example/karaf-graphql-example-core/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-core/pom.xml
@@ -32,6 +32,18 @@
     <name>Apache Karaf :: Examples :: GraphQL :: Core</name>
     <packaging>bundle</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>karaf-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.karaf.examples</groupId>

--- a/examples/karaf-graphql-example/karaf-graphql-example-scr-servlet/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-scr-servlet/pom.xml
@@ -32,6 +32,18 @@
     <name>Apache Karaf :: Examples :: GraphQL :: SCR Servlet</name>
     <packaging>bundle</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>karaf-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/examples/karaf-graphql-example/karaf-graphql-example-websocket/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-websocket/pom.xml
@@ -32,6 +32,18 @@
     <name>Apache Karaf :: Examples :: GraphQL :: WebSocket</name>
     <packaging>bundle</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>karaf-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>

--- a/manual/pom.xml
+++ b/manual/pom.xml
@@ -25,6 +25,18 @@
 	<name>Apache Karaf :: Manual</name>
 	<packaging>bundle</packaging>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.karaf</groupId>
+				<artifactId>karaf-bom</artifactId>
+				<version>${project.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.karaf.subsystem</groupId>


### PR DESCRIPTION
Override transitive dependency version for `org.slf4j` from **1.7.32** and **1.7.35**  to **2.0.12** as defined in Karaf BOM project.

This issue arose after bumping slf4j to 2.0.12 in this commit:
https://github.com/apache/karaf/pull/1831/commits/03354d2635441d19ff762e217348f798a19cc983#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R324

However, some transitive dependencies still remain at version 1.7.32 and 1.7.35. See the `mvn dependency:tree` output:

[INFO] --- dependency:3.6.1:tree (default-cli) @ `manual` ---
[INFO] org.apache.karaf:manual:bundle:4.5.0-SNAPSHOT
[INFO] +- org.apache.karaf.subsystem:org.apache.karaf.subsystem.core:jar:4.5.0-SNAPSHOT:provided
[INFO] |  +- org.apache.karaf.features:org.apache.karaf.features.core:jar:4.5.0-SNAPSHOT:provided
[INFO] |  |  +- org.ops4j.pax.url:pax-url-aether:jar:2.6.14:provided
[INFO] |  |  |  \- `org.slf4j:jcl-over-slf4j:jar:1.7.32:provided`

[INFO] --- dependency:3.6.1:tree (default-cli) @ `karaf-graphql-example-commands` ---
[INFO] org.apache.karaf.examples:karaf-graphql-example-commands:bundle:4.5.0-SNAPSHOT
[INFO] +- org.apache.karaf.shell:org.apache.karaf.shell.core:jar:4.5.0-SNAPSHOT:compile
[INFO] |  +- org.jline:jline:jar:3.21.0:compile
[INFO] |  +- org.apache.karaf.jaas:org.apache.karaf.jaas.boot:jar:4.5.0-SNAPSHOT:compile
[INFO] |  \- org.apache.sshd:sshd-osgi:jar:2.12.1:compile
[INFO] |     \- `org.slf4j:jcl-over-slf4j:jar:1.7.32:compile`
[INFO] +- com.graphql-java:graphql-java:jar:19.2:compile
[INFO] |  +- com.graphql-java:java-dataloader:jar:3.2.0:compile
[INFO] |  +- org.reactivestreams:reactive-streams:jar:1.0.3:compile
[INFO] |  \- `org.slf4j:slf4j-api:jar:1.7.35:compile`

[INFO] --- dependency:3.6.1:tree (default-cli) @ `karaf-graphql-example-api` ---
[INFO] org.apache.karaf.examples:karaf-graphql-example-api:bundle:4.5.0-SNAPSHOT
[INFO] +- com.graphql-java:graphql-java:jar:19.2:compile
[INFO] |  +- com.graphql-java:java-dataloader:jar:3.2.0:compile
[INFO] |  +- org.reactivestreams:reactive-streams:jar:1.0.3:compile
[INFO] |  \- `org.slf4j:slf4j-api:jar:1.7.35:compile`

[INFO] --- dependency:3.6.1:tree (default-cli) @ `karaf-graphql-example-scr-servlet` ---
[INFO] org.apache.karaf.examples:karaf-graphql-example-scr-servlet:bundle:4.5.0-SNAPSHOT
[INFO] +- org.osgi:org.osgi.service.component.annotations:jar:1.4.0:provided
[INFO] +- com.graphql-java:graphql-java:jar:19.2:compile
[INFO] |  +- com.graphql-java:java-dataloader:jar:3.2.0:compile
[INFO] |  +- org.reactivestreams:reactive-streams:jar:1.0.3:compile
[INFO] |  \- `org.slf4j:slf4j-api:jar:1.7.35:compile`

[INFO] --- dependency:3.6.1:tree (default-cli) @ `karaf-graphql-example-core` ---
[INFO] org.apache.karaf.examples:karaf-graphql-example-core:bundle:4.5.0-SNAPSHOT
[INFO] +- org.apache.karaf.examples:karaf-graphql-example-api:jar:4.5.0-SNAPSHOT:compile
[INFO] +- org.osgi:org.osgi.service.component.annotations:jar:1.4.0:provided
[INFO] +- com.graphql-java:graphql-java:jar:19.2:compile
[INFO] |  +- com.graphql-java:java-dataloader:jar:3.2.0:compile
[INFO] |  +- org.reactivestreams:reactive-streams:jar:1.0.3:compile
[INFO] |  \- `org.slf4j:slf4j-api:jar:1.7.35:compile`

[INFO] --- dependency:3.6.1:tree (default-cli) @ `karaf-graphql-example-websocket` ---
[INFO] org.apache.karaf.examples:karaf-graphql-example-websocket:bundle:4.5.0-SNAPSHOT
[INFO] +- org.eclipse.jetty.websocket:websocket-servlet:jar:9.4.54.v20240208:provided
[INFO] |  +- org.eclipse.jetty.websocket:websocket-api:jar:9.4.54.v20240208:provided
[INFO] |  \- javax.servlet:javax.servlet-api:jar:3.1.0:provided
[INFO] +- org.apache.karaf.examples:karaf-graphql-example-api:jar:4.5.0-SNAPSHOT:compile
[INFO] |  \- com.graphql-java:graphql-java:jar:19.2:compile
[INFO] |     +- com.graphql-java:java-dataloader:jar:3.2.0:compile
[INFO] |     +- org.reactivestreams:reactive-streams:jar:1.0.3:compile
[INFO] |     \- `org.slf4j:slf4j-api:jar:1.7.35:compile`


This can be fixed by specifying the correct version in dependency management.