### PR TITLE
[KARAF-7927] Add missing java.nio.file.spi to etc/jre.properties

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
+++ b/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
@@ -58,6 +58,7 @@ jre-base= \
  java.nio.charset.spi, \
  java.nio.file, \
  java.nio.file.attribute, \
+ java.nio.file.spi, \
  java.rmi, \
  java.rmi.activation, \
  java.rmi.dgc, \


### PR DESCRIPTION
@jbonofre Please commit to main (aka v4.5.0-SNAPSHOT) and cherry pick to apache-karaf-4.4.x for v4.4.7 release. Thanks!
