### PR TITLE
[karaf-4.4.x] Bump jackson.version from 2.20.1 to 2.21.0 (#2230)

### DIFF
--- a/jndi/pom.xml
+++ b/jndi/pom.xml
@@ -106,6 +106,7 @@
                         </Export-Package>
                         <Import-Package>
                             org.osgi.framework;version="[1,3)",
+                            org.apache.xbean*;version="[4,5)",
                             *
                         </Import-Package>
                         <Private-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -174,8 +174,8 @@
         <camel.version>3.6.0</camel.version>
         <cglib.bundle.version>3.2.9_1</cglib.bundle.version>
         <cxf.version>3.6.9</cxf.version>
-        <jackson.annotations.version>2.20</jackson.annotations.version>
-        <jackson.version>2.20.1</jackson.version>
+        <jackson.annotations.version>2.21</jackson.annotations.version>
+        <jackson.version>2.21.0</jackson.version>
         <jna.version>5.18.1</jna.version>
         <jaxb-bom.version>2.3.9</jaxb-bom.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>


### PR DESCRIPTION
* Bump jackson.version from 2.20.1 to 2.21.0

Bumps `jackson.version` from 2.20.1 to 2.21.0.

Updates `com.fasterxml.jackson.core:jackson-databind` from 2.20.1 to 2.21.0
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider` from 2.20.1 to 2.21.0

---
updated-dependencies:
- dependency-name: com.fasterxml.jackson.core:jackson-databind dependency-version: 2.21.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider dependency-version: 2.21.0 dependency-type: direct:production update-type: version-update:semver-minor ...



* Align jackson annotation version

* Relax JNDI bundle xbean import range

---------