### PR TITLE
Make spifly feature start spifly.dynamic.bundle at start-level 20 to fix KARAF-7843

### DIFF
--- a/assemblies/features/specs/src/main/feature/feature.xml
+++ b/assemblies/features/specs/src/main/feature/feature.xml
@@ -30,7 +30,7 @@
     <!-- spifly -->
     <feature name="spifly" version="${aries.spifly.version}">
         <feature>asm</feature>
-        <bundle>mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.bundle/${aries.spifly.version}</bundle>
+        <bundle start-level="20">mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.bundle/${aries.spifly.version}</bundle>
     </feature>
 
     <!-- annotation -->


### PR DESCRIPTION
start-level 20 is the same start level as the asm bundles in the asm feature the spifly feature depends on, so that seems appropriate.

And [as the docs say](https://aries.apache.org/documentation/modules/spi-fly.html#_dynamic_weaving_bundle), spifly.dynamic.bundle is intended to be started at a low start level.