### PR TITLE
[KARAF-7671] Fix LDAP cache handling so it does not reset on every login attempt

### DIFF
--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/impl/Activator.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/impl/Activator.java
@@ -56,6 +56,7 @@ public class Activator extends BaseActivator implements ManagedService {
     @Override
     protected void doOpen() throws Exception {
         super.doOpen();
+        LDAPCache.clear();
         register(BackingEngineFactory.class, new PropertiesBackingEngineFactory());
         register(BackingEngineFactory.class, new PublickeyBackingEngineFactory());
 

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPBackingEngine.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPBackingEngine.java
@@ -18,8 +18,6 @@ import org.apache.karaf.jaas.boot.principal.GroupPrincipal;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
 import org.apache.karaf.jaas.modules.BackingEngine;
-import org.apache.karaf.jaas.modules.ldap.LDAPCache;
-import org.apache.karaf.jaas.modules.ldap.LDAPOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPBackingEngineFactory.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPBackingEngineFactory.java
@@ -16,7 +16,6 @@ package org.apache.karaf.jaas.modules.ldap;
 
 import org.apache.karaf.jaas.modules.BackingEngine;
 import org.apache.karaf.jaas.modules.BackingEngineFactory;
-import org.apache.karaf.jaas.modules.ldap.LDAPLoginModule;
 import java.util.Map;
 
 /**

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPLoginModule.java
@@ -42,11 +42,9 @@ import org.slf4j.LoggerFactory;
 public class LDAPLoginModule extends AbstractKarafLoginModule {
 
     private static Logger logger = LoggerFactory.getLogger(LDAPLoginModule.class);
-    
-        
+
     public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
         super.initialize(subject, callbackHandler, options);
-        LDAPCache.clear();
     }
 
     public boolean login() throws LoginException {

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPPubkeyLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPPubkeyLoginModule.java
@@ -44,7 +44,6 @@ public class LDAPPubkeyLoginModule extends AbstractKarafLoginModule {
 
     public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
         super.initialize(subject, callbackHandler, options);
-        LDAPCache.clear();
     }
 
     public boolean login() throws LoginException {

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/ldap.properties
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/ldap.properties
@@ -18,6 +18,7 @@
 ################################################################################
 
 debug=true
+disableCache=false
 connection.url=ldap://127.0.0.1:portno
 connection.username=uid=admin,ou=system
 connection.password=secret

--- a/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/ldap_badref.properties
+++ b/jaas/modules/src/test/resources/org/apache/karaf/jaas/modules/ldap/ldap_badref.properties
@@ -18,6 +18,7 @@
 ################################################################################
 
 debug=true
+disableCache=false
 connection.url=ldap://127.0.0.1:portno
 connection.username=uid=admin,ou=system
 connection.password=secret


### PR DESCRIPTION
 - Move initial cache clear to the Activator
 - Add metrics to the LDAPCache object
 - Fix unit test to _not_ disable cache
 - Update unit test to verify metrics counts and caching are working

NOTE: Caches may pile up when repeatedly deployed via blueprint (since no Activator). This shouldn't be an issue, since even 100 deploys would be small memory impact, and eventually all the caches get cleared.