### PR TITLE
Define the maven-deploy-plugin version to avoid to resolve on Maven 4

### DIFF
--- a/tooling/karaf-maven-plugin/src/it/test-commands-generate-help/test-markdown/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-commands-generate-help/test-markdown/pom.xml
@@ -46,10 +46,20 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.4</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.9</version>
                 <extensions>true</extensions>
             </plugin>
             <plugin>


### PR DESCRIPTION
This closes #2238 