### PR TITLE
[KARAF-7971] Support Java 26

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
+++ b/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
@@ -508,3 +508,6 @@ jre-19 = ${jre-9}
 jre-20 = ${jre-9}
 jre-21 = ${jre-9}
 jre-23 = ${jre-9}
+jre-24 = ${jre-9}
+jre-25 = ${jre-9}
+jre-26 = ${jre-9}

--- a/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
+++ b/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
@@ -199,7 +199,12 @@ public class Builder {
         Java18("18"),
         Java19("19"),
         Java20("20"),
-        Java21("21");
+        Java21("21"),
+        Java22("22"),
+        Java23("23"),
+        Java24("24"),
+        Java25("25"),
+        Java26("26");
 
         private String version;
 


### PR DESCRIPTION
Update jre.properties and Builder.JavaVersion to suport Javaversions up to,
and including Java 26.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
