### PR TITLE
[karaf-4.4.x] Bump bouncycastle.version from 1.82 to 1.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <asm.version>9.9</asm.version>
         <javax.annotation.version>1.3.2</javax.annotation.version>
         <awaitility.version>3.1.6</awaitility.version>
-        <bouncycastle.version>1.82</bouncycastle.version>
+        <bouncycastle.version>1.83</bouncycastle.version>
         <camel.version>3.6.0</camel.version>
         <cglib.bundle.version>3.2.9_1</cglib.bundle.version>
         <cxf.version>3.6.9</cxf.version>


### PR DESCRIPTION
Bumps `bouncycastle.version` from 1.82 to 1.83.

Updates `org.bouncycastle:bcprov-jdk18on` from 1.82 to 1.83
- [Changelog](https://github.com/bcgit/bc-java/blob/main/docs/releasenotes.html)
- [Commits](https://github.com/bcgit/bc-java/commits)

Updates `org.bouncycastle:bcpkix-jdk18on` from 1.82 to 1.83
- [Changelog](https://github.com/bcgit/bc-java/blob/main/docs/releasenotes.html)
- [Commits](https://github.com/bcgit/bc-java/commits)

Updates `org.bouncycastle:bcutil-jdk18on` from 1.82 to 1.83
- [Changelog](https://github.com/bcgit/bc-java/blob/main/docs/releasenotes.html)
- [Commits](https://github.com/bcgit/bc-java/commits)

---
updated-dependencies:
- dependency-name: org.bouncycastle:bcprov-jdk18on dependency-version: '1.83' dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.bouncycastle:bcpkix-jdk18on dependency-version: '1.83' dependency-type: direct:development update-type: version-update:semver-minor
- dependency-name: org.bouncycastle:bcutil-jdk18on dependency-version: '1.83' dependency-type: direct:production update-type: version-update:semver-minor ...