### PR TITLE
fix(tooling): support non-standard feature classifier names in karaf-maven-plugin (#2144)

### DIFF
--- a/tooling/karaf-maven-plugin/src/it/test-feature-classifier/consumer-feature/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-classifier/consumer-feature/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>test-feature-classifier</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>test</groupId>
+    <artifactId>consumer-feature</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>feature</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- Depend on the feature with a non-standard classifier -->
+        <dependency>
+            <groupId>test</groupId>
+            <artifactId>custom-classifier-feature</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <classifier>features-core</classifier>
+            <type>xml</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+                <version>@pom.version@</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <enableGeneration>true</enableGeneration>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-feature-classifier/control.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-classifier/control.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="consumer-feature">
+    <repository>mvn:test/custom-classifier-feature/1.0-SNAPSHOT/xml/features-core</repository>
+    <feature name="consumer-feature" description="consumer-feature" version="1.0.0.SNAPSHOT">
+        <feature version="1.0.0.SNAPSHOT" prerequisite="false" dependency="false">custom-classifier-feature</feature>
+    </feature>
+</features>

--- a/tooling/karaf-maven-plugin/src/it/test-feature-classifier/custom-classifier-feature/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-classifier/custom-classifier-feature/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>test-feature-classifier</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>test</groupId>
+    <artifactId>custom-classifier-feature</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>feature</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>test</groupId>
+            <artifactId>test-bundle</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+                <version>@pom.version@</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <enableGeneration>true</enableGeneration>
+                    <attachmentArtifactClassifier>features-core</attachmentArtifactClassifier>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-feature-classifier/invoker.properties
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-classifier/invoker.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals = install

--- a/tooling/karaf-maven-plugin/src/it/test-feature-classifier/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-classifier/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>test-feature-classifier</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <!-- Test that a feature with a non-standard classifier (features-core) is properly recognized -->
+
+    <modules>
+        <module>test-bundle</module>
+        <module>custom-classifier-feature</module>
+        <module>consumer-feature</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <maxmem>256M</maxmem>
+                    <fork>${compiler.fork}</fork>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-feature-classifier/test-bundle/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-classifier/test-bundle/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>test</groupId>
+        <artifactId>test-feature-classifier</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>test</groupId>
+    <artifactId>test-bundle</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tooling/karaf-maven-plugin/src/it/test-feature-classifier/test-bundle/src/main/java/test/TestClass.java
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-classifier/test-bundle/src/main/java/test/TestClass.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test;
+
+public class TestClass
+{
+    public static String VALUE = "test";
+}

--- a/tooling/karaf-maven-plugin/src/it/test-feature-classifier/verify.bsh
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-classifier/verify.bsh
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.custommonkey.xmlunit.*;
+import java.io.*;
+import java.lang.*;
+
+Reader r = new FileReader(new File(basedir, "control.xml"));
+
+// load the features file pushed to the repository
+File generated = new File(basedir, "consumer-feature/target/feature/feature.xml" );
+if (generated.exists()) {
+    XMLAssert.assertXMLEqual(r, new FileReader(generated));
+    return true;
+}
+
+return false;

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
@@ -838,7 +838,7 @@ public class AssemblyMojo extends MojoSupport {
             }
         }
         // Identify features
-        if ("features".equals(artifact.getClassifier())) {
+        if (artifact.getClassifier() != null && artifact.getClassifier().startsWith("features")) {
             return "features";
         }
         if ("xml".equals(artifact.getType())) {

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
@@ -545,7 +545,7 @@ public class RunMojo extends MojoSupport {
     private File getAttachedFeatureFile(MavenProject project) {
         List<Artifact> attachedArtifacts = project.getAttachedArtifacts();
         for (Artifact artifact : attachedArtifacts) {
-            if ("features".equals(artifact.getClassifier()) && "xml".equals(artifact.getType())) {
+            if (artifact.getClassifier() != null && artifact.getClassifier().startsWith("features") && "xml".equals(artifact.getType())) {
                 return artifact.getFile();
             }
         }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -18,8 +18,6 @@
 package org.apache.karaf.tooling.features;
 
 import static java.lang.String.format;
-import static org.apache.karaf.deployer.kar.KarArtifactInstaller.FEATURE_CLASSIFIER;
-
 import java.io.*;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -370,7 +368,7 @@ public class GenerateDescriptorMojo extends MojoSupport {
                 if (project.getPackaging().equals("feature") && enableGeneration) {
                     getLog().info("Set artifact");
                     Artifact artifact = factory.createArtifactWithClassifier(project.getGroupId(), project.getArtifactId(), project.getVersion(), attachmentArtifactType
-                    , FEATURE_CLASSIFIER);
+                    , attachmentArtifactClassifier);
                     artifact.setFile(outputFile);
                     project.setArtifact(artifact);
                 } else {
@@ -611,8 +609,7 @@ public class GenerateDescriptorMojo extends MojoSupport {
                                         Map<Feature, String> featureRepositories, FeaturesCache cache,
                                         Object artifact, Object parent, boolean add)
             throws MojoExecutionException, XMLStreamException, JAXBException, IOException {
-        if (this.dependencyHelper.isArtifactAFeature(artifact) && FEATURE_CLASSIFIER.equals(
-                this.dependencyHelper.getClassifier(artifact))) {
+        if (this.dependencyHelper.isArtifactAFeature(artifact)) {
             File featuresFile = this.dependencyHelper.resolve(artifact, getLog());
             if (featuresFile == null || !featuresFile.exists()) {
                 throw new MojoExecutionException(

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/Dependency31Helper.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/Dependency31Helper.java
@@ -284,7 +284,8 @@ public class Dependency31Helper implements DependencyHelper {
     }
 
     public static boolean isFeature(Artifact artifact) {
-        return artifact.getExtension().equals("kar") || FEATURE_CLASSIFIER.equals(artifact.getClassifier());
+        return artifact.getExtension().equals("kar")
+                || (artifact.getClassifier() != null && artifact.getClassifier().startsWith(FEATURE_CLASSIFIER));
     }
 
     @Override

--- a/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/utils/Dependency31HelperTest.java
+++ b/tooling/karaf-maven-plugin/src/test/java/org/apache/karaf/tooling/utils/Dependency31HelperTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.tooling.utils;
+
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Dependency31HelperTest {
+
+    @Test
+    public void testIsFeatureWithStandardClassifier() {
+        // groupId:artifactId:extension:classifier:version
+        DefaultArtifact artifact = new DefaultArtifact("org.foo:bar:xml:features:1.0");
+        assertTrue(Dependency31Helper.isFeature(artifact));
+    }
+
+    @Test
+    public void testIsFeatureWithNonStandardClassifier() {
+        DefaultArtifact artifact = new DefaultArtifact("org.foo:bar:xml:features-core:1.0");
+        assertTrue(Dependency31Helper.isFeature(artifact));
+    }
+
+    @Test
+    public void testIsFeatureWithAnotherNonStandardClassifier() {
+        DefaultArtifact artifact = new DefaultArtifact("org.foo:bar:xml:features-extra:1.0");
+        assertTrue(Dependency31Helper.isFeature(artifact));
+    }
+
+    @Test
+    public void testIsFeatureWithKarExtension() {
+        DefaultArtifact artifact = new DefaultArtifact("org.foo:bar:kar:1.0");
+        assertTrue(Dependency31Helper.isFeature(artifact));
+    }
+
+    @Test
+    public void testIsFeatureWithJarExtensionNoClassifier() {
+        DefaultArtifact artifact = new DefaultArtifact("org.foo:bar:jar:1.0");
+        assertFalse(Dependency31Helper.isFeature(artifact));
+    }
+
+    @Test
+    public void testIsFeatureWithUnrelatedClassifier() {
+        DefaultArtifact artifact = new DefaultArtifact("org.foo:bar:xml:sources:1.0");
+        assertFalse(Dependency31Helper.isFeature(artifact));
+    }
+
+    @Test
+    public void testIsFeatureWithEmptyClassifier() {
+        DefaultArtifact artifact = new DefaultArtifact("org.foo:bar:xml:1.0");
+        assertFalse(Dependency31Helper.isFeature(artifact));
+    }
+}


### PR DESCRIPTION
The feature descriptor generator hardcoded the "features" classifier, causing dependencies with non-standard classifiers (e.g. "features-core") to be inlined as bundles instead of recognized as feature dependencies.

- Dependency31Helper.isFeature(): match classifiers starting with "features"
- GenerateDescriptorMojo.processFeatureArtifact(): remove redundant classifier check
- GenerateDescriptorMojo: use configured attachmentArtifactClassifier instead of hardcoded FEATURE_CLASSIFIER when setting the project artifact
- AssemblyMojo.getType() and RunMojo.getAttachedFeatureFile(): same classifier fix