### PR TITLE
[karaf-4.4.x] Bump org.codehaus.modello:modello-maven-plugin from 2.5.1 to 2.6.0 (#…

### DIFF
--- a/tooling/utils/pom.xml
+++ b/tooling/utils/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.codehaus.modello</groupId>
                 <artifactId>modello-maven-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>2.6.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>


### PR DESCRIPTION
…2243)

Bumps [org.codehaus.modello:modello-maven-plugin](https://github.com/codehaus-plexus/modello) from 2.5.1 to 2.6.0.
- [Release notes](https://github.com/codehaus-plexus/modello/releases)
- [Commits](https://github.com/codehaus-plexus/modello/compare/modello-2.5.1...modello-2.6.0)

---
updated-dependencies:
- dependency-name: org.codehaus.modello:modello-maven-plugin dependency-version: 2.6.0 dependency-type: direct:development update-type: version-update:semver-minor ...