### PR TITLE
[karaf-4.4.x] Bump bouncycastle.version from 1.81 to 1.82

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <asm.version>9.8</asm.version>
         <javax.annotation.version>1.3.2</javax.annotation.version>
         <awaitility.version>3.1.6</awaitility.version>
-        <bouncycastle.version>1.81</bouncycastle.version>
+        <bouncycastle.version>1.82</bouncycastle.version>
         <camel.version>3.6.0</camel.version>
         <cglib.bundle.version>3.2.9_1</cglib.bundle.version>
         <cxf.version>3.6.5</cxf.version>


### PR DESCRIPTION
Bumps `bouncycastle.version` from 1.81 to 1.82.

Updates `org.bouncycastle:bcprov-jdk18on` from 1.81 to 1.82
- [Changelog](https://github.com/bcgit/bc-java/blob/main/docs/releasenotes.html)
- [Commits](https://github.com/bcgit/bc-java/commits)

Updates `org.bouncycastle:bcpkix-jdk18on` from 1.81 to 1.82
- [Changelog](https://github.com/bcgit/bc-java/blob/main/docs/releasenotes.html)
- [Commits](https://github.com/bcgit/bc-java/commits)

Updates `org.bouncycastle:bcutil-jdk18on` from 1.81 to 1.82
- [Changelog](https://github.com/bcgit/bc-java/blob/main/docs/releasenotes.html)
- [Commits](https://github.com/bcgit/bc-java/commits)

---
updated-dependencies:
- dependency-name: org.bouncycastle:bcprov-jdk18on dependency-version: '1.82' dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.bouncycastle:bcpkix-jdk18on dependency-version: '1.82' dependency-type: direct:development update-type: version-update:semver-minor
- dependency-name: org.bouncycastle:bcutil-jdk18on dependency-version: '1.82' dependency-type: direct:production update-type: version-update:semver-minor ...