### PR TITLE
[karaf-4.4.x] Do not use properties with dots in org.ops4j.pax.logging config

### DIFF
--- a/assemblies/features/base/src/main/resources/resources/etc/org.ops4j.pax.logging.cfg
+++ b/assemblies/features/base/src/main/resources/resources/etc/org.ops4j.pax.logging.cfg
@@ -27,7 +27,7 @@ color.trace = cyan
 
 # Common pattern layout for appenders
 log4j2.pattern = %d{ISO8601} | %-5p | %-16t | %-32c{1} | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %encode{%.-500m}{CRLF}%n
-log4j2.out.pattern = \u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{FATAL=${color.fatal}, ERROR=${color.error}, WARN=${color.warn}, INFO=${color.info}, DEBUG=${color.debug}, TRACE=${color.trace}} \u001b[90m[%t]\u001b[0m %msg%n%throwable
+log4j2.outpattern = \u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{FATAL=${color.fatal}, ERROR=${color.error}, WARN=${color.warn}, INFO=${color.info}, DEBUG=${color.debug}, TRACE=${color.trace}} \u001b[90m[%t]\u001b[0m %msg%n%throwable
 
 
 # Root logger
@@ -64,7 +64,7 @@ log4j2.logger.audit.appenderRef.AuditRollingFile.ref = AuditRollingFile
 log4j2.appender.console.type = Console
 log4j2.appender.console.name = Console
 log4j2.appender.console.layout.type = PatternLayout
-log4j2.appender.console.layout.pattern = ${log4j2.out.pattern}
+log4j2.appender.console.layout.pattern = ${log4j2.outpattern}
 
 # Rolling file appender
 log4j2.appender.rolling.type = RollingRandomAccessFile

--- a/examples/karaf-profile-example/karaf-profile-example-registry/src/main/resources/karaf.profile/org.ops4j.pax.logging.cfg
+++ b/examples/karaf-profile-example/karaf-profile-example-registry/src/main/resources/karaf.profile/org.ops4j.pax.logging.cfg
@@ -27,7 +27,7 @@ color.trace = cyan
 
 # Common pattern layout for appenders
 log4j2.pattern = %d{ISO8601} | %-5p | %-16t | %-32c{1} | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
-log4j2.out.pattern = \u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{FATAL=${color.fatal}, ERROR=${color.error}, WARN=${color.warn}, INFO=${color.info}, DEBUG=${color.debug}, TRACE=${color.trace}} \u001b[90m[%t]\u001b[0m %msg%n%throwable
+log4j2.outpattern = \u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{FATAL=${color.fatal}, ERROR=${color.error}, WARN=${color.warn}, INFO=${color.info}, DEBUG=${color.debug}, TRACE=${color.trace}} \u001b[90m[%t]\u001b[0m %msg%n%throwable
 
 
 # Root logger
@@ -63,7 +63,7 @@ log4j2.logger.audit.appenderRef.AuditRollingFile.ref = AuditRollingFile
 log4j2.appender.console.type = Console
 log4j2.appender.console.name = Console
 log4j2.appender.console.layout.type = PatternLayout
-log4j2.appender.console.layout.pattern = ${log4j2.out.pattern}
+log4j2.appender.console.layout.pattern = ${log4j2.outpattern}
 
 # Rolling file appender
 log4j2.appender.rolling.type = RollingRandomAccessFile

--- a/examples/karaf-profile-example/karaf-profile-example-registry/src/main/resources/karaf.profile/org.ops4j.pax.logging.cfg#static
+++ b/examples/karaf-profile-example/karaf-profile-example-registry/src/main/resources/karaf.profile/org.ops4j.pax.logging.cfg#static
@@ -27,7 +27,7 @@ color.trace = cyan
 
 # Common pattern layout for appenders
 log4j2.pattern = %d{ISO8601} | %-5p | %-16t | %-32c{1} | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
-log4j2.out.pattern = \u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{FATAL=${color.fatal}, ERROR=${color.error}, WARN=${color.warn}, INFO=${color.info}, DEBUG=${color.debug}, TRACE=${color.trace}} \u001b[90m[%t]\u001b[0m %msg%n%throwable
+log4j2.outpattern = \u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{FATAL=${color.fatal}, ERROR=${color.error}, WARN=${color.warn}, INFO=${color.info}, DEBUG=${color.debug}, TRACE=${color.trace}} \u001b[90m[%t]\u001b[0m %msg%n%throwable
 
 
 # Root logger
@@ -63,7 +63,7 @@ log4j2.logger.audit.appenderRef.AuditRollingFile.ref = AuditRollingFile
 log4j2.appender.console.type = Console
 log4j2.appender.console.name = Console
 log4j2.appender.console.layout.type = PatternLayout
-log4j2.appender.console.layout.pattern = ${log4j2.out.pattern}
+log4j2.appender.console.layout.pattern = ${log4j2.outpattern}
 
 # Rolling file appender
 log4j2.appender.rolling.type = RollingRandomAccessFile


### PR DESCRIPTION
This fixes #2265 