### PR TITLE
karaf-maven-plugin: Remove try/catch blocks from tests

### DIFF
--- a/tooling/karaf-maven-plugin/src/it/test-aggregate-features/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-aggregate-features/verify.bsh
@@ -26,9 +26,7 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "aggregate-features/target/feature/feature.xml");
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-basic-generation/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-basic-generation/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-check-dependencies-failure/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-check-dependencies-failure/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "dependencies-features/target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-check-dependencies/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-check-dependencies/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "dependencies-features/target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-feature-dependencies/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-dependencies/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "dependencies-features/target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-feature-use-base-version/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-use-base-version/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-feature-use-version-range-transfer-properties/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-use-version-range-transfer-properties/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "feature/target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-feature-use-version-range-transitive/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-use-version-range-transitive/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "feature/target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-feature-use-version-range/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-use-version-range/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-include-project-artifact/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-include-project-artifact/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-input-file/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-input-file/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-recursive/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-recursive/verify.bsh
@@ -21,6 +21,7 @@ import org.custommonkey.xmlunit.*;
 import java.io.*;
 import java.lang.*;
 
+// TODO fix this testcase
 //String control = "<features xmlns=\"http://karaf.apache.org/xmlns/features/v1.0.0\" name=\"test-basic-generation\"/>";
 //
 //File generated = new File( basedir, "target/feature/feature.xml" );

--- a/tooling/karaf-maven-plugin/src/it/test-rename-main-feature/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-rename-main-feature/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-repository-dependencies/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-repository-dependencies/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "dependency-feature-a/target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/verify.bsh
@@ -26,9 +26,7 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "simplify-features/target/feature/feature.xml");
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-transitive-as-dependency/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-transitive-as-dependency/verify.bsh
@@ -26,10 +26,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // load the features file pushed to the repository
 File generated = new File(basedir, "transitive-as-dependency-feature/target/feature/feature.xml" );
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;

--- a/tooling/karaf-maven-plugin/src/it/test-type-classifier/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-type-classifier/verify.bsh
@@ -29,10 +29,8 @@ Reader r = new FileReader(new File(basedir, "control.xml"));
 // TODO: repository and build offline (see KARAF-2927) 
 File generated = new File(basedir, "target/feature/feature.xml");
 if (generated.exists()) {
-    try {
-        XMLAssert.assertXMLEqual(r, new FileReader(generated));
-        return true;
-    } catch (Throwable ignored) { }
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
 }
 
 return false;


### PR DESCRIPTION
Error messages including the root cause are now being printed in case the test is failing.

Example error message when commons-lang3 version did not match the feature:


```
[INFO]   junit.framework.AssertionFailedError: org.custommonkey.xmlunit.Diff
[different] Expected text value 'mvn:org.apache.commons/commons-lang3/3.4' but was 'mvn:org.apache.commons/commons-lang3/3.18.0' - comparing <bundle ...>mvn:org.apache.commons/commons-lang3/3.4</bundle> at /features[1]/feature[1]/bundle[1]/text()[1] to <bundle ...>mvn:org.apache.commons/commons-lang3/3.18.0</bundle> at /features[1]/feature[1]/bundle[1]/text()[1]
```
