### PR TITLE
[karaf-4.4.x] Bump org.eclipse.persistence:javax.persistence from 2.1.0 to 2.2.1 (#2113)

### DIFF
--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-api/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-api/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.1</version>
         </dependency>
     </dependencies>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-eclipselink/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-eclipselink/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>javax.transaction</groupId>

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-hibernate/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-hibernate/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>javax.transaction</groupId>

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-openjpa/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-openjpa/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>javax.transaction</groupId>

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-eclipselink/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-eclipselink/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>javax.transaction</groupId>

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-hibernate/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-hibernate/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>javax.transaction</groupId>

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-openjpa/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-openjpa/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>javax.transaction</groupId>


### PR DESCRIPTION
Bumps org.eclipse.persistence:javax.persistence from 2.1.0 to 2.2.1.

---
updated-dependencies:
- dependency-name: org.eclipse.persistence:javax.persistence dependency-version: 2.2.1 dependency-type: direct:production update-type: version-update:semver-minor ...