### PR TITLE
fix(itests): fix flaky SystemShutdownTest by using delayed shutdown

### DIFF
--- a/itests/common/src/main/java/org/apache/karaf/itests/KarafTestSupport.java
+++ b/itests/common/src/main/java/org/apache/karaf/itests/KarafTestSupport.java
@@ -109,9 +109,9 @@ public class KarafTestSupport {
 
     // Commands provided by boot features will be available to the test at all times
     // Only additionally installed features may require a proper custom timeout
-    // keep the default command timeout to ensure existing tests don't break, but use this
-    // as a default timeout for aliases
-    static final Long ALIAS_SERVICE_TIMEOUT = 1L;
+    // Aliases are resolved via the init script but the underlying command service
+    // may not yet be registered, so allow a reasonable wait on CI
+    static final Long ALIAS_SERVICE_TIMEOUT = 30000L;
 
     private static Logger LOG = LoggerFactory.getLogger(KarafTestSupport.class);
 

--- a/itests/test/src/test/java/org/apache/karaf/itests/SystemShutdownTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/SystemShutdownTest.java
@@ -17,6 +17,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -25,25 +26,35 @@ import org.ops4j.pax.exam.spi.reactors.PerMethod;
 
 import java.lang.management.ManagementFactory;
 
+/**
+ * Tests for system shutdown commands. Uses a delayed shutdown (+1 minute)
+ * instead of immediate to avoid a race condition where the async shutdown
+ * thread kills the OSGi framework before PaxExam receives the RMI response,
+ * causing intermittent NoSuchObject/Connection refused errors.
+ * PaxExam's container teardown (stop) will cleanly terminate the process
+ * before the delayed shutdown fires.
+ */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerMethod.class)
 public class SystemShutdownTest extends BaseTest {
 
     @Test
     public void shutdownCommand() throws Exception {
-        System.out.println(executeCommand("system:shutdown -f", new RolePrincipal("admin")));
+        String response = executeCommand("system:shutdown -f +1", new RolePrincipal("admin"));
+        Assert.assertFalse("Shutdown command should not time out", response.contains("SHELL COMMAND TIMED OUT"));
     }
 
     @Test
     public void haltAlias() throws Exception {
-        System.out.println(executeAlias("halt", new RolePrincipal("admin")));
+        String response = executeAlias("halt +1", new RolePrincipal("admin"));
+        Assert.assertFalse("Alias command should not time out", response.contains("SHELL COMMAND TIMED OUT"));
     }
 
     @Test
     public void shutdownViaMBean() throws Exception {
         MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
         ObjectName name = new ObjectName("org.apache.karaf:type=system,name=root");
-        mbeanServer.invoke(name, "halt", new Object[]{}, new String[]{});
+        mbeanServer.invoke(name, "halt", new Object[]{"+1"}, new String[]{ String.class.getName() });
     }
 
 }


### PR DESCRIPTION
The test was intermittently failing with NoSuchObject/Connection refused RMI errors because the async shutdown thread could kill the OSGi framework before PaxExam received the RMI response from the test method.

Use a delayed shutdown (+1 minute) instead of immediate so the command is validated without actually halting the framework during the test. PaxExam's container teardown cleanly terminates the process before the timer fires.

Also increase ALIAS_SERVICE_TIMEOUT from 1ms to 30s so alias-based tests don't fail on loaded CI machines where command service registration takes longer.