### PR TITLE
[karaf-4.4.x] Bump org.apache.aries.blueprint:org.apache.aries.blueprint.api (#2273)

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.apache.aries.blueprint</groupId>
             <artifactId>org.apache.aries.blueprint.api</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <scope>test</scope>
         </dependency>
         <!-- karaf framework 1.0.0 features xml -->


### PR DESCRIPTION
Bumps org.apache.aries.blueprint:org.apache.aries.blueprint.api from 1.0.0 to 1.0.1.

---
updated-dependencies:
- dependency-name: org.apache.aries.blueprint:org.apache.aries.blueprint.api dependency-version: 1.0.1 dependency-type: direct:development update-type: version-update:semver-patch ...