### PR TITLE
Define the required java version range in karaf maven plugins

### DIFF
--- a/tooling/karaf-maven-plugin/pom.xml
+++ b/tooling/karaf-maven-plugin/pom.xml
@@ -356,8 +356,12 @@
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>3.15.2</version>
+                <configuration>
+                    <requiredJavaVersion>[17,)</requiredJavaVersion>
+                </configuration>
                 <executions>
                     <execution>
                         <id>default-descriptor</id>

--- a/tooling/karaf-services-maven-plugin/pom.xml
+++ b/tooling/karaf-services-maven-plugin/pom.xml
@@ -144,7 +144,12 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.15.2</version>
+                <configuration>
+                    <requiredJavaVersion>[17,)</requiredJavaVersion>
+                </configuration>
                 <executions>
                     <execution>
                         <id>default-descriptor</id>


### PR DESCRIPTION
This fixes #2218 