### PR TITLE
[karaf-4.4.x] Bump pax.logging.version from 2.3.1 to 2.3.2 (#2254)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
 
         <pax.cdi.version>1.1.4</pax.cdi.version>
         <pax.exam.version>4.14.0</pax.exam.version>
-        <pax.logging.version>2.3.0</pax.logging.version>
+        <pax.logging.version>2.3.2</pax.logging.version>
         <pax.base.version>1.5.1</pax.base.version>
         <pax.swissbox.version>1.9.0</pax.swissbox.version>
         <pax.url.version>2.6.17</pax.url.version>


### PR DESCRIPTION
Bumps `pax.logging.version` from 2.3.1 to 2.3.2.

Updates `org.ops4j.pax.logging:pax-logging-api` from 2.3.1 to 2.3.2
- [Changelog](https://github.com/ops4j/org.ops4j.pax.logging/blob/main/RELEASE-NOTES.html)
- [Commits](https://github.com/ops4j/org.ops4j.pax.logging/compare/logging-2.3.1...logging-2.3.2)

Updates `org.ops4j.pax.logging:pax-logging-log4j2` from 2.3.1 to 2.3.2
- [Changelog](https://github.com/ops4j/org.ops4j.pax.logging/blob/main/RELEASE-NOTES.html)
- [Commits](https://github.com/ops4j/org.ops4j.pax.logging/compare/logging-2.3.1...logging-2.3.2)

Updates `org.ops4j.pax.logging:pax-logging-log4j2-extra` from 2.3.1 to 2.3.2
- [Changelog](https://github.com/ops4j/org.ops4j.pax.logging/blob/main/RELEASE-NOTES.html)
- [Commits](https://github.com/ops4j/org.ops4j.pax.logging/compare/logging-2.3.1...logging-2.3.2)

Updates `org.ops4j.pax.logging:pax-logging-logback` from 2.3.1 to 2.3.2
- [Changelog](https://github.com/ops4j/org.ops4j.pax.logging/blob/main/RELEASE-NOTES.html)
- [Commits](https://github.com/ops4j/org.ops4j.pax.logging/compare/logging-2.3.1...logging-2.3.2)

---
updated-dependencies:
- dependency-name: org.ops4j.pax.logging:pax-logging-api dependency-version: 2.3.2 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.ops4j.pax.logging:pax-logging-log4j2 dependency-version: 2.3.2 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.ops4j.pax.logging:pax-logging-log4j2-extra dependency-version: 2.3.2 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.ops4j.pax.logging:pax-logging-logback dependency-version: 2.3.2 dependency-type: direct:production update-type: version-update:semver-patch ...