### PR TITLE
ci(dependabot): add dependency updates for karaf-4.4.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,17 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "karaf-4.4.x"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "karaf-4.4.x"
+    open-pull-requests-limit: 50
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- Add Dependabot entries for `github-actions` and `maven` ecosystems targeting the `karaf-4.4.x` branch
- Mirrors the existing `main` branch configuration (daily schedule, no semver-major updates, 50 PR limit for Maven)