### PR TITLE
[#2217] Feature: Support specifying type for JAAS keystores

### DIFF
--- a/jaas/blueprint/config/src/main/java/org/apache/karaf/jaas/blueprint/config/impl/NamespaceHandler.java
+++ b/jaas/blueprint/config/src/main/java/org/apache/karaf/jaas/blueprint/config/impl/NamespaceHandler.java
@@ -53,6 +53,8 @@ public class NamespaceHandler implements org.apache.aries.blueprint.NamespaceHan
                 return getClass().getResource("/org/apache/karaf/jaas/blueprint/config/karaf-jaas-1.0.0.xsd");
             case "http://karaf.apache.org/xmlns/jaas/v1.1.0":
                 return getClass().getResource("/org/apache/karaf/jaas/blueprint/config/karaf-jaas-1.1.0.xsd");
+            case "http://karaf.apache.org/xmlns/jaas/v1.2.0":
+                return getClass().getResource("/org/apache/karaf/jaas/blueprint/config/karaf-jaas-1.2.0.xsd");
             default:
                 return null;
         }
@@ -131,6 +133,13 @@ public class NamespaceHandler implements org.apache.aries.blueprint.NamespaceHan
         if (rank != null && rank.length() > 0) {
             bean.addProperty("rank", createValue(context, rank));
         }
+
+        // Parse type
+        String type = element.getAttribute("type");
+        if (type != null && type.length() > 0) {
+            bean.addProperty("type", createValue(context, type));
+        }
+
         // Parse path
         String path = element.getAttribute("path");
         if (path != null && path.length() > 0) {

--- a/jaas/blueprint/config/src/main/resources/OSGI-INF/blueprint/karaf-jaas.xml
+++ b/jaas/blueprint/config/src/main/resources/OSGI-INF/blueprint/karaf-jaas.xml
@@ -33,4 +33,10 @@
         </service-properties>
     </service>
 
+    <service ref="namespaceHandler" interface="org.apache.aries.blueprint.NamespaceHandler">
+        <service-properties>
+            <entry key="osgi.service.blueprint.namespace" value="http://karaf.apache.org/xmlns/jaas/v1.2.0" />
+        </service-properties>
+    </service>
+
 </blueprint>

--- a/jaas/blueprint/config/src/main/resources/org/apache/karaf/jaas/blueprint/config/karaf-jaas-1.2.0.xsd
+++ b/jaas/blueprint/config/src/main/resources/org/apache/karaf/jaas/blueprint/config/karaf-jaas-1.2.0.xsd
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema elementFormDefault='qualified'
+           targetNamespace='http://karaf.apache.org/xmlns/jaas/v1.2.0'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'
+           xmlns:bp="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:tns='http://karaf.apache.org/xmlns/jaas/v1.1.0'>
+
+    <xs:import namespace="http://www.osgi.org/xmlns/blueprint/v1.0.0"/>
+
+    <xs:element name="config">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="module" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType mixed="true">
+                        <xs:attribute name="name" use="optional" type="xs:string"/>
+                        <xs:attribute name="className" use="required" type="xs:string"/>
+                        <xs:attribute name="flags" default="required">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:NMTOKEN">
+                                    <xs:enumeration value="required"/>
+                                    <xs:enumeration value="requisite"/>
+                                    <xs:enumeration value="sufficient"/>
+                                    <xs:enumeration value="optional"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+            <xs:attribute name="rank" use="optional" default="0" type="xs:int"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="keystore">
+        <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+            <xs:attribute name="rank" use="optional" default="0" type="xs:int"/>
+            <xs:attribute name="path" use="required" type="xs:string"/>
+            <xs:attribute name="keystorePassword" use="optional" type="xs:string"/>
+            <xs:attribute name="keyPasswords" use="optional" type="xs:string"/>
+            <xs:attribute name="type" use="optional" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>

--- a/jaas/config/src/main/java/org/apache/karaf/jaas/config/KeystoreInstance.java
+++ b/jaas/config/src/main/java/org/apache/karaf/jaas/config/KeystoreInstance.java
@@ -35,6 +35,8 @@ public interface KeystoreInstance {
 
     int getRank();
 
+    String getType();
+
     String[] listTrustCertificates();
 
     Certificate getCertificate(String alias);

--- a/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/ResourceKeystoreInstance.java
+++ b/jaas/config/src/main/java/org/apache/karaf/jaas/config/impl/ResourceKeystoreInstance.java
@@ -53,6 +53,7 @@ public class ResourceKeystoreInstance implements KeystoreInstance {
     private static final String JKS = "JKS";
 
     private String name;
+    private String type = JKS;
     private int rank;
     private URL path;
     private String keystorePassword;
@@ -75,6 +76,20 @@ public class ResourceKeystoreInstance implements KeystoreInstance {
      */
     public void setName(String keystoreName) {
         this.name = keystoreName;
+    }
+
+    /**
+     * @return the keystoreName
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param type the keystore type to set
+     */
+    public void setType(String type) {
+        this.type = type;
     }
 
     /**
@@ -213,7 +228,8 @@ public class ResourceKeystoreInstance implements KeystoreInstance {
     }
 
     public boolean isKeyLocked(String keyAlias) {
-        return keyPasswords.get(keyAlias) == null;
+        // [KARAF-2117] JKS requires a password, PKCS12 does not permit a password
+        return (JKS.equals(type) && keyPasswords.get(keyAlias) == null);
     }
 
     public boolean isKeystoreLocked() {
@@ -247,7 +263,7 @@ public class ResourceKeystoreInstance implements KeystoreInstance {
             keystoreReadDate = System.currentTimeMillis();
             trustCerts.clear();
             if (keystore == null) {
-                keystore = KeyStore.getInstance(JKS);
+                keystore = KeyStore.getInstance(getType());
             }
             InputStream in = new BufferedInputStream(path.openStream());
             keystore.load(in, keystorePassword == null ? new char[0] : keystorePassword.toCharArray());


### PR DESCRIPTION
Sample jaas config blueprint

```
<?xml version="1.0" encoding="UTF-8"?>
<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
           xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.2.0">
  <jaas:keystore name="jmx-truststore.ks"
                 type="PKCS12"
                 rank="1"
                 path="file:etc/truststore.jks"
                 keystorePassword="a..z"/>
  <jaas:keystore name="jmx-keystore.ks"
                 type="PKCS12"
                 rank="2"
                 path="file:etc/keystore.jks"
                 keystorePassword="z...a"
                 keyPasswords="karaf-server.company.com=z..a"/>
</blueprint>
```

