### PR TITLE
[KARAF-7805] Add JAAS Subject to SSH shell session

### DIFF
--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/ShellFactoryImpl.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/ShellFactoryImpl.java
@@ -108,6 +108,7 @@ public class ShellFactoryImpl implements ShellFactory {
                 for (Map.Entry<String, String> e : environment.getEnv().entrySet()) {
                     shell.put(e.getKey(), e.getValue());
                 }
+                shell.put(Subject.class.getName(), subject);
                 JaasHelper.runAs(subject, () ->
                         new Thread(shell, "Karaf ssh console user " + ShellUtil.getCurrentUserName()).start());
             } catch (Exception e) {


### PR DESCRIPTION
This is needed ahead of JDK 21+ support which removes some parts of JAAS that use thread-local.

Eventually, this will be used to replace all the getCurrentUser() operations, and/or allow injection directly using @Reference Subject subject;