### PR TITLE
[karaf-4.4.x] Bump asm.version from 9.8 to 9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <activemq.version>5.19.1</activemq.version>
         <aopalliance.bundle.version>1.0_6</aopalliance.bundle.version>
         <aspectj.bundle.version>1.9.21.1_1</aspectj.bundle.version>
-        <asm.version>9.8</asm.version>
+        <asm.version>9.9</asm.version>
         <javax.annotation.version>1.3.2</javax.annotation.version>
         <awaitility.version>3.1.6</awaitility.version>
         <bouncycastle.version>1.81</bouncycastle.version>


### PR DESCRIPTION
Bumps `asm.version` from 9.8 to 9.9.

Updates `org.ow2.asm:asm` from 9.8 to 9.9

Updates `org.ow2.asm:asm-util` from 9.8 to 9.9

Updates `org.ow2.asm:asm-tree` from 9.8 to 9.9

Updates `org.ow2.asm:asm-analysis` from 9.8 to 9.9

Updates `org.ow2.asm:asm-commons` from 9.8 to 9.9

---
updated-dependencies:
- dependency-name: org.ow2.asm:asm dependency-version: '9.9' dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.ow2.asm:asm-util dependency-version: '9.9' dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.ow2.asm:asm-tree dependency-version: '9.9' dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.ow2.asm:asm-analysis dependency-version: '9.9' dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.ow2.asm:asm-commons dependency-version: '9.9' dependency-type: direct:production update-type: version-update:semver-minor ...