### PR TITLE
[karaf-4.4.x] Bump cxf.version from 3.6.9 to 3.6.10 (#2282)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <bouncycastle.version>1.83</bouncycastle.version>
         <camel.version>3.6.0</camel.version>
         <cglib.bundle.version>3.2.9_1</cglib.bundle.version>
-        <cxf.version>3.6.9</cxf.version>
+        <cxf.version>3.6.10</cxf.version>
         <jackson.annotations.version>2.21</jackson.annotations.version>
         <jackson.version>2.21.0</jackson.version>
         <jna.version>5.18.1</jna.version>


### PR DESCRIPTION
Bumps `cxf.version` from 3.6.9 to 3.6.10.

Updates `org.apache.cxf:cxf-rt-frontend-jaxrs` from 3.6.9 to 3.6.10

Updates `org.apache.cxf:cxf-rt-rs-client` from 3.6.9 to 3.6.10

Updates `org.apache.cxf:cxf-rt-frontend-jaxws` from 3.6.9 to 3.6.10

---
updated-dependencies:
- dependency-name: org.apache.cxf:cxf-rt-frontend-jaxrs dependency-version: 3.6.10 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.cxf:cxf-rt-rs-client dependency-version: 3.6.10 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.cxf:cxf-rt-frontend-jaxws dependency-version: 3.6.10 dependency-type: direct:production update-type: version-update:semver-patch ...