### PR TITLE
fix(ci): ensure test results are displayed on error or timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,14 +78,15 @@ jobs:
           key: maven-local-repo-${{ github.run_id }}
       - name: Test
         run: mvn -B -e install -Ptest
+        timeout-minutes: 180
       - name: Upload Test Results
-        if: (!cancelled())
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: '**/target/surefire-reports/*.xml'
       - name: Publish Test Results
-        if: (!cancelled())
+        if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           large_files: true


### PR DESCRIPTION
Use `always()` instead of `!cancelled()` so the upload and publish steps run even when the job is cancelled due to a timeout.  Add a step-level timeout to the Maven test run so a timeout stops the step without cancelling the entire job, giving the reporting steps a chance to execute.