### PR TITLE
[karaf-4.4.x] Bump sshd.version from 2.16.0 to 2.17.1 (#2244)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
         <spring.security62.version>6.2.7_3</spring.security62.version>
 
         <sling.commons.johnzon.version>1.2.16</sling.commons.johnzon.version>
-        <sshd.version>2.15.0</sshd.version>
+        <sshd.version>2.17.1</sshd.version>
         <struts.bundle.version>1.3.10_1</struts.bundle.version>
         <xbean.version>4.30</xbean.version>
         <javax.mail.version>1.4.7</javax.mail.version>


### PR DESCRIPTION
Bumps `sshd.version` from 2.16.0 to 2.17.1.

Updates `org.apache.sshd:sshd-osgi` from 2.16.0 to 2.17.1
- [Release notes](https://github.com/apache/mina-sshd/releases)
- [Changelog](https://github.com/apache/mina-sshd/blob/master/CHANGES.md)
- [Commits](https://github.com/apache/mina-sshd/compare/sshd-2.16.0...sshd-2.17.1)

Updates `org.apache.sshd:sshd-scp` from 2.16.0 to 2.17.1
- [Release notes](https://github.com/apache/mina-sshd/releases)
- [Changelog](https://github.com/apache/mina-sshd/blob/master/CHANGES.md)
- [Commits](https://github.com/apache/mina-sshd/compare/sshd-2.16.0...sshd-2.17.1)

Updates `org.apache.sshd:sshd-sftp` from 2.16.0 to 2.17.1
- [Release notes](https://github.com/apache/mina-sshd/releases)
- [Changelog](https://github.com/apache/mina-sshd/blob/master/CHANGES.md)
- [Commits](https://github.com/apache/mina-sshd/compare/sshd-2.16.0...sshd-2.17.1)

Updates `org.apache.sshd:sshd-mina` from 2.16.0 to 2.17.1
- [Release notes](https://github.com/apache/mina-sshd/releases)
- [Changelog](https://github.com/apache/mina-sshd/blob/master/CHANGES.md)
- [Commits](https://github.com/apache/mina-sshd/compare/sshd-2.16.0...sshd-2.17.1)

---
updated-dependencies:
- dependency-name: org.apache.sshd:sshd-osgi dependency-version: 2.17.1 dependency-type: direct:development update-type: version-update:semver-minor
- dependency-name: org.apache.sshd:sshd-scp dependency-version: 2.17.1 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.sshd:sshd-sftp dependency-version: 2.17.1 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.apache.sshd:sshd-mina dependency-version: 2.17.1 dependency-type: direct:development update-type: version-update:semver-minor ...