### PR TITLE
KARAF-8002: Upgrade to Hamcrest 3.0

### DIFF
--- a/event/pom.xml
+++ b/event/pom.xml
@@ -89,8 +89,8 @@
         
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/features/core/pom.xml
+++ b/features/core/pom.xml
@@ -167,8 +167,8 @@
 
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/jaas/modules/pom.xml
+++ b/jaas/modules/pom.xml
@@ -148,8 +148,8 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -88,8 +88,8 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Upgrade from `hamcrest-all` 1.3 to `hamcrest` 3.0

See release notes at
https://github.com/hamcrest/JavaHamcrest/releases
