### PR TITLE
Fix LogServiceLogback to find root logger correctly and add support for basic variable substitution

### DIFF
--- a/log/src/test/java/org/apache/karaf/log/core/internal/LogServiceLog4j2XmlImplTest.java
+++ b/log/src/test/java/org/apache/karaf/log/core/internal/LogServiceLog4j2XmlImplTest.java
@@ -34,99 +34,99 @@ public class LogServiceLog4j2XmlImplTest {
 
     @Test
     public void testInsertIndentedTabs() throws Exception {
-        String xml = "<Configuration>\n" +
-                "\t<Loggers>\n" +
-                "\t</Loggers>\n" +
+        String xml = "<Configuration>" + System.lineSeparator() +
+                "\t<Loggers>" + System.lineSeparator() +
+                "\t</Loggers>" + System.lineSeparator() +
                 "</Configuration>";
 
         String out = insertIndented(xml, false);
         assertEquals(
-                "<Configuration>\n" +
-                        "\t<Loggers>\n" +
-                        "\t\t<Logger/>\n" +
-                        "\t</Loggers>\n" +
+                "<Configuration>" + System.lineSeparator() +
+                        "\t<Loggers>" + System.lineSeparator() +
+                        "\t\t<Logger/>" + System.lineSeparator() +
+                        "\t</Loggers>" + System.lineSeparator() +
                         "</Configuration>", out);
         out = insertIndented(xml, true);
         assertEquals(
-                "<Configuration>\n" +
-                        "\t<Loggers>\n" +
-                        "\t\t<Logger/>\n" +
-                        "\t</Loggers>\n" +
+                "<Configuration>" + System.lineSeparator() +
+                        "\t<Loggers>" + System.lineSeparator() +
+                        "\t\t<Logger/>" + System.lineSeparator() +
+                        "\t</Loggers>" + System.lineSeparator() +
                         "</Configuration>", out);
     }
 
     @Test
     public void testInsertIndentedSpaces() throws Exception {
-        String xml = "<Configuration>\n" +
-                "  <Loggers>\n" +
-                "  </Loggers>\n" +
+        String xml = "<Configuration>" + System.lineSeparator() +
+                "  <Loggers>" + System.lineSeparator() +
+                "  </Loggers>" + System.lineSeparator() +
                 "</Configuration>";
 
         String out = insertIndented(xml, false);
         assertEquals(
-                "<Configuration>\n" +
-                        "  <Loggers>\n" +
-                        "    <Logger/>\n" +
-                        "  </Loggers>\n" +
+                "<Configuration>" + System.lineSeparator() +
+                        "  <Loggers>" + System.lineSeparator() +
+                        "    <Logger/>" + System.lineSeparator() +
+                        "  </Loggers>" + System.lineSeparator() +
                         "</Configuration>", out);
         out = insertIndented(xml, true);
         assertEquals(
-                "<Configuration>\n" +
-                        "  <Loggers>\n" +
-                        "    <Logger/>\n" +
-                        "  </Loggers>\n" +
+                "<Configuration>" + System.lineSeparator() +
+                        "  <Loggers>" + System.lineSeparator() +
+                        "    <Logger/>" + System.lineSeparator() +
+                        "  </Loggers>" + System.lineSeparator() +
                         "</Configuration>", out);
     }
 
     @Test
     public void testInsertIndentedTabsWithRoot() throws Exception {
-        String xml = "<Configuration>\n" +
-                "\t<Loggers>\n" +
-                "\t\t<Root/>\n" +
-                "\t</Loggers>\n" +
+        String xml = "<Configuration>" + System.lineSeparator() +
+                "\t<Loggers>" + System.lineSeparator() +
+                "\t\t<Root/>" + System.lineSeparator() +
+                "\t</Loggers>" + System.lineSeparator() +
                 "</Configuration>";
 
         String out = insertIndented(xml, false);
         assertEquals(
-                "<Configuration>\n" +
-                        "\t<Loggers>\n" +
-                        "\t\t<Root/>\n" +
-                        "\t\t<Logger/>\n" +
-                        "\t</Loggers>\n" +
+                "<Configuration>" + System.lineSeparator() +
+                        "\t<Loggers>" + System.lineSeparator() +
+                        "\t\t<Root/>" + System.lineSeparator() +
+                        "\t\t<Logger/>" + System.lineSeparator() +
+                        "\t</Loggers>" + System.lineSeparator() +
                         "</Configuration>", out);
         out = insertIndented(xml, true);
         assertEquals(
-                "<Configuration>\n" +
-                        "\t<Loggers>\n" +
-                        "\t\t<Logger/>\n" +
-                        "\t\t<Root/>\n" +
-                        "\t</Loggers>\n" +
+                "<Configuration>" + System.lineSeparator() +
+                        "\t<Loggers>" + System.lineSeparator() +
+                        "\t\t<Logger/>" + System.lineSeparator() +
+                        "\t\t<Root/>" + System.lineSeparator() +
+                        "\t</Loggers>" + System.lineSeparator() +
                         "</Configuration>", out);
     }
 
     @Test
     public void testInsertIndentedSpacesWithRoot() throws Exception {
-        String xml = "<Configuration>\n" +
-                "  <Loggers>\n" +
-                "    <Root/>\n" +
-                "  </Loggers>\n" +
+        String xml = "<Configuration>" + System.lineSeparator() +
+                "  <Loggers>" + System.lineSeparator() +
+                "    <Root/>" + System.lineSeparator() +
+                "  </Loggers>" + System.lineSeparator() +
                 "</Configuration>";
-
+        
         String out = insertIndented(xml, false);
         assertEquals(
-                "<Configuration>\n" +
-                        "  <Loggers>\n" +
-                        "    <Root/>\n" +
-                        "    <Logger/>\n" +
-                        "  </Loggers>\n" +
+                "<Configuration>" + System.lineSeparator() +
+                        "  <Loggers>" + System.lineSeparator() +
+                        "    <Root/>" + System.lineSeparator() +
+                        "    <Logger/>" + System.lineSeparator() +
+                        "  </Loggers>" + System.lineSeparator() +
                         "</Configuration>", out);
         out = insertIndented(xml, true);
         assertEquals(
-                "<Configuration>\n" +
-                        "  <Loggers>\n" +
-                        "    <Logger/>\n" +
-                        "    <Root/>\n" +
-                        "  </Loggers>\n" +
+                "<Configuration>" + System.lineSeparator() +
+                        "  <Loggers>" + System.lineSeparator() +
+                        "    <Logger/>" + System.lineSeparator() +
+                        "    <Root/>" + System.lineSeparator() +
+                        "  </Loggers>" + System.lineSeparator() +
                         "</Configuration>", out);
     }
 

--- a/log/src/test/java/org/apache/karaf/log/core/internal/LogServiceLogbackXmlTest.java
+++ b/log/src/test/java/org/apache/karaf/log/core/internal/LogServiceLogbackXmlTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.karaf.log.core.internal;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -27,63 +28,85 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class LogServiceLogbackXmlTest {
 
+    public static final String LOG_LEVEL_TOKEN = "log.level";
+
+    private static String file;
+    @BeforeClass
+    public static void initClass() {
+        Path p;
+        try {
+            p = Paths.get(LogServiceLogbackXmlImpl.class.getResource("/logback.xml").toURI());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        file = p.toString();
+    }
+
     @Test
     public void testInsertIndentedTabs() throws Exception {
-        String xml = "<configuration>\n" +
+        String xml = "<configuration>" + System.lineSeparator() +
                 "</configuration>";
 
         String out = insertIndented(xml);
         assertEquals(
-                "<configuration>\n" +
-                        "\t<logger/>\n" +
+                "<configuration>" + System.lineSeparator() +
+                        "\t<logger/>" + System.lineSeparator() +
                         "</configuration>", out);
     }
 
     @Test
     public void testInsertIndentedSpaces() throws Exception {
         //this one tests with one logger already added, because with no loggers there is no indentation to decide by and the function will choose tab
-        String xml = "<configuration>\n" +
-                "  <logger/>\n" +
+        String xml = "<configuration>" + System.lineSeparator() +
+                "  <logger/>" + System.lineSeparator() +
                 "</configuration>";
 
         String out = insertIndented(xml);
         assertEquals(
-                "<configuration>\n" +
-                        "  <logger/>\n" +
-                        "  <logger/>\n" +
+                "<configuration>" + System.lineSeparator() +
+                        "  <logger/>" + System.lineSeparator() +
+                        "  <logger/>" + System.lineSeparator() +
                         "</configuration>", out);
     }
 
     @Test
     public void testInsertIndentedTabsWithRoot() throws Exception {
-        String xml = "<configuration>\n" +
-                "\t<root/>\n" +
+        String xml = "<configuration>" + System.lineSeparator() +
+                "\t<root/>" + System.lineSeparator() +
                 "</configuration>";
 
         String out = insertIndented(xml);
         assertEquals(
-                "<configuration>\n" +
-                        "\t<root/>\n" +
-                        "\t<logger/>\n" +
+                "<configuration>" + System.lineSeparator() +
+                        "\t<root/>" + System.lineSeparator() +
+                        "\t<logger/>" + System.lineSeparator() +
                         "</configuration>", out);
     }
 
     @Test
     public void testInsertIndentedSpacesWithRoot() throws Exception {
-        String xml = "<configuration>\n" +
-                "  <root/>\n" +
+        String xml = "<configuration>" + System.lineSeparator() +
+                "  <root/>" + System.lineSeparator() +
                 "</configuration>";
 
         String out = insertIndented(xml);
         assertEquals(
-                "<configuration>\n" +
-                        "  <root/>\n" +
-                        "  <logger/>\n" +
+                "<configuration>" + System.lineSeparator() +
+                        "  <root/>" + System.lineSeparator() +
+                        "  <logger/>" + System.lineSeparator() +
                         "</configuration>", out);
     }
 
@@ -91,7 +114,7 @@ public class LogServiceLogbackXmlTest {
         Document doc = LogServiceLog4j2XmlImpl.loadConfig(null, new ByteArrayInputStream(xml.getBytes()));
         Element element = doc.createElement("logger");
         LogServiceLogbackXmlImpl.insertIndented(
-                (Element) doc.getDocumentElement(),
+                doc.getDocumentElement(),
                 element);
         try (StringWriter os = new StringWriter()) {
             TransformerFactory tFactory = TransformerFactory.newInstance();
@@ -101,4 +124,87 @@ public class LogServiceLogbackXmlTest {
             return os.toString();
         }
     }
+
+    @Test
+    public void testBasicValue() {
+        Properties systemProps = new Properties();
+        String resolved = LogServiceLogbackXmlImpl.resolveValue("DEBUG", Collections.emptyMap(), systemProps, Collections.emptyMap());
+        assertEquals("DEBUG", resolved);
+    }
+
+    @Test
+    public void testPropertySubstitution() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(LOG_LEVEL_TOKEN, "WARN");
+        String resolved = LogServiceLogbackXmlImpl.resolveValue("${log.level:-DEBUG}", properties, new Properties(), Collections.emptyMap());
+        assertEquals("WARN", resolved);
+    }
+
+    @Test
+    public void testSystemPropertiesSubstitution() {
+        Properties systemProps = new Properties();
+        systemProps.put(LOG_LEVEL_TOKEN, "WARN");
+        String resolved = LogServiceLogbackXmlImpl.resolveValue("${log.level:-DEBUG}", Collections.emptyMap(), systemProps, Collections.emptyMap());
+        assertEquals("WARN", resolved);
+    }
+
+    @Test
+    public void testEnvVariableSubstitution() {
+        Map<String, String> env = new HashMap<>();
+        env.put(LOG_LEVEL_TOKEN, "WARN");
+        String resolved = LogServiceLogbackXmlImpl.resolveValue("${log.level:-DEBUG}", Collections.emptyMap(), new Properties(), env);
+        assertEquals("WARN", resolved);
+    }
+
+    @Test
+    public void testPropertyWinsEnvSubstitution() {
+        Map<String, String> props = new HashMap<>();
+        props.put(LOG_LEVEL_TOKEN, "DEBUG");
+        Map<String, String> env = new HashMap<>();
+        env.put(LOG_LEVEL_TOKEN, "WARN");
+        String resolved = LogServiceLogbackXmlImpl.resolveValue("${log.level}", props , new Properties(), env);
+        assertEquals("DEBUG", resolved);
+    }
+
+    @Test
+    public void testRootLogLevel() {
+        LogServiceLogbackXmlImpl logService = getLogService();
+        assertEquals("WARN", logService.getLevel(LogServiceInternal.ROOT_LOGGER).get(LogServiceInternal.ROOT_LOGGER));
+    }
+
+    @Test
+    public void testPropertyLogLevel() {
+        String logger = "debugPropertyLogger";
+        LogServiceLogbackXmlImpl logService = getLogService();
+        assertEquals("DEBUG", logService.getLevel(logger).get(logger));
+    }
+
+    @Test
+    public void testSystemPropertyLogLevel() {
+        String logger = "systemPropertyLogger";
+        System.setProperty("LOG_LEVEL", "DEBUG");
+        LogServiceLogbackXmlImpl logService = getLogService();
+        assertEquals("DEBUG", logService.getLevel(logger).get(logger));
+        System.clearProperty("LOG_LEVEL");
+    }
+
+    @Test
+    public void testDefaultValueLogLevel() {
+        String logger = "defaultValueLogger";
+        LogServiceLogbackXmlImpl logService = getLogService();
+        assertEquals("DEBUG", logService.getLevel(logger).get(logger));
+    }
+
+    @Test
+    public void testAllLoggerLogLevel() {
+        LogServiceLogbackXmlImpl logService = getLogService();
+        Map<String, String> levels = logService.getLevel(LogServiceInternal.ALL_LOGGER);
+        assertEquals(4, levels.size());
+        assertTrue(levels.containsKey(LogServiceInternal.ROOT_LOGGER));
+    }
+
+    private LogServiceLogbackXmlImpl getLogService() {
+        return new LogServiceLogbackXmlImpl(file);
+    }
+
 }

--- a/log/src/test/resources/logback.xml
+++ b/log/src/test/resources/logback.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<configuration>
+    <property name="system.log.level" scope="context" value="${LOG_LEVEL}"/>
+    <property name="debug.log.level" scope="context" value="DEBUG"/>
+
+    <root level="WARN"/>
+
+    <logger name="debugPropertyLogger" level="${debug.log.level}"/>
+    <logger name="systemPropertyLogger" level="${system.log.level}"/>
+    <logger name="defaultValueLogger" level="${not.existing.property:-DEBUG}"/>
+</configuration>


### PR DESCRIPTION
This closes #2147 