### PR TITLE
fix(shell): normalize line endings in testColoredTable for Windows compatibility (karaf-4.4.x)

### DIFF
--- a/shell/core/src/test/java/org/apache/karaf/shell/support/table/ShellTableTest.java
+++ b/shell/core/src/test/java/org/apache/karaf/shell/support/table/ShellTableTest.java
@@ -131,7 +131,7 @@ public class ShellTableTest {
         table.print(new PrintStream(baos), false);
         assertEquals("Normal          \tThis should have default color\n" +
         		"[32mActive          [39m\tGreen color\n" +
-        		"[33mThis is Resolved[39m\tYellow color\n", baos.toString());
+        		"[33mThis is Resolved[39m\tYellow color\n", getString(baos));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Backport of #2318 to the `karaf-4.4.x` branch
- Uses `getString()` helper to normalize `\r\n` to `\n` in the colored table test assertion, consistent with other tests in the same class