### PR TITLE
[karaf-4.4.x] Bump org.hibernate:hibernate-validator from 7.0.2.Final to 7.0.5.Final (#2112)

### DIFF
--- a/assemblies/features/enterprise/src/main/feature/feature.xml
+++ b/assemblies/features/enterprise/src/main/feature/feature.xml
@@ -20,7 +20,6 @@
 
     <!-- NB: this file is not the one really used. This file is used by the karaf-maven-plugin to define the start-level of bundles in the generated feature.xml -->
 
-    <repository>mvn:org.hibernate.validator/hibernate-validator-osgi-karaf-features/${hibernate.validator.version}/xml/features</repository>
     <!-- <repository>mvn:org.hibernate/hibernate-osgi/${hibernate.version}/xml/karaf</repository> -->
     <repository>mvn:org.ops4j.pax.cdi/pax-cdi-features/${pax.cdi.version}/xml/features</repository>
     <repository>mvn:org.ops4j.pax.jdbc/pax-jdbc-features/${pax.jdbc.version}/xml/features</repository>
@@ -190,6 +189,34 @@ com.atomikos.icatch.log_base_dir=${karaf.data}/atomikos
         <feature version="${hibernate.version}">hibernate</feature>
         <bundle>mvn:org.jboss/jandex/2.2.3.Final</bundle>
         <bundle>mvn:org.hibernate/hibernate-envers/${hibernate.version}</bundle>
+    </feature>
+
+    <feature name="hibernate-validator" version="${hibernate.validator.version}">
+        <bundle>mvn:org.hibernate.validator/hibernate-validator/${hibernate.validator.version}</bundle>
+        <bundle>mvn:jakarta.validation/jakarta.validation-api/3.0.0</bundle>
+        <bundle>mvn:org.jboss.logging/jboss-logging/3.4.1.Final</bundle>
+        <bundle>mvn:com.fasterxml/classmate/1.5.1</bundle>
+        <bundle>mvn:jakarta.el/jakarta.el-api/4.0.0</bundle>
+        <bundle>mvn:org.glassfish/jakarta.el/4.0.1</bundle>
+    </feature>
+    <feature name="hibernate-validator-joda-time" version="${hibernate.validator.version}">
+        <feature>hibernate-validator</feature>
+        <bundle>mvn:joda-time/joda-time/2.9.7</bundle>
+    </feature>
+    <feature name="hibernate-validator-javax-money" version="${hibernate.validator.version}">
+        <feature>hibernate-validator</feature>
+        <bundle>mvn:javax.money/money-api/1.0.1</bundle>
+        <bundle>mvn:org.javamoney/moneta/1.1</bundle>
+        <bundle>mvn:javax.annotation/javax.annotation-api/1.3.2</bundle>
+    </feature>
+    <feature name="hibernate-validator-groovy" version="${hibernate.validator.version}">
+        <feature>hibernate-validator</feature>
+        <bundle>mvn:org.codehaus.groovy/groovy-all/2.4.12</bundle>
+    </feature>
+    <feature name="hibernate-validator-paranamer" version="${hibernate.validator.version}">
+        <feature prerequisite="true">wrap</feature>
+        <feature>hibernate-validator</feature>
+        <bundle>wrap:mvn:com.thoughtworks.paranamer/paranamer/2.8</bundle>
     </feature>
 
     <feature name="eclipselink" description="Eclipselink JPA persistence engine support" version="${eclipselink.version}">

--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
         <narayana.version>5.13.1.Final</narayana.version>
         <hibernate.ejb.version>3.4.0.GA</hibernate.ejb.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
-        <hibernate.validator.version>7.0.2.Final</hibernate.validator.version>
+        <hibernate.validator.version>7.0.5.Final</hibernate.validator.version>
         <httpclient.version>4.5.13</httpclient.version>
         <jansi.version>2.4.2</jansi.version>
         <javassist.version>3.9.0.GA</javassist.version>


### PR DESCRIPTION


* Bump org.hibernate:hibernate-validator from 7.0.2.Final to 7.0.5.Final

Bumps org.hibernate:hibernate-validator from 7.0.2.Final to 7.0.5.Final.

---
updated-dependencies:
- dependency-name: org.hibernate:hibernate-validator dependency-version: 7.0.5.Final dependency-type: direct:production update-type: version-update:semver-patch ...



* Create feature for hibernate-validator

* Bump activemq.version from 5.19.0 to 5.19.1 (#2111)

Bumps `activemq.version` from 5.19.0 to 5.19.1.

Updates `org.apache.activemq:activemq-pool` from 5.19.0 to 5.19.1
- [Commits](https://github.com/apache/activemq/compare/activemq-5.19.0...activemq-5.19.1)

Updates `org.apache.activemq:activemq-karaf` from 5.19.0 to 5.19.1
- [Commits](https://github.com/apache/activemq/compare/activemq-5.19.0...activemq-5.19.1)

---
updated-dependencies:
- dependency-name: org.apache.activemq:activemq-pool dependency-version: 5.19.1 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.activemq:activemq-karaf dependency-version: 5.19.1 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump maven.version from 3.8.6 to 3.9.11 (#2110)

* Bump maven.version from 3.8.6 to 3.9.11

Bumps `maven.version` from 3.8.6 to 3.9.11.

Updates `org.apache.maven:maven-plugin-api` from 3.8.6 to 3.9.11
- [Release notes](https://github.com/apache/maven/releases)
- [Commits](https://github.com/apache/maven/compare/maven-3.8.6...maven-3.9.11)

Updates `org.apache.maven:maven-compat` from 3.8.6 to 3.9.11
- [Release notes](https://github.com/apache/maven/releases)
- [Commits](https://github.com/apache/maven/compare/maven-3.8.6...maven-3.9.11)

Updates `org.apache.maven:maven-core` from 3.8.6 to 3.9.11

Updates `org.apache.maven:maven-artifact` from 3.8.6 to 3.9.11

Updates `org.apache.maven:maven-settings` from 3.8.6 to 3.9.11

Updates `org.apache.maven:maven-settings-builder` from 3.8.6 to 3.9.11

---
updated-dependencies:
- dependency-name: org.apache.maven:maven-plugin-api dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.maven:maven-compat dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.maven:maven-core dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.maven:maven-artifact dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.maven:maven-settings dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.maven:maven-settings-builder dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-minor ...



* Add commons-io dependency in the maven.core test

---------





* Add other hibernate-validator features

* Fix typo in features repository xml

---------