### PR TITLE
[KARAF-7950] Use modular OSGi dependencies

### DIFF
--- a/audit/pom.xml
+++ b/audit/pom.xml
@@ -53,7 +53,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,10 +41,109 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <!-- Monolithic OSGi Core. This dependency should not be used by users. -->
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>osgi.core</artifactId>
                 <version>${osgi.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Modular equivalent of osgi.annotation, i.e. the annotation processing of OSGi Core. -->
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.annotation.bundle</artifactId>
+                <version>${org.osgi.annotation.bundle.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.annotation.versioning</artifactId>
+                <version>${org.osgi.annotation.versioning.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Modular equivalent of osgi.core, i.e. the run-time of OSGi Core. -->
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.dto</artifactId>
+                <version>${org.osgi.dto.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.framework</artifactId>
+                <version>${org.osgi.framework.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.resource</artifactId>
+                <version>${org.osgi.resource.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.service.condition</artifactId>
+                <version>${org.osgi.service.condition.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.service.condpermadmin</artifactId>
+                <version>${org.osgi.service.condpermadmin.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.service.log</artifactId>
+                <version>${org.osgi.service.log.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <!-- Note: replaced by org.osgi.framework.wiring since at least OSGi Core Release 4 -->
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.service.packageadmin</artifactId>
+                <version>${org.osgi.service.packageadmin.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.service.permissionadmin</artifactId>
+                <version>${org.osgi.service.permissionadmin.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.service.resolver</artifactId>
+                <version>${org.osgi.service.resolver.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.service.startlevel</artifactId>
+                <version>${org.osgi.service.startlevel.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.service.url</artifactId>
+                <version>${org.osgi.service.url.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.util.tracker</artifactId>
+                <version>${org.osgi.util.tracker.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Modular pieces of osgi.cmpn, i.e. the pieces of OSGi Companion we support. -->
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.namespace.service</artifactId>
+                <version>${org.osgi.namespace.service.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -85,26 +184,32 @@
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.service.log</artifactId>
-                <version>${org.osgi.service.log.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.service.metatype</artifactId>
                 <version>${org.osgi.service.metatype.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.namespace.service</artifactId>
-                <version>${org.osgi.service.namespace.version}</version>
+                <artifactId>org.osgi.service.metatype.annotations</artifactId>
+                <version>${org.osgi.service.metatype.annotations.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.service.repository</artifactId>
                 <version>${org.osgi.service.repository.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.service.subsystem</artifactId>
+                <version>${org.osgi.service.subsystem.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.util.converter</artifactId>
+                <version>${org.osgi.util.converter.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/bundle/blueprintstate/pom.xml
+++ b/bundle/blueprintstate/pom.xml
@@ -59,8 +59,7 @@
 
 		<dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/bundle/core/pom.xml
+++ b/bundle/core/pom.xml
@@ -56,16 +56,22 @@
             <artifactId>org.apache.aries.blueprint.api</artifactId>
             <scope>provided</scope>
         </dependency>
-		
-		<dependency>
+
+        <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.resource</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
 
         <dependency>

--- a/bundle/springstate/pom.xml
+++ b/bundle/springstate/pom.xml
@@ -59,8 +59,7 @@
 
 		<dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/config/command/pom.xml
+++ b/config/command/pom.xml
@@ -53,18 +53,15 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.metatype</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/config/core/pom.xml
+++ b/config/core/pom.xml
@@ -53,26 +53,21 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.metatype</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.util.converter</artifactId>
-            <version>1.0.9</version>
-            <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/deployer/blueprint/pom.xml
+++ b/deployer/blueprint/pom.xml
@@ -68,8 +68,11 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.url</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/deployer/features/pom.xml
+++ b/deployer/features/pom.xml
@@ -62,14 +62,15 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.annotation.versioning</artifactId>
-            <version>${org.osgi.annotation.versioning.version}</version>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.url</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.osgi</groupId>

--- a/deployer/kar/pom.xml
+++ b/deployer/kar/pom.xml
@@ -62,8 +62,7 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
 
         <dependency>

--- a/deployer/spring/pom.xml
+++ b/deployer/spring/pom.xml
@@ -67,8 +67,11 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.url</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.osgi</groupId>

--- a/deployer/wrap/pom.xml
+++ b/deployer/wrap/pom.xml
@@ -57,8 +57,11 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.url</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/diagnostic/boot/pom.xml
+++ b/diagnostic/boot/pom.xml
@@ -53,8 +53,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
     </dependencies>
 

--- a/diagnostic/core/pom.xml
+++ b/diagnostic/core/pom.xml
@@ -53,13 +53,15 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
 
         <dependency>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -52,8 +52,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/event/pom.xml
+++ b/event/pom.xml
@@ -66,8 +66,11 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.event</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/features/command/pom.xml
+++ b/features/command/pom.xml
@@ -52,8 +52,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.features</groupId>

--- a/features/core/pom.xml
+++ b/features/core/pom.xml
@@ -54,37 +54,35 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.namespace.service</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.event</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.namespace.service</artifactId>
-            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.repository</artifactId>
-            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
             <artifactId>org.osgi.util.promise</artifactId>
-            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
 

--- a/features/extension/pom.xml
+++ b/features/extension/pom.xml
@@ -52,8 +52,11 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.resource</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf</groupId>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -53,18 +53,15 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.http</artifactId>
-            <scope>provided</scope>
         </dependency>
 
 		<dependency>

--- a/instance/pom.xml
+++ b/instance/pom.xml
@@ -54,8 +54,7 @@
 
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
 
         <dependency>

--- a/itests/common/pom.xml
+++ b/itests/common/pom.xml
@@ -84,8 +84,11 @@
 
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/itests/test/pom.xml
+++ b/itests/test/pom.xml
@@ -77,8 +77,7 @@
 
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
 
         <dependency>

--- a/jaas/blueprint/config/pom.xml
+++ b/jaas/blueprint/config/pom.xml
@@ -51,11 +51,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.karaf.jaas</groupId>
             <artifactId>org.apache.karaf.jaas.boot</artifactId>
             <scope>provided</scope>

--- a/jaas/boot/pom.xml
+++ b/jaas/boot/pom.xml
@@ -52,8 +52,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
     </dependencies>
 

--- a/jaas/command/pom.xml
+++ b/jaas/command/pom.xml
@@ -52,8 +52,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
 
     	<dependency>

--- a/jaas/config/pom.xml
+++ b/jaas/config/pom.xml
@@ -67,8 +67,11 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.osgi</groupId>

--- a/jaas/jasypt/pom.xml
+++ b/jaas/jasypt/pom.xml
@@ -18,21 +18,21 @@
         See the License for the specific language governing permissions and
         limitations under the License.
     -->
-    
+
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.apache.karaf.jaas</groupId>
         <artifactId>jaas</artifactId>
         <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    
+
     <artifactId>org.apache.karaf.jaas.jasypt</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Karaf :: JAAS :: Jasypt Encryption</name>
     <description>This bundle provide Jasypt service for the encryption support in the JAAS security framework.</description>
-    
+
     <properties>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
     </properties>
@@ -48,17 +48,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <dependencies>
 
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.apache.karaf.jaas</groupId>
-            <artifactId>org.apache.karaf.jaas.modules</artifactId>    
+            <artifactId>org.apache.karaf.jaas.modules</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.jaas</groupId>

--- a/jaas/modules/pom.xml
+++ b/jaas/modules/pom.xml
@@ -76,18 +76,19 @@
 
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.event</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
 
         <dependency>
@@ -95,7 +96,7 @@
             <artifactId>org.apache.karaf.util</artifactId>
             <scope>provided</scope>
         </dependency>
- 
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
@@ -196,7 +197,7 @@
                             !net.spy.memcached*,
                             com.sun.security.auth.module;resolution:=optional,
                             javax.xml.bind*;version="[2.2,3)",
-														org.apache.commons.logging;version="[1,2)",
+                            org.apache.commons.logging;version="[1,2)",
                             *
                         </Import-Package>
                         <Private-Package>

--- a/jaas/spring-security-crypto/pom.xml
+++ b/jaas/spring-security-crypto/pom.xml
@@ -18,21 +18,21 @@
         See the License for the specific language governing permissions and
         limitations under the License.
     -->
-    
+
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.apache.karaf.jaas</groupId>
         <artifactId>jaas</artifactId>
         <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    
+
     <artifactId>org.apache.karaf.jaas.spring-security-crypto</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Karaf :: JAAS :: Spring Security Crypto Encryption</name>
     <description>This bundle provide Spring Security Crypto service for the encryption support in the JAAS security framework.</description>
-    
+
     <properties>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
     </properties>
@@ -48,17 +48,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <dependencies>
 
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.apache.karaf.jaas</groupId>
-            <artifactId>org.apache.karaf.jaas.modules</artifactId>    
+            <artifactId>org.apache.karaf.jaas.modules</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.jaas</groupId>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -53,18 +53,15 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.jdbc</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf</groupId>

--- a/jms/pom.xml
+++ b/jms/pom.xml
@@ -53,13 +53,11 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.jms</groupId>

--- a/jndi/pom.xml
+++ b/jndi/pom.xml
@@ -57,7 +57,7 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.aries.proxy</groupId>

--- a/kar/pom.xml
+++ b/kar/pom.xml
@@ -53,13 +53,11 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -53,8 +53,11 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
 
         <dependency>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -53,8 +53,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
 
         <dependency>

--- a/management/server/pom.xml
+++ b/management/server/pom.xml
@@ -53,18 +53,19 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.event</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
 
         <dependency>

--- a/maven/core/pom.xml
+++ b/maven/core/pom.xml
@@ -49,7 +49,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/obr/pom.xml
+++ b/obr/pom.xml
@@ -53,8 +53,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -60,8 +60,11 @@
 
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.resource</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -290,20 +290,35 @@
         <maven.resolver.version>1.8.2</maven.resolver.version>
 
         <osgi.version>8.0.0</osgi.version>
+        <org.osgi.annotation.bundle.version>1.1.0</org.osgi.annotation.bundle.version>
         <org.osgi.annotation.versioning.version>1.1.2</org.osgi.annotation.versioning.version>
+        <org.osgi.dto.version>1.1.1</org.osgi.dto.version>
+        <org.osgi.framework.version>1.10.0</org.osgi.framework.version>
+        <org.osgi.namespace.service.version>1.0.0</org.osgi.namespace.service.version>
+        <org.osgi.resource.version>1.0.1</org.osgi.resource.version>
         <org.osgi.service.cm.version>1.6.1</org.osgi.service.cm.version>
         <org.osgi.service.component.version>1.5.1</org.osgi.service.component.version>
         <org.osgi.service.component.annotations.version>1.5.1</org.osgi.service.component.annotations.version>
+        <org.osgi.service.condition.version>1.0.0</org.osgi.service.condition.version>
+        <org.osgi.service.condpermadmin.version>1.1.2</org.osgi.service.condpermadmin.version>
         <org.osgi.service.event.version>1.4.1</org.osgi.service.event.version>
         <org.osgi.service.http.version>1.2.2</org.osgi.service.http.version>
         <org.osgi.service.jdbc.version>1.1.0</org.osgi.service.jdbc.version>
         <org.osgi.service.jpa.version>1.0.0</org.osgi.service.jpa.version>
         <org.osgi.service.log.version>1.5.0</org.osgi.service.log.version>
         <org.osgi.service.metatype.version>1.4.1</org.osgi.service.metatype.version>
-        <org.osgi.service.namespace.version>1.0.0</org.osgi.service.namespace.version>
+        <org.osgi.service.metatype.annotations.version>1.4.1</org.osgi.service.metatype.annotations.version>
+        <org.osgi.service.packageadmin.version>1.2.1</org.osgi.service.packageadmin.version>
+        <org.osgi.service.permissionadmin.version>1.2.1</org.osgi.service.permissionadmin.version>
         <org.osgi.service.repository.version>1.1.0</org.osgi.service.repository.version>
+        <org.osgi.service.resolver.version>1.1.1</org.osgi.service.resolver.version>
+        <org.osgi.service.startlevel.version>1.1.1</org.osgi.service.startlevel.version>
+        <org.osgi.service.subsystem.version>1.1.0</org.osgi.service.subsystem.version>
+        <org.osgi.service.url.version>1.0.1</org.osgi.service.url.version>
+        <org.osgi.util.converter.version>1.0.9</org.osgi.util.converter.version>
         <org.osgi.util.function.version>1.2.0</org.osgi.util.function.version>
         <org.osgi.util.promise.version>1.3.0</org.osgi.util.promise.version>
+        <org.osgi.util.tracker.version>1.5.4</org.osgi.util.tracker.version>
 
         <pax.cdi.version>1.1.4</pax.cdi.version>
         <pax.exam.version>4.13.5</pax.exam.version>

--- a/profile/pom.xml
+++ b/profile/pom.xml
@@ -54,13 +54,15 @@
 
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.resource</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -114,13 +114,15 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/scr/management/pom.xml
+++ b/scr/management/pom.xml
@@ -57,18 +57,19 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.dto</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.component</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.component.annotations</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/scr/state/pom.xml
+++ b/scr/state/pom.xml
@@ -53,8 +53,15 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.component</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.component.annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -69,16 +76,6 @@
         <dependency>
             <groupId>org.apache.karaf.bundle</groupId>
             <artifactId>org.apache.karaf.bundle.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.service.component</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.service.component.annotations</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/service/core/pom.xml
+++ b/service/core/pom.xml
@@ -52,8 +52,11 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf</groupId>

--- a/service/guard/pom.xml
+++ b/service/guard/pom.xml
@@ -67,13 +67,19 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.resource</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/services/coordinator/pom.xml
+++ b/services/coordinator/pom.xml
@@ -48,11 +48,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.equinox.coordinator</artifactId>
             <scope>provided</scope>

--- a/services/eventadmin/pom.xml
+++ b/services/eventadmin/pom.xml
@@ -108,18 +108,19 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.metatype</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/services/interceptor/impl/pom.xml
+++ b/services/interceptor/impl/pom.xml
@@ -53,8 +53,7 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>

--- a/services/staticcm/pom.xml
+++ b/services/staticcm/pom.xml
@@ -90,14 +90,15 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <version>1.6.0</version>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/shell/commands/pom.xml
+++ b/shell/commands/pom.xml
@@ -65,8 +65,11 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/shell/console/pom.xml
+++ b/shell/console/pom.xml
@@ -52,13 +52,19 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.packageadmin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
 
         <dependency>

--- a/shell/core/pom.xml
+++ b/shell/core/pom.xml
@@ -61,18 +61,23 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.resource</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.event</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.jaas</groupId>

--- a/shell/ssh/pom.xml
+++ b/shell/ssh/pom.xml
@@ -63,13 +63,15 @@
 
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
 
         <dependency>

--- a/specs/activator/pom.xml
+++ b/specs/activator/pom.xml
@@ -49,8 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
     </dependencies>
 

--- a/specs/locator/pom.xml
+++ b/specs/locator/pom.xml
@@ -30,24 +30,4 @@
     <artifactId>org.apache.karaf.specs.locator</artifactId>
     <name>Apache Karaf :: Specs :: Locator</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.karaf</groupId>
-                <artifactId>karaf-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
-
 </project>

--- a/subsystem/pom.xml
+++ b/subsystem/pom.xml
@@ -52,8 +52,11 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.subsystem</artifactId>
         </dependency>
 
         <dependency>

--- a/system/pom.xml
+++ b/system/pom.xml
@@ -55,8 +55,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -18,16 +18,16 @@
         See the License for the specific language governing permissions and
         limitations under the License.
     -->
-    
+
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.apache.karaf</groupId>
         <artifactId>karaf</artifactId>
         <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    
+
     <artifactId>org.apache.karaf.util</artifactId>
     <packaging>jar</packaging>
     <name>Apache Karaf :: Util</name>
@@ -48,13 +48,15 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
@@ -75,7 +77,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <properties>
         <appendedResourcesDirectory>${basedir}/../etc/appended-resources</appendedResourcesDirectory>
     </properties>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -55,8 +55,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.web</groupId>

--- a/webconsole/console/pom.xml
+++ b/webconsole/console/pom.xml
@@ -20,7 +20,7 @@
     -->
 
     <modelVersion>4.0.0</modelVersion>
-  
+
     <parent>
         <groupId>org.apache.karaf.webconsole</groupId>
         <artifactId>webconsole</artifactId>
@@ -56,7 +56,7 @@
 		</dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
@@ -65,6 +65,10 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf</groupId>
@@ -183,7 +187,7 @@
                             org.apache.felix.framework;inline=org/apache/felix/framework/util/VersionRange**,
 
                             <!-- ServiceTracker -->
-                            osgi.core;inline=org/osgi/util/tracker/*,
+                            org.osgi.util.tracker;inline=**,
 
                             <!-- File Upload -->
                             commons-fileupload,

--- a/webconsole/features/pom.xml
+++ b/webconsole/features/pom.xml
@@ -52,8 +52,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/webconsole/gogo/pom.xml
+++ b/webconsole/gogo/pom.xml
@@ -52,8 +52,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
 
         <dependency>

--- a/webconsole/http/pom.xml
+++ b/webconsole/http/pom.xml
@@ -52,8 +52,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <scope>provided</scope>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/webconsole/instance/pom.xml
+++ b/webconsole/instance/pom.xml
@@ -57,8 +57,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>osgi.core</artifactId>
-			<scope>provided</scope>
+			<artifactId>org.osgi.framework</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.felix</groupId>

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -56,7 +56,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
+            <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf</groupId>


### PR DESCRIPTION
osgi-core is non-modular, i.e. it has no Automatic-Module-Name declaration.

This patches switches to using org.osgi.{dto,framework,resource,...}, which are provide this stability.