### PR TITLE
[karaf-4.4.x] Bump maven.version from 3.8.6 to 3.9.11 (#2110)

### DIFF
--- a/maven/core/pom.xml
+++ b/maven/core/pom.xml
@@ -87,6 +87,11 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
         <junit.version>4.13.2</junit.version>
         <jsw.version>3.2.3</jsw.version>
         <log4j.version>2.24.3</log4j.version>
-        <maven.version>3.8.6</maven.version>
+        <maven.version>3.9.11</maven.version>
         <maven.wagon.version>3.5.3</maven.wagon.version>
         <maven-plugin-annotations.version>3.10.2</maven-plugin-annotations.version>
         <maven.resolver.version>1.8.2</maven.resolver.version>


### PR DESCRIPTION
* Bump maven.version from 3.8.6 to 3.9.11

Bumps `maven.version` from 3.8.6 to 3.9.11.

Updates `org.apache.maven:maven-plugin-api` from 3.8.6 to 3.9.11
- [Release notes](https://github.com/apache/maven/releases)
- [Commits](https://github.com/apache/maven/compare/maven-3.8.6...maven-3.9.11)

Updates `org.apache.maven:maven-compat` from 3.8.6 to 3.9.11
- [Release notes](https://github.com/apache/maven/releases)
- [Commits](https://github.com/apache/maven/compare/maven-3.8.6...maven-3.9.11)

Updates `org.apache.maven:maven-core` from 3.8.6 to 3.9.11

Updates `org.apache.maven:maven-artifact` from 3.8.6 to 3.9.11

Updates `org.apache.maven:maven-settings` from 3.8.6 to 3.9.11

Updates `org.apache.maven:maven-settings-builder` from 3.8.6 to 3.9.11

---
updated-dependencies:
- dependency-name: org.apache.maven:maven-plugin-api dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.maven:maven-compat dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.maven:maven-core dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.maven:maven-artifact dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.maven:maven-settings dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.maven:maven-settings-builder dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-minor ...



* Add commons-io dependency in the maven.core test

---------