### PR TITLE
Update metatype.properties

### DIFF
--- a/management/server/src/main/resources/OSGI-INF/metatype/metatype.properties
+++ b/management/server/src/main/resources/OSGI-INF/metatype/metatype.properties
@@ -73,7 +73,7 @@ secureProtocol.name = Secure Protocol
 secureProtocol.description = Protocol to use
 
 keyStore.name = Keystore Name
-keyStore.desciption = Keystore name from keystore manager
+keyStore.description = Keystore name from keystore manager
 
 keyAlias.name = Key Alias
 keyAlias.description = Key alias to be used with secured connector


### PR DESCRIPTION
Fixed typo in property keyStore.desciption (missing 'r') and should be keyStore.description as it's referenced that way by metatype.xml as well.