### PR TITLE
[karaf-4.4.x] Bump xbean.version from 4.28 to 4.29 (#2200)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
         <sling.commons.johnzon.version>1.2.16</sling.commons.johnzon.version>
         <sshd.version>2.15.0</sshd.version>
         <struts.bundle.version>1.3.10_1</struts.bundle.version>
-        <xbean.version>4.28</xbean.version>
+        <xbean.version>4.29</xbean.version>
         <javax.mail.version>1.4.7</javax.mail.version>
 
         <winsw.version>2.3.0</winsw.version>


### PR DESCRIPTION
Bumps `xbean.version` from 4.28 to 4.29.

Updates `org.apache.xbean:xbean-bundleutils` from 4.28 to 4.29

Updates `org.apache.xbean:xbean-finder` from 4.28 to 4.29

Updates `org.apache.xbean:xbean-finder-shaded` from 4.28 to 4.29

Updates `org.apache.xbean:xbean-blueprint` from 4.28 to 4.29

Updates `org.apache.xbean:xbean-naming` from 4.28 to 4.29

Updates `org.apache.xbean:xbean-reflect` from 4.28 to 4.29

---
updated-dependencies:
- dependency-name: org.apache.xbean:xbean-bundleutils dependency-version: '4.29' dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.xbean:xbean-finder dependency-version: '4.29' dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.xbean:xbean-finder-shaded dependency-version: '4.29' dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.xbean:xbean-blueprint dependency-version: '4.29' dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.xbean:xbean-naming dependency-version: '4.29' dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.xbean:xbean-reflect dependency-version: '4.29' dependency-type: direct:production update-type: version-update:semver-minor ...