### PR TITLE
KARAF-7999: expose JFR packages

### DIFF
--- a/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
+++ b/assemblies/features/base/src/main/filtered-resources/resources/etc/jre.properties
@@ -474,6 +474,9 @@ jre-9= \
  javafx.stage, \
  javafx.util, \
  javafx.util.converter, \
+ jdk.jfr, \
+ jdk.jfr.consumer, \
+ jdk.management.jfr, \
  netscape.javascript, \
  org.ietf.jgss, \
  org.w3c.dom, \


### PR DESCRIPTION
Expose the three JFR-related packages:
- jdk.jfr from jdk.jfr module.
- jdk.jfr.consumer from jdk.jfr module.
- jdk.management.jfr from jdk.management.jfr module

These are available a commercial features since Java 9, but are available normally since Java 11.