### PR TITLE
[KARAF-7789] Bump Apache POM to 34

### DIFF
--- a/archetypes/assembly/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/assembly/src/main/resources/archetype-resources/pom.xml
@@ -174,7 +174,7 @@
                         <!-- minimal distribution -->
                         <!--<feature>minimal</feature>-->
                     </bootFeatures>
-                    <javase>1.8</javase>
+                    <javase>11</javase>
                 </configuration>
             </plugin>
         </plugins>

--- a/assemblies/apache-karaf-minimal/pom.xml
+++ b/assemblies/apache-karaf-minimal/pom.xml
@@ -145,7 +145,7 @@
                         !org.apache.karaf.command.acl.*,
                         *
                     </pidsToExtract>
-                    <javase>1.8</javase>
+                    <javase>${karaf.runtime.target}</javase>
                 </configuration>
             </plugin>
             <plugin>

--- a/assemblies/apache-karaf/pom.xml
+++ b/assemblies/apache-karaf/pom.xml
@@ -178,7 +178,7 @@
                     </bootFeatures>
                     <libraries>
                     </libraries>
-                    <javase>1.8</javase>
+                    <javase>${karaf.runtime.target}</javase>
                     <generateConsistencyReport>${project.build.directory}</generateConsistencyReport>
                     <consistencyReportProjectName>Apache Karaf (full)</consistencyReportProjectName>
                 </configuration>

--- a/assemblies/features/enterprise/pom.xml
+++ b/assemblies/features/enterprise/pom.xml
@@ -241,7 +241,7 @@
                                 <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
                             </descriptors>
                             <distribution>org.apache.karaf.features:framework</distribution>
-                            <javase>1.8</javase>
+                            <javase>${karaf.runtime.target}</javase>
                             <framework>
                                 <feature>framework</feature>
                             </framework>

--- a/assemblies/features/specs/pom.xml
+++ b/assemblies/features/specs/pom.xml
@@ -96,7 +96,7 @@
                                 <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
                             </descriptors>
                             <distribution>org.apache.karaf.features:framework</distribution>
-                            <javase>9</javase>
+                            <javase>${karaf.runtime.target}</javase>
                             <framework>
                                 <feature>framework</feature>
                             </framework>

--- a/assemblies/features/standard/pom.xml
+++ b/assemblies/features/standard/pom.xml
@@ -465,7 +465,7 @@
                                 <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
                             </descriptors>
                             <distribution>org.apache.karaf.features:framework</distribution>
-                            <javase>9</javase>
+                            <javase>${karaf.runtime.target}</javase>
                             <framework>
                                 <feature>framework</feature>
                             </framework>

--- a/diagnostic/boot/pom.xml
+++ b/diagnostic/boot/pom.xml
@@ -36,6 +36,8 @@
 
     <properties>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
+        <!-- FIXME: remove when maven.compiler.target defaults to >= 11 -->
+        <maven.compiler.target>${karaf.runtime.target}</maven.compiler.target>
     </properties>
 
     <dependencyManagement>

--- a/examples/karaf-docker-example/karaf-docker-example-dynamic-dist/pom.xml
+++ b/examples/karaf-docker-example/karaf-docker-example-dynamic-dist/pom.xml
@@ -138,7 +138,7 @@
                     </bootFeatures>
                     <libraries>
                     </libraries>
-                    <javase>1.8</javase>
+                    <javase>${karaf.runtime.target}</javase>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/karaf-docker-example/karaf-docker-example-static-dist/pom.xml
+++ b/examples/karaf-docker-example/karaf-docker-example-static-dist/pom.xml
@@ -108,7 +108,7 @@
                     <framework>static</framework>
                     <useReferenceUrls>true</useReferenceUrls>
                     <environment>static</environment>
-                    <javase>1.8</javase>
+                    <javase>${karaf.runtime.target}</javase>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/karaf-graphql-example/karaf-graphql-example-websocket/src/main/java/org/apache/karaf/examples/graphql/websocket/GraphQLWebSocketExample.java
+++ b/examples/karaf-graphql-example/karaf-graphql-example-websocket/src/main/java/org/apache/karaf/examples/graphql/websocket/GraphQLWebSocketExample.java
@@ -58,7 +58,7 @@ public class GraphQLWebSocketExample {
         ExecutionResult executionResult = graphQL.execute(query);
         Publisher<ExecutionResult> bookStream = executionResult.getData();
         AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
-        bookStream.subscribe(new Subscriber<>() {
+        bookStream.subscribe(new Subscriber<ExecutionResult>() {
             @Override
             public void onSubscribe(Subscription subscription) {
                 subscriptionRef.set(subscription);

--- a/management/server/pom.xml
+++ b/management/server/pom.xml
@@ -36,6 +36,8 @@
 
     <properties>
         <appendedResourcesDirectory>${basedir}/../etc/appended-resources</appendedResourcesDirectory>
+        <!-- FIXME: remove when maven.compiler.target defaults to >= 11 -->
+        <maven.compiler.target>${karaf.runtime.target}</maven.compiler.target>
     </properties>
 
     <dependencyManagement>

--- a/management/server/src/main/java/org/apache/karaf/management/ConnectorServerFactory.java
+++ b/management/server/src/main/java/org/apache/karaf/management/ConnectorServerFactory.java
@@ -33,9 +33,6 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.ServerSocketChannel;
-import java.rmi.AccessException;
-import java.rmi.AlreadyBoundException;
-import java.rmi.NotBoundException;
 import java.rmi.Remote;
 import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
@@ -363,7 +360,7 @@ public class ConnectorServerFactory {
             }
         }
         if (registry == null && create) {
-            registry = new JmxRegistry(getPort(), getBindingName(url));
+            registry = new JmxRegistry(getBindingName(url));
             locallyCreated = true;
         }
         if (registry != null) {
@@ -921,36 +918,36 @@ public class ConnectorServerFactory {
     /*
      * Better to use the internal API than re-invent the wheel.
      */
-    @SuppressWarnings("restriction")
-    private class JmxRegistry extends sun.rmi.registry.RegistryImpl {
+    private final class JmxRegistry implements Registry {
         private final String lookupName;
 
-        JmxRegistry(final int port, final String lookupName) throws RemoteException {
-            super(port, null, new KarafRMIServerSocketFactory(getHost()));
+        JmxRegistry(String lookupName) {
             this.lookupName = lookupName;
         }
 
         @Override
-        public Remote lookup(String s) throws RemoteException, NotBoundException {
+        public Remote lookup(String s) {
             return lookupName.equals(s) ? remoteServerStub : null;
         }
 
         @Override
-        public void bind(String s, Remote remote) throws RemoteException, AlreadyBoundException, AccessException {
+        public void bind(String s, Remote remote) {
+            // No-op
         }
 
         @Override
-        public void unbind(String s) throws RemoteException, NotBoundException, AccessException {
+        public void unbind(String s)  {
+            // No-op
         }
 
         @Override
-        public void rebind(String s, Remote remote) throws RemoteException, AccessException {
+        public void rebind(String s, Remote remote) {
+            // No-op
         }
 
         @Override
         public String[] list() throws RemoteException {
-            return new String[] {lookupName};
+            return new String[] { lookupName };
         }
     }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>31</version>
+        <version>34</version>
         <relativePath />
     </parent>
 
@@ -163,7 +163,7 @@
         <distributionManagement.snapshot.name>Apache Development Snapshot Repository</distributionManagement.snapshot.name>
         <distributionManagement.snapshot.url>https://repository.apache.org/content/repositories/snapshots</distributionManagement.snapshot.url>
 
-        <!-- controls also maven.compiler.source and maven.javadoc.source -->
+        <!-- controls also maven.compiler.{release,source} and maven.javadoc.source -->
         <maven.compiler.target>8</maven.compiler.target>
         <!-- minimum required JVM version -->
         <karaf.runtime.target>11</karaf.runtime.target>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,8 @@
 
         <!-- controls also maven.compiler.source and maven.javadoc.source -->
         <maven.compiler.target>8</maven.compiler.target>
+        <!-- minimum required JVM version -->
+        <karaf.runtime.target>11</karaf.runtime.target>
 
         <activemq.version>5.17.1</activemq.version>
         <aopalliance.bundle.version>1.0_6</aopalliance.bundle.version>
@@ -706,7 +708,7 @@
                                     <version>[3.3.9,4)</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[11,)</version>
+                                    <version>[${karaf.runtime.target},)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,9 @@
         <distributionManagement.snapshot.name>Apache Development Snapshot Repository</distributionManagement.snapshot.name>
         <distributionManagement.snapshot.url>https://repository.apache.org/content/repositories/snapshots</distributionManagement.snapshot.url>
 
+        <!-- controls also maven.compiler.source and maven.javadoc.source -->
+        <maven.compiler.target>8</maven.compiler.target>
+
         <activemq.version>5.17.1</activemq.version>
         <aopalliance.bundle.version>1.0_6</aopalliance.bundle.version>
         <aspectj.bundle.version>1.9.5_1</aspectj.bundle.version>
@@ -684,8 +687,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
                     <maxmem>256M</maxmem>
                     <fork>${compiler.fork}</fork>
                 </configuration>
@@ -991,9 +992,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <source>1.8</source>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
The bump to version 32 implies that maven.compiler.release
is also set, which means stricter rules for builds with Java 9+.

We do this in piece multiple parts, cleaning up obvious cases first:
- **Do not use RegistryImpl**
- **Un-modernize GraphQLWebSocketExample**

Next we improve our control over build/runtime enviroment versions:
- **Control m-c-p/m-j-p through property**
- **Add karaf.runtime.target**

Finally leap into the 'building post-Java 9' world:
- **Require Java 11+ for management.server**
- **Require Java 11+ for diagnostic.boot**
- **[KARAF-7789] Bump Apache POM to 34**
