### PR TITLE
[karaf-4.4.x] Bump javax.transaction:javax.transaction-api from 1.2 to 1.3 (#2109)

### DIFF
--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-eclipselink/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-eclipselink/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>javax.interceptor</groupId>
@@ -65,6 +65,7 @@
                         <Meta-Persistence>META-INF/persistence.xml</Meta-Persistence>
                         <Import-Package>
                             javax.persistence;version="[2,3)",
+                            javax.transaction;version="[1,2)",
                             *
                         </Import-Package>
                     </instructions>

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-hibernate/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-hibernate/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>javax.interceptor</groupId>
@@ -65,6 +65,7 @@
                         <Meta-Persistence>META-INF/persistence.xml</Meta-Persistence>
                         <Import-Package>
                             javax.persistence;version="[2,3)",
+                            javax.transaction;version="[1,2)",
                             *
                         </Import-Package>
                     </instructions>

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-openjpa/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-openjpa/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>javax.interceptor</groupId>
@@ -65,6 +65,7 @@
                         <Meta-Persistence>META-INF/persistence.xml</Meta-Persistence>
                         <Import-Package>
                             javax.persistence;version="[2,3)",
+                            javax.transaction;version="[1,2)",
                             *
                         </Import-Package>
                     </instructions>

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-eclipselink/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-eclipselink/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>javax.interceptor</groupId>

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-hibernate/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-hibernate/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>javax.interceptor</groupId>

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-openjpa/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-openjpa/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>javax.interceptor</groupId>


### PR DESCRIPTION
* Bump javax.transaction:javax.transaction-api from 1.2 to 1.3

Bumps [javax.transaction:javax.transaction-api](https://github.com/javaee/javax.transaction) from 1.2 to 1.3.
- [Commits](https://github.com/javaee/javax.transaction/compare/1.2...javax.transaction-api-1.3)

---
updated-dependencies:
- dependency-name: javax.transaction:javax.transaction-api dependency-version: '1.3' dependency-type: direct:production update-type: version-update:semver-minor ...



* Extent javax.transaction import range

---------