### PR TITLE
[karaf-4.4.x] Bump org.apache.rat:apache-rat-plugin from 0.16.1 to 0.17 (#2119)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -740,7 +740,7 @@
                     <plugin>
                         <groupId>org.apache.rat</groupId>
                         <artifactId>apache-rat-plugin</artifactId>
-                        <version>0.16.1</version>
+                        <version>0.17</version>
                         <executions>
                             <execution>
                                 <phase>verify</phase>
@@ -785,9 +785,12 @@
                                 <exclude>**/*.json</exclude>
                                 <!-- test wiring resource files -->
                                 <exclude>**/src/test/resources/wirings/*</exclude>
+                                <!-- other test resources -->
+                                <exclude>**/badZipFile.zip</exclude>
                                 <!-- SSH keys -->
-				                <exclude>**/*.key</exclude>
+				                        <exclude>**/*.key</exclude>
                                 <exclude>**/*.id_rsa</exclude>
+                                <exclude>**/rsa.pem</exclude>
                                 <!-- For Jenkins, ignore the .repository -->
                                 <exclude>.repository/**</exclude>
                                 <!-- jar files -->


### PR DESCRIPTION
* Bump org.apache.rat:apache-rat-plugin from 0.16.1 to 0.17

Bumps org.apache.rat:apache-rat-plugin from 0.16.1 to 0.17.

---
updated-dependencies:
- dependency-name: org.apache.rat:apache-rat-plugin dependency-version: '0.17' dependency-type: direct:production update-type: version-update:semver-minor ...



* Exclude new test files from rat

---------