### PR TITLE
fix(shell): prevent LinkageError from killing the local console thread (karaf-4.4.x)

### DIFF
--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/ConsoleSessionImpl.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/ConsoleSessionImpl.java
@@ -473,6 +473,7 @@ public class ConsoleSessionImpl implements Session {
             command = "";
         } catch (Throwable t) {
             ShellUtil.logException(this, t);
+            command = "";
         } finally {
             reading.set(false);
         }

--- a/shell/core/src/main/java/org/apache/karaf/shell/support/ShellUtil.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/support/ShellUtil.java
@@ -183,8 +183,9 @@ public class ShellUtil {
                 session.getConsole().println(str);
             }
             session.getConsole().flush();
-        } catch (Exception ignore) {
-            // ignore
+        } catch (Throwable ignore) {
+            // ignore (catch Throwable to handle LinkageError from JLine classloader
+            // changes during bundle refresh, which would otherwise kill the console thread)
         }
     }
 


### PR DESCRIPTION
Backport of #2313 to karaf-4.4.x.

When the JLine bundle is refreshed during runtime (e.g., due to feature install/update), the bundle classloader changes and AttributedString may be loaded by two different classloaders. This causes a LinkageError in ShellUtil.applyStyle().

The logException() error handler only caught Exception, not Error, so the LinkageError escaped and killed the console thread. Broaden the catch to Throwable so classloading errors during exception display are handled gracefully.

Also set command to empty string in readCommand()'s catch-all handler so transient errors re-prompt instead of exiting the session.