### PR TITLE
KARAF-7993: Upgrade to commons-fileupload 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-codec.version>1.15</commons-codec.version>
         <commons-compress.version>1.27.1</commons-compress.version>
-        <commons-fileupload.version>1.5</commons-fileupload.version>
+        <commons-fileupload.version>1.6.0</commons-fileupload.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-logging.version>1.3.5</commons-logging.version>
         <commons-pool2.version>2.12.0</commons-pool2.version>


### PR DESCRIPTION
Upgrade to version 1.6.0, see release notes:

https://commons.apache.org/proper/commons-fileupload/changes.html#a1.6.0


This also avoids [CVE-2025-48976](https://www.cve.org/CVERecord?id=CVE-2025-48976)