### PR TITLE
[karaf-4.4.x] Bump maven.version from 3.9.11 to 3.9.12 (#2201)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
         <junit.version>4.13.2</junit.version>
         <jsw.version>3.2.3</jsw.version>
         <log4j.version>2.24.3</log4j.version>
-        <maven.version>3.9.11</maven.version>
+        <maven.version>3.9.12</maven.version>
         <maven.wagon.version>3.5.3</maven.wagon.version>
         <maven-plugin-annotations.version>3.10.2</maven-plugin-annotations.version>
         <maven.resolver.version>1.8.2</maven.resolver.version>


### PR DESCRIPTION
Bumps `maven.version` from 3.9.11 to 3.9.12.

Updates `org.apache.maven:maven-plugin-api` from 3.9.11 to 3.9.12
- [Release notes](https://github.com/apache/maven/releases)
- [Commits](https://github.com/apache/maven/compare/maven-3.9.11...maven-3.9.12)

Updates `org.apache.maven:maven-compat` from 3.9.11 to 3.9.12
- [Release notes](https://github.com/apache/maven/releases)
- [Commits](https://github.com/apache/maven/compare/maven-3.9.11...maven-3.9.12)

Updates `org.apache.maven:maven-core` from 3.9.11 to 3.9.12

Updates `org.apache.maven:maven-artifact` from 3.9.11 to 3.9.12

Updates `org.apache.maven:maven-settings` from 3.9.11 to 3.9.12

Updates `org.apache.maven:maven-settings-builder` from 3.9.11 to 3.9.12

---
updated-dependencies:
- dependency-name: org.apache.maven:maven-plugin-api dependency-version: 3.9.12 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.maven:maven-compat dependency-version: 3.9.12 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.maven:maven-core dependency-version: 3.9.12 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.maven:maven-artifact dependency-version: 3.9.12 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.maven:maven-settings dependency-version: 3.9.12 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.maven:maven-settings-builder dependency-version: 3.9.12 dependency-type: direct:production update-type: version-update:semver-patch ...