### PR TITLE
fix(ci): make test job depend on build to resolve SNAPSHOT artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,15 +45,21 @@ jobs:
           cache: 'maven'
       - name: Build
         run: mvn -U -B -e clean install -Prat -DskipTests "-Dinvoker.skip=true"
+      - name: Save Maven Local Repository
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-local-repo-${{ github.run_id }}
 
   test:
     name: test
+    needs: build
 
     permissions:
       contents: read
       checks: write
       pull-requests: write
-  
+
     runs-on: ubuntu-24.04
 
     steps:
@@ -65,8 +71,13 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
+      - name: Restore Maven Local Repository
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-local-repo-${{ github.run_id }}
       - name: Test
-        run: mvn -U -B -e clean install -Ptest
+        run: mvn -B -e install -Ptest
       - name: Upload Test Results
         if: (!cancelled())
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- The CI `test` job uses the `-Ptest` Maven profile which disables assembly packaging (`install-kar`, `package` phases set to `none`), meaning artifacts like `apache-karaf:tar.gz` are never built during the test run
- Previously, `build` and `test` ran as independent parallel jobs on separate runners, so the `test` job could not resolve these SNAPSHOT artifacts from `~/.m2/repository`
- This caused `services/interceptor/impl` to fail with: `Could not find artifact org.apache.karaf:apache-karaf:tar.gz:4.4.10-SNAPSHOT`

## Fix

- Add `needs: build` so the test job runs after build completes
- Save the Maven local repository from the build job using `actions/cache/save` with a run-scoped key
- Restore it in the test job using `actions/cache/restore`
- Remove `clean` from the test Maven command to preserve the restored local repo

## Test plan

- [ ] Verify the `build` job completes and caches `~/.m2/repository`
- [ ] Verify the `test` job restores the cache and resolves `apache-karaf:tar.gz` successfully
- [ ] Verify test results are still uploaded and published correctly