### PR TITLE
Fix incomplete upgrade of commons-lang3

### DIFF
--- a/tooling/karaf-maven-plugin/src/it/test-feature-use-base-version/control.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-use-base-version/control.xml
@@ -20,7 +20,7 @@
 
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="test-feature-use-base-version">
     <feature name="test-feature-use-base-version" description="test-feature-use-base-version" version="1.0.0.SNAPSHOT">
-        <bundle>mvn:org.apache.commons/commons-lang3/3.4</bundle>
+        <bundle>mvn:org.apache.commons/commons-lang3/3.19.0</bundle>
     </feature>
 </features>
 

--- a/tooling/karaf-maven-plugin/src/it/test-feature-use-base-version/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-use-base-version/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
     		<groupId>org.apache.commons</groupId>
     		<artifactId>commons-lang3</artifactId>
-    		<version>3.18.0</version>
+    		<version>3.19.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This is required to get the use-base-version test in karaf-maven-plugin pass.
I don't know why the CI passed at that time.

This is the error the PR is fixing:
```
[INFO]   junit.framework.AssertionFailedError: org.custommonkey.xmlunit.Diff
[different] Expected text value 'mvn:org.apache.commons/commons-lang3/3.4' but was 'mvn:org.apache.commons/commons-lang3/3.18.0' - comparing <bundle ...>mvn:org.apache.commons/commons-lang3/3.4</bundle> at /features[1]/feature[1]/bundle[1]/text()[1] to <bundle ...>mvn:org.apache.commons/commons-lang3/3.18.0</bundle> at /features[1]/feature[1]/bundle[1]/text()[1]
```

To see that this is the root cause, one needs to remove the try-catch blocks from the tests.
Then the tests print the exception when failing.
I will create another PR for this.
