### PR TITLE
[karaf-4.4.x] Bump activemq.version from 5.19.1 to 5.19.2 (#2281)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <distributionManagement.snapshot.name>Apache Development Snapshot Repository</distributionManagement.snapshot.name>
         <distributionManagement.snapshot.url>https://repository.apache.org/content/repositories/snapshots</distributionManagement.snapshot.url>
 
-        <activemq.version>5.19.1</activemq.version>
+        <activemq.version>5.19.2</activemq.version>
         <aopalliance.bundle.version>1.0_6</aopalliance.bundle.version>
         <aspectj.bundle.version>1.9.21.1_1</aspectj.bundle.version>
         <asm.version>9.9</asm.version>


### PR DESCRIPTION
Bumps `activemq.version` from 5.19.1 to 5.19.2.

Updates `org.apache.activemq:activemq-pool` from 5.19.1 to 5.19.2
- [Commits](https://github.com/apache/activemq/compare/activemq-5.19.1...activemq-5.19.2)

Updates `org.apache.activemq:activemq-karaf` from 5.19.1 to 5.19.2
- [Commits](https://github.com/apache/activemq/compare/activemq-5.19.1...activemq-5.19.2)

---
updated-dependencies:
- dependency-name: org.apache.activemq:activemq-pool dependency-version: 5.19.2 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.activemq:activemq-karaf dependency-version: 5.19.2 dependency-type: direct:production update-type: version-update:semver-patch ...