### PR TITLE
[karaf-4.4.x] Bump org.codehaus.plexus:plexus-archiver from 4.2.7 to 4.11.0 (#2224)

### DIFF
--- a/tooling/karaf-maven-plugin/pom.xml
+++ b/tooling/karaf-maven-plugin/pom.xml
@@ -169,7 +169,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
-            <version>4.2.7</version>
+            <version>4.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
* Bump org.codehaus.plexus:plexus-archiver from 4.2.7 to 4.11.0

Bumps [org.codehaus.plexus:plexus-archiver](https://github.com/codehaus-plexus/plexus-archiver) from 4.2.7 to 4.11.0.
- [Release notes](https://github.com/codehaus-plexus/plexus-archiver/releases)
- [Changelog](https://github.com/codehaus-plexus/plexus-archiver/blob/master/ReleaseNotes.md)
- [Commits](https://github.com/codehaus-plexus/plexus-archiver/compare/plexus-archiver-4.2.7...plexus-archiver-4.11.0)

---
updated-dependencies:
- dependency-name: org.codehaus.plexus:plexus-archiver dependency-version: 4.11.0 dependency-type: direct:production update-type: version-update:semver-minor ...



* Fix the way to deal with temp files in the KarMojo

---------