### PR TITLE
feat(services): add native karaf.url service as mvn: protocol handler

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -38,6 +38,7 @@
         <module>eventadmin</module>
         <module>staticcm</module>
         <module>interceptor</module>
+        <module>url</module>
     </modules>
 
 </project>

--- a/services/url/pom.xml
+++ b/services/url/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>karaf</artifactId>
+        <groupId>org.apache.karaf</groupId>
+        <version>4.5.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.karaf.services</groupId>
+    <artifactId>org.apache.karaf.services.url</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Karaf :: OSGi Services :: URL Handlers</name>
+    <description>Karaf URL Handlers Service (mvn: protocol)</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-services-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>
+                            ${project.artifactId}
+                        </Bundle-SymbolicName>
+                        <Bundle-Activator>
+                            org.apache.karaf.services.url.internal.osgi.Activator
+                        </Bundle-Activator>
+                        <Bundle-Vendor>The Apache Software Foundation</Bundle-Vendor>
+                        <Import-Package>
+                            org.osgi.framework;version="[1,3)",
+                            org.osgi.service.url;version="[1.0,2)",
+                            org.osgi.service.cm;version="[1.5,2)";resolution:=optional,
+                            org.osgi.util.tracker;version="[1.5,2)",
+                            javax.net.ssl,
+                            javax.xml.parsers,
+                            org.w3c.dom,
+                            org.xml.sax,
+                            *
+                        </Import-Package>
+                        <Export-Package>
+                            org.apache.karaf.services.url;version="${project.version}"
+                        </Export-Package>
+                        <Private-Package>
+                            org.apache.karaf.services.url.internal,
+                            org.apache.karaf.services.url.internal.osgi
+                        </Private-Package>
+                        <Export-Service>
+                            org.osgi.service.url.URLStreamHandlerService,
+                            org.apache.karaf.services.url.MavenResolver
+                        </Export-Service>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>karaf-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.url</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.cm</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.tracker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf</groupId>
+            <artifactId>org.apache.karaf.util</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/services/url/pom.xml
+++ b/services/url/pom.xml
@@ -48,9 +48,6 @@
                         <Bundle-SymbolicName>
                             ${project.artifactId}
                         </Bundle-SymbolicName>
-                        <Bundle-Activator>
-                            org.apache.karaf.services.url.internal.osgi.Activator
-                        </Bundle-Activator>
                         <Bundle-Vendor>The Apache Software Foundation</Bundle-Vendor>
                         <Import-Package>
                             org.osgi.framework;version="[1,3)",
@@ -68,7 +65,10 @@
                         </Export-Package>
                         <Private-Package>
                             org.apache.karaf.services.url.internal,
-                            org.apache.karaf.services.url.internal.osgi
+                            org.apache.karaf.services.url.internal.osgi,
+                            org.apache.karaf.util.maven,
+                            org.apache.karaf.util.tracker,
+                            org.apache.karaf.util.tracker.annotation
                         </Private-Package>
                         <Export-Service>
                             org.osgi.service.url.URLStreamHandlerService,

--- a/services/url/src/main/java/org/apache/karaf/services/url/MavenResolver.java
+++ b/services/url/src/main/java/org/apache/karaf/services/url/MavenResolver.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.services.url;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Service interface for resolving Maven artifact URIs.
+ * <p>
+ * Maven URIs follow the syntax:
+ * {@code mvn:[repository_url!]groupId/artifactId[/[version][/[type][/classifier]]]}
+ */
+public interface MavenResolver {
+
+    /**
+     * Resolve a Maven artifact URI to a local file.
+     *
+     * @param url the Maven artifact URI (e.g. {@code mvn:groupId/artifactId/version})
+     * @return the resolved file
+     * @throws IOException if the artifact cannot be resolved
+     */
+    File resolve(String url) throws IOException;
+
+    /**
+     * Resolve a Maven artifact by its coordinates to a local file.
+     *
+     * @param groupId    the group ID
+     * @param artifactId the artifact ID
+     * @param version    the version (can be {@code null} for LATEST)
+     * @param type       the type/extension (can be {@code null} for jar)
+     * @param classifier the classifier (can be {@code null})
+     * @return the resolved file
+     * @throws IOException if the artifact cannot be resolved
+     */
+    File resolve(String groupId, String artifactId, String version, String type, String classifier) throws IOException;
+
+    /**
+     * Get the local repository path.
+     *
+     * @return the local repository directory
+     */
+    File getLocalRepository();
+
+}

--- a/services/url/src/main/java/org/apache/karaf/services/url/internal/MavenConfiguration.java
+++ b/services/url/src/main/java/org/apache/karaf/services/url/internal/MavenConfiguration.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.services.url.internal;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.List;
+
+import org.osgi.framework.BundleContext;
+
+/**
+ * Configuration for the Maven URL resolver.
+ */
+public class MavenConfiguration {
+
+    public static final String PID = "org.apache.karaf.url.mvn";
+
+    public static final String PROP_LOCAL_REPOSITORY = "localRepository";
+    public static final String PROP_DEFAULT_REPOSITORIES = "defaultRepositories";
+    public static final String PROP_REPOSITORIES = "repositories";
+    public static final String PROP_UPDATE_POLICY = "globalUpdatePolicy";
+    public static final String PROP_CHECKSUM_POLICY = "globalChecksumPolicy";
+    public static final String PROP_SETTINGS = "settings";
+    public static final String PROP_CONNECTION_TIMEOUT = "socket.connectionTimeout";
+    public static final String PROP_READ_TIMEOUT = "socket.readTimeout";
+    public static final String PROP_TIMEOUT = "timeout";
+    public static final String PROP_CERTIFICATE_CHECK = "certificateCheck";
+    public static final String PROP_RETRY_COUNT = "connection.retryCount";
+
+    private File localRepository;
+    private List<String> defaultRepositories;
+    private List<String> repositories;
+    private String updatePolicy;
+    private String checksumPolicy;
+    private int connectionTimeout;
+    private int readTimeout;
+    private boolean certificateCheck;
+    private int retryCount;
+
+    public MavenConfiguration(BundleContext context, Dictionary<String, ?> properties) {
+        // Local repository
+        String localRepo = getProperty(context, properties, PROP_LOCAL_REPOSITORY);
+        if (localRepo != null && !localRepo.isEmpty()) {
+            localRepository = resolveFile(context, localRepo);
+        } else {
+            localRepository = new File(System.getProperty("user.home"), ".m2/repository");
+        }
+
+        // Default repositories (local file-based repos)
+        String defaultRepos = getProperty(context, properties, PROP_DEFAULT_REPOSITORIES);
+        defaultRepositories = parseRepositories(context, defaultRepos);
+
+        // Remote repositories
+        String repos = getProperty(context, properties, PROP_REPOSITORIES);
+        repositories = parseRepositories(context, repos);
+
+        // Policies
+        updatePolicy = getProperty(context, properties, PROP_UPDATE_POLICY);
+        checksumPolicy = getProperty(context, properties, PROP_CHECKSUM_POLICY);
+
+        // Timeouts
+        int defaultTimeout = getIntProperty(context, properties, PROP_TIMEOUT, 5000);
+        connectionTimeout = getIntProperty(context, properties, PROP_CONNECTION_TIMEOUT, defaultTimeout);
+        readTimeout = getIntProperty(context, properties, PROP_READ_TIMEOUT, 30000);
+
+        // SSL
+        certificateCheck = getBooleanProperty(context, properties, PROP_CERTIFICATE_CHECK, true);
+
+        // Retry
+        retryCount = getIntProperty(context, properties, PROP_RETRY_COUNT, 3);
+    }
+
+    private String getProperty(BundleContext context, Dictionary<String, ?> properties, String key) {
+        String fullKey = PID + "." + key;
+        // Check dictionary first
+        if (properties != null) {
+            Object value = properties.get(fullKey);
+            if (value == null) {
+                value = properties.get(key);
+            }
+            if (value != null) {
+                return substituteVars(context, value.toString());
+            }
+        }
+        // Fall back to system/framework properties
+        String value = context.getProperty(fullKey);
+        if (value == null) {
+            value = System.getProperty(fullKey);
+        }
+        if (value != null) {
+            return substituteVars(context, value);
+        }
+        return null;
+    }
+
+    private int getIntProperty(BundleContext context, Dictionary<String, ?> properties, String key, int defaultValue) {
+        String value = getProperty(context, properties, key);
+        if (value != null && !value.isEmpty()) {
+            try {
+                return Integer.parseInt(value.trim());
+            } catch (NumberFormatException e) {
+                // ignore
+            }
+        }
+        return defaultValue;
+    }
+
+    private boolean getBooleanProperty(BundleContext context, Dictionary<String, ?> properties, String key, boolean defaultValue) {
+        String value = getProperty(context, properties, key);
+        if (value != null && !value.isEmpty()) {
+            return Boolean.parseBoolean(value.trim());
+        }
+        return defaultValue;
+    }
+
+    private List<String> parseRepositories(BundleContext context, String repos) {
+        if (repos == null || repos.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> result = new ArrayList<>();
+        for (String repo : repos.split(",")) {
+            String trimmed = repo.trim();
+            if (!trimmed.isEmpty()) {
+                trimmed = substituteVars(context, trimmed);
+                result.add(trimmed);
+            }
+        }
+        return result;
+    }
+
+    private File resolveFile(BundleContext context, String path) {
+        path = substituteVars(context, path);
+        File file = new File(path);
+        if (!file.isAbsolute()) {
+            String karafHome = context.getProperty("karaf.home");
+            if (karafHome != null) {
+                file = new File(karafHome, path);
+            }
+        }
+        return file;
+    }
+
+    private String substituteVars(BundleContext context, String value) {
+        if (value == null) {
+            return null;
+        }
+        StringBuilder result = new StringBuilder();
+        int i = 0;
+        while (i < value.length()) {
+            if (value.charAt(i) == '$' && i + 1 < value.length() && value.charAt(i + 1) == '{') {
+                int end = value.indexOf('}', i + 2);
+                if (end > 0) {
+                    String varName = value.substring(i + 2, end);
+                    String varValue = context.getProperty(varName);
+                    if (varValue == null) {
+                        varValue = System.getProperty(varName);
+                    }
+                    if (varValue != null) {
+                        result.append(varValue);
+                    } else {
+                        result.append(value, i, end + 1);
+                    }
+                    i = end + 1;
+                } else {
+                    result.append(value.charAt(i));
+                    i++;
+                }
+            } else {
+                result.append(value.charAt(i));
+                i++;
+            }
+        }
+        return result.toString();
+    }
+
+    public File getLocalRepository() {
+        return localRepository;
+    }
+
+    public List<String> getDefaultRepositories() {
+        return defaultRepositories;
+    }
+
+    public List<String> getRepositories() {
+        return repositories;
+    }
+
+    public String getUpdatePolicy() {
+        return updatePolicy;
+    }
+
+    public String getChecksumPolicy() {
+        return checksumPolicy;
+    }
+
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    public boolean isCertificateCheck() {
+        return certificateCheck;
+    }
+
+    public int getRetryCount() {
+        return retryCount;
+    }
+
+}

--- a/services/url/src/main/java/org/apache/karaf/services/url/internal/MavenResolverImpl.java
+++ b/services/url/src/main/java/org/apache/karaf/services/url/internal/MavenResolverImpl.java
@@ -1,0 +1,362 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.services.url.internal;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.apache.karaf.services.url.MavenResolver;
+import org.apache.karaf.util.maven.Parser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of the {@link MavenResolver} service.
+ * <p>
+ * Resolves Maven artifacts from local default repositories first,
+ * then falls back to remote repositories, downloading to the local repository.
+ */
+public class MavenResolverImpl implements MavenResolver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MavenResolverImpl.class);
+
+    private static final int BUFFER_SIZE = 8192;
+
+    private final MavenConfiguration configuration;
+
+    public MavenResolverImpl(MavenConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public File resolve(String url) throws IOException {
+        if (url == null) {
+            throw new IOException("URL cannot be null");
+        }
+        String path = url;
+        if (path.startsWith("mvn:")) {
+            path = path.substring("mvn:".length());
+        }
+        Parser parser = new Parser(path);
+        return resolve(parser);
+    }
+
+    @Override
+    public File resolve(String groupId, String artifactId, String version, String type, String classifier) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append(groupId).append('/').append(artifactId);
+        if (version != null && !version.isEmpty()) {
+            sb.append('/').append(version);
+        }
+        if (type != null && !type.isEmpty()) {
+            sb.append('/').append(type);
+        }
+        if (classifier != null && !classifier.isEmpty()) {
+            if (type == null || type.isEmpty()) {
+                sb.append('/');
+            }
+            sb.append('/').append(classifier);
+        }
+        Parser parser = new Parser(sb.toString());
+        return resolve(parser);
+    }
+
+    @Override
+    public File getLocalRepository() {
+        return configuration.getLocalRepository();
+    }
+
+    private File resolve(Parser parser) throws IOException {
+        String artifactPath = parser.getArtifactPath();
+
+        // 1. Check default repositories (local file-based)
+        for (String repo : configuration.getDefaultRepositories()) {
+            File file = resolveFromDefaultRepository(repo, artifactPath);
+            if (file != null) {
+                LOG.debug("Resolved {} from default repository", artifactPath);
+                return file;
+            }
+        }
+
+        // 2. Check local repository
+        File localFile = new File(configuration.getLocalRepository(), artifactPath);
+        if (localFile.exists() && localFile.isFile()) {
+            LOG.debug("Resolved {} from local repository", artifactPath);
+            return localFile;
+        }
+
+        // 3. Try remote repositories
+        for (String repo : configuration.getRepositories()) {
+            File file = resolveFromRemoteRepository(repo, artifactPath, localFile);
+            if (file != null) {
+                LOG.debug("Resolved {} from remote repository {}", artifactPath, repo);
+                return file;
+            }
+        }
+
+        throw new IOException("Could not resolve artifact: mvn:" + parser.toMvnURI());
+    }
+
+    private File resolveFromDefaultRepository(String repo, String artifactPath) {
+        // Parse repository URL, stripping @id=... @snapshots @noreleases flags
+        String repoUrl = stripRepositoryFlags(repo);
+
+        File repoDir;
+        if (repoUrl.startsWith("file:")) {
+            repoDir = new File(URI.create(repoUrl));
+        } else {
+            repoDir = new File(repoUrl);
+        }
+
+        File file = new File(repoDir, artifactPath);
+        if (file.exists() && file.isFile()) {
+            return file;
+        }
+        return null;
+    }
+
+    private File resolveFromRemoteRepository(String repo, String artifactPath, File localFile) throws IOException {
+        String repoUrl = stripRepositoryFlags(repo);
+
+        // Skip file-based repos that were already checked
+        if (repoUrl.startsWith("file:")) {
+            return null;
+        }
+
+        // Build the full URL
+        String url = repoUrl;
+        if (!url.endsWith("/")) {
+            url += "/";
+        }
+        url += artifactPath;
+
+        int retryCount = configuration.getRetryCount();
+        for (int attempt = 0; attempt <= retryCount; attempt++) {
+            try {
+                return downloadArtifact(url, localFile);
+            } catch (IOException e) {
+                if (attempt < retryCount) {
+                    LOG.debug("Retry {}/{} for {}: {}", attempt + 1, retryCount, url, e.getMessage());
+                } else {
+                    LOG.debug("Failed to download {} after {} attempts: {}", url, retryCount + 1, e.getMessage());
+                }
+            }
+        }
+        return null;
+    }
+
+    private File downloadArtifact(String url, File localFile) throws IOException {
+        LOG.debug("Downloading {}", url);
+
+        URLConnection connection = new URL(url).openConnection();
+        if (connection instanceof HttpsURLConnection && !configuration.isCertificateCheck()) {
+            disableSslVerification((HttpsURLConnection) connection);
+        }
+
+        connection.setConnectTimeout(configuration.getConnectionTimeout());
+        connection.setReadTimeout(configuration.getReadTimeout());
+
+        if (connection instanceof HttpURLConnection) {
+            HttpURLConnection httpConnection = (HttpURLConnection) connection;
+            int responseCode = httpConnection.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+                return null;
+            }
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                throw new IOException("HTTP " + responseCode + " for " + url);
+            }
+        }
+
+        // Download to a temp file, then move to the target location
+        File parentDir = localFile.getParentFile();
+        if (!parentDir.exists() && !parentDir.mkdirs()) {
+            throw new IOException("Could not create directory: " + parentDir);
+        }
+
+        File tmpFile = new File(parentDir, localFile.getName() + ".tmp");
+        try (InputStream in = connection.getInputStream();
+             FileOutputStream out = new FileOutputStream(tmpFile)) {
+            byte[] buffer = new byte[BUFFER_SIZE];
+            int bytesRead;
+            while ((bytesRead = in.read(buffer)) != -1) {
+                out.write(buffer, 0, bytesRead);
+            }
+        } catch (IOException e) {
+            tmpFile.delete();
+            throw e;
+        }
+
+        // Verify checksum if available
+        if (connection instanceof HttpURLConnection) {
+            verifyChecksum(url, tmpFile);
+        }
+
+        // Atomic rename
+        if (!tmpFile.renameTo(localFile)) {
+            // Fallback: copy and delete
+            tmpFile.delete();
+            throw new IOException("Could not move downloaded file to " + localFile);
+        }
+
+        return localFile;
+    }
+
+    private void verifyChecksum(String url, File file) throws IOException {
+        String checksumPolicy = configuration.getChecksumPolicy();
+        if ("ignore".equals(checksumPolicy)) {
+            return;
+        }
+
+        // Try SHA-1 first, then MD5
+        String remoteChecksum = fetchChecksum(url + ".sha1");
+        if (remoteChecksum != null) {
+            String localChecksum = computeChecksum(file, "SHA-1");
+            if (!remoteChecksum.equalsIgnoreCase(localChecksum)) {
+                String msg = "SHA-1 checksum mismatch for " + url;
+                if ("fail".equals(checksumPolicy)) {
+                    file.delete();
+                    throw new IOException(msg);
+                }
+                LOG.warn(msg);
+            }
+            return;
+        }
+
+        remoteChecksum = fetchChecksum(url + ".md5");
+        if (remoteChecksum != null) {
+            String localChecksum = computeChecksum(file, "MD5");
+            if (!remoteChecksum.equalsIgnoreCase(localChecksum)) {
+                String msg = "MD5 checksum mismatch for " + url;
+                if ("fail".equals(checksumPolicy)) {
+                    file.delete();
+                    throw new IOException(msg);
+                }
+                LOG.warn(msg);
+            }
+        }
+    }
+
+    private String fetchChecksum(String url) {
+        try {
+            URLConnection connection = new URL(url).openConnection();
+            connection.setConnectTimeout(configuration.getConnectionTimeout());
+            connection.setReadTimeout(configuration.getReadTimeout());
+            if (connection instanceof HttpURLConnection) {
+                int code = ((HttpURLConnection) connection).getResponseCode();
+                if (code != HttpURLConnection.HTTP_OK) {
+                    return null;
+                }
+            }
+            try (InputStream in = connection.getInputStream()) {
+                byte[] data = in.readAllBytes();
+                String checksum = new String(data).trim();
+                // Handle checksum files that contain filename after the hash
+                int space = checksum.indexOf(' ');
+                if (space > 0) {
+                    checksum = checksum.substring(0, space);
+                }
+                return checksum;
+            }
+        } catch (IOException e) {
+            LOG.debug("Could not fetch checksum from {}: {}", url, e.getMessage());
+            return null;
+        }
+    }
+
+    private String computeChecksum(File file, String algorithm) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(algorithm);
+            try (InputStream in = new java.io.FileInputStream(file)) {
+                byte[] buffer = new byte[BUFFER_SIZE];
+                int bytesRead;
+                while ((bytesRead = in.read(buffer)) != -1) {
+                    digest.update(buffer, 0, bytesRead);
+                }
+            }
+            byte[] hash = digest.digest();
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException("Algorithm not available: " + algorithm, e);
+        }
+    }
+
+    private void disableSslVerification(HttpsURLConnection connection) {
+        try {
+            TrustManager[] trustAllCerts = new TrustManager[]{
+                new X509TrustManager() {
+                    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+                    public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+                    }
+                    public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+                    }
+                }
+            };
+            SSLContext sc = SSLContext.getInstance("TLS");
+            sc.init(null, trustAllCerts, new java.security.SecureRandom());
+            connection.setSSLSocketFactory(sc.getSocketFactory());
+            connection.setHostnameVerifier((hostname, session) -> true);
+        } catch (Exception e) {
+            LOG.warn("Could not disable SSL verification", e);
+        }
+    }
+
+    static String stripRepositoryFlags(String repo) {
+        // Strip flags like @id=central @snapshots @noreleases @multi @update=...
+        String result = repo;
+        while (result.contains("@")) {
+            int atIdx = result.indexOf('@');
+            int nextComma = result.indexOf(',', atIdx);
+            int nextSpace = result.indexOf(' ', atIdx);
+            int end;
+            if (nextComma >= 0 && nextSpace >= 0) {
+                end = Math.min(nextComma, nextSpace);
+            } else if (nextComma >= 0) {
+                end = nextComma;
+            } else if (nextSpace >= 0) {
+                end = nextSpace;
+            } else {
+                end = result.length();
+            }
+            result = result.substring(0, atIdx) + result.substring(end);
+        }
+        return result.trim();
+    }
+
+}

--- a/services/url/src/main/java/org/apache/karaf/services/url/internal/MvnUrlHandler.java
+++ b/services/url/src/main/java/org/apache/karaf/services/url/internal/MvnUrlHandler.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.services.url.internal;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+
+import org.apache.karaf.services.url.MavenResolver;
+import org.osgi.service.url.AbstractURLStreamHandlerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * OSGi URL stream handler for the {@code mvn:} protocol.
+ * <p>
+ * Syntax: {@code mvn:[repository_url!]groupId/artifactId[/[version][/[type][/classifier]]]}
+ */
+public class MvnUrlHandler extends AbstractURLStreamHandlerService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MvnUrlHandler.class);
+
+    private final MavenResolver resolver;
+
+    public MvnUrlHandler(MavenResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public URLConnection openConnection(URL url) throws IOException {
+        LOG.debug("Opening connection for mvn: URL {}", url);
+        return new MvnConnection(url, resolver);
+    }
+
+    static class MvnConnection extends URLConnection {
+
+        private final MavenResolver resolver;
+        private File resolvedFile;
+
+        MvnConnection(URL url, MavenResolver resolver) {
+            super(url);
+            this.resolver = resolver;
+        }
+
+        @Override
+        public void connect() throws IOException {
+            if (resolvedFile == null) {
+                String mvnUrl = url.toExternalForm();
+                resolvedFile = resolver.resolve(mvnUrl);
+            }
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            connect();
+            return new FileInputStream(resolvedFile);
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            try {
+                connect();
+                return resolvedFile.length();
+            } catch (IOException e) {
+                return -1;
+            }
+        }
+
+        @Override
+        public String getContentType() {
+            return "application/octet-stream";
+        }
+
+    }
+
+}

--- a/services/url/src/main/java/org/apache/karaf/services/url/internal/osgi/Activator.java
+++ b/services/url/src/main/java/org/apache/karaf/services/url/internal/osgi/Activator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.services.url.internal.osgi;
+
+import java.util.Hashtable;
+
+import org.apache.karaf.services.url.MavenResolver;
+import org.apache.karaf.services.url.internal.MavenConfiguration;
+import org.apache.karaf.services.url.internal.MavenResolverImpl;
+import org.apache.karaf.services.url.internal.MvnUrlHandler;
+import org.apache.karaf.util.tracker.BaseActivator;
+import org.apache.karaf.util.tracker.annotation.Managed;
+import org.apache.karaf.util.tracker.annotation.ProvideService;
+import org.apache.karaf.util.tracker.annotation.Services;
+import org.osgi.service.cm.ManagedService;
+import org.osgi.service.url.URLStreamHandlerService;
+
+@Services(
+        provides = @ProvideService(MavenResolver.class)
+)
+@Managed(MavenConfiguration.PID)
+public class Activator extends BaseActivator implements ManagedService {
+
+    @Override
+    protected void doStart() throws Exception {
+        MavenConfiguration config = new MavenConfiguration(bundleContext, getConfiguration());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        register(MavenResolver.class, resolver);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("url.handler.protocol", "mvn");
+        register(URLStreamHandlerService.class, new MvnUrlHandler(resolver), props);
+    }
+
+}

--- a/services/url/src/main/resources/META-INF/LICENSE
+++ b/services/url/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/services/url/src/main/resources/META-INF/NOTICE
+++ b/services/url/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,9 @@
+Apache Karaf :: OSGi Services :: URL Handlers
+Copyright 2007-2025 The Apache Software Foundation
+
+-----------------------------------------------------------------------------
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+-----------------------------------------------------------------------------

--- a/services/url/src/main/resources/org.apache.karaf.url.mvn.cfg
+++ b/services/url/src/main/resources/org.apache.karaf.url.mvn.cfg
@@ -1,0 +1,84 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# Apache Karaf Maven URL Handler configuration
+#
+# This replaces the pax-url-mvn configuration with a native Karaf implementation.
+# Property names are compatible with org.ops4j.pax.url.mvn.* for easier migration.
+#
+
+# If set to true, SSL certificate validation is enforced when accessing
+# Maven repositories through HTTPS
+#
+org.apache.karaf.url.mvn.certificateCheck = true
+
+#
+# Path to the local Maven repository which is used to avoid downloading
+# artifacts when they already exist locally.
+# Defaults to: ${user.home}/.m2/repository
+#
+#org.apache.karaf.url.mvn.localRepository =
+
+#
+# Comma separated list of default repositories (local, file-based).
+# These are checked first, before the local repository and remote repositories.
+# A repository URL can be appended with:
+#    @snapshots  : the repository contains snapshots
+#    @noreleases : the repository does not contain releases
+#    @id=repo.id : the repository identifier
+#
+org.apache.karaf.url.mvn.defaultRepositories = \
+    ${karaf.home.uri}${karaf.default.repository}@id=system.repository@snapshots, \
+    ${karaf.data.uri}kar@id=kar.repository@multi@snapshots, \
+    ${karaf.base.uri}${karaf.default.repository}@id=child.system.repository@snapshots
+
+#
+# Comma separated list of remote repositories.
+# These are accessed via HTTP/HTTPS when the artifact is not found locally.
+# A repository URL can be appended with:
+#    @snapshots  : the repository contains snapshots
+#    @noreleases : the repository does not contain releases
+#    @id=repo.id : the repository identifier
+#
+org.apache.karaf.url.mvn.repositories = \
+    https://repo1.maven.org/maven2@id=central, \
+    https://repository.apache.org/content/groups/snapshots-group@id=apache@snapshots@noreleases
+
+#
+# Global update policy: always, daily, interval:NNN (minutes), never
+#
+#org.apache.karaf.url.mvn.globalUpdatePolicy = daily
+
+#
+# Global checksum policy: warn, fail, ignore
+#
+#org.apache.karaf.url.mvn.globalChecksumPolicy = warn
+
+#
+# Connection and socket timeouts
+#
+org.apache.karaf.url.mvn.timeout = 5000
+org.apache.karaf.url.mvn.socket.connectionTimeout = 5000
+org.apache.karaf.url.mvn.socket.readTimeout = 30000
+
+#
+# Number of connection retries after failure
+#
+org.apache.karaf.url.mvn.connection.retryCount = 3

--- a/services/url/src/test/java/org/apache/karaf/services/url/internal/MavenConfigurationTest.java
+++ b/services/url/src/test/java/org/apache/karaf/services/url/internal/MavenConfigurationTest.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.services.url.internal;
+
+import java.io.File;
+import java.util.Hashtable;
+
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class MavenConfigurationTest {
+
+    @Test
+    public void testDefaultConfiguration() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty(anyString())).andReturn(null).anyTimes();
+        replay(context);
+
+        MavenConfiguration config = new MavenConfiguration(context, null);
+
+        assertEquals(new File(System.getProperty("user.home"), ".m2/repository"), config.getLocalRepository());
+        assertTrue(config.getDefaultRepositories().isEmpty());
+        assertTrue(config.getRepositories().isEmpty());
+        assertNull(config.getUpdatePolicy());
+        assertNull(config.getChecksumPolicy());
+        assertEquals(5000, config.getConnectionTimeout());
+        assertEquals(30000, config.getReadTimeout());
+        assertTrue(config.isCertificateCheck());
+        assertEquals(3, config.getRetryCount());
+
+        verify(context);
+    }
+
+    @Test
+    public void testCustomLocalRepository() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty(anyString())).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("localRepository", "/tmp/test-repo");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        assertEquals(new File("/tmp/test-repo"), config.getLocalRepository());
+
+        verify(context);
+    }
+
+    @Test
+    public void testFullyQualifiedPropertyKey() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty(anyString())).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("org.apache.karaf.url.mvn.localRepository", "/tmp/fq-repo");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        assertEquals(new File("/tmp/fq-repo"), config.getLocalRepository());
+
+        verify(context);
+    }
+
+    @Test
+    public void testRepositoriesParsing() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty(anyString())).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("repositories", "https://repo1.maven.org/maven2@id=central, https://repo.apache.org@id=apache");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        assertEquals(2, config.getRepositories().size());
+        assertEquals("https://repo1.maven.org/maven2@id=central", config.getRepositories().get(0));
+        assertEquals("https://repo.apache.org@id=apache", config.getRepositories().get(1));
+
+        verify(context);
+    }
+
+    @Test
+    public void testDefaultRepositoriesParsing() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty(anyString())).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("defaultRepositories", "/opt/karaf/system@id=system@snapshots, /opt/karaf/data/kar@id=kar");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        assertEquals(2, config.getDefaultRepositories().size());
+
+        verify(context);
+    }
+
+    @Test
+    public void testTimeoutConfiguration() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty(anyString())).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("timeout", "10000");
+        props.put("socket.connectionTimeout", "3000");
+        props.put("socket.readTimeout", "60000");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        assertEquals(3000, config.getConnectionTimeout());
+        assertEquals(60000, config.getReadTimeout());
+
+        verify(context);
+    }
+
+    @Test
+    public void testTimeoutFallsBackToDefaultTimeout() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty(anyString())).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("timeout", "7000");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        // connectionTimeout should fall back to the "timeout" value
+        assertEquals(7000, config.getConnectionTimeout());
+
+        verify(context);
+    }
+
+    @Test
+    public void testCertificateCheckDisabled() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty(anyString())).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("certificateCheck", "false");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        assertFalse(config.isCertificateCheck());
+
+        verify(context);
+    }
+
+    @Test
+    public void testRetryCount() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty(anyString())).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("connection.retryCount", "5");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        assertEquals(5, config.getRetryCount());
+
+        verify(context);
+    }
+
+    @Test
+    public void testPolicies() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty(anyString())).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("globalUpdatePolicy", "daily");
+        props.put("globalChecksumPolicy", "fail");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        assertEquals("daily", config.getUpdatePolicy());
+        assertEquals("fail", config.getChecksumPolicy());
+
+        verify(context);
+    }
+
+    @Test
+    public void testVariableSubstitution() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty("karaf.home")).andReturn("/opt/karaf").anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".localRepository")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".defaultRepositories")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".repositories")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".globalUpdatePolicy")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".globalChecksumPolicy")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".timeout")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".socket.connectionTimeout")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".socket.readTimeout")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".certificateCheck")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".connection.retryCount")).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("defaultRepositories", "${karaf.home}/system@id=system");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        assertEquals(1, config.getDefaultRepositories().size());
+        assertEquals("/opt/karaf/system@id=system", config.getDefaultRepositories().get(0));
+
+        verify(context);
+    }
+
+    @Test
+    public void testRelativeLocalRepositoryResolved() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty("karaf.home")).andReturn("/opt/karaf").anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".localRepository")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".defaultRepositories")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".repositories")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".globalUpdatePolicy")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".globalChecksumPolicy")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".timeout")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".socket.connectionTimeout")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".socket.readTimeout")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".certificateCheck")).andReturn(null).anyTimes();
+        expect(context.getProperty(MavenConfiguration.PID + ".connection.retryCount")).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("localRepository", "data/repo");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        assertEquals(new File("/opt/karaf", "data/repo"), config.getLocalRepository());
+
+        verify(context);
+    }
+
+    @Test
+    public void testInvalidIntPropertyUsesDefault() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty(anyString())).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("connection.retryCount", "notanumber");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        assertEquals(3, config.getRetryCount());
+
+        verify(context);
+    }
+
+    @Test
+    public void testEmptyRepositoriesString() {
+        BundleContext context = createMock(BundleContext.class);
+        expect(context.getProperty(anyString())).andReturn(null).anyTimes();
+        replay(context);
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("repositories", "   ");
+
+        MavenConfiguration config = new MavenConfiguration(context, props);
+
+        assertTrue(config.getRepositories().isEmpty());
+
+        verify(context);
+    }
+
+}

--- a/services/url/src/test/java/org/apache/karaf/services/url/internal/MavenResolverImplTest.java
+++ b/services/url/src/test/java/org/apache/karaf/services/url/internal/MavenResolverImplTest.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.services.url.internal;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class MavenResolverImplTest {
+
+    private File tempDir;
+    private File localRepo;
+
+    @Before
+    public void setUp() throws Exception {
+        tempDir = new File(System.getProperty("java.io.tmpdir"), "karaf-url-test-" + System.nanoTime());
+        tempDir.mkdirs();
+        localRepo = new File(tempDir, "local-repo");
+        localRepo.mkdirs();
+    }
+
+    @After
+    public void tearDown() {
+        deleteRecursive(tempDir);
+    }
+
+    @Test
+    public void testResolveFromLocalRepository() throws Exception {
+        // Create a fake artifact in the local repo
+        File artifactDir = new File(localRepo, "org/apache/karaf/test-artifact/1.0.0");
+        artifactDir.mkdirs();
+        File artifactFile = new File(artifactDir, "test-artifact-1.0.0.jar");
+        createFile(artifactFile, "fake-jar-content");
+
+        MavenConfiguration config = createConfig(localRepo, Collections.emptyList(), Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        File resolved = resolver.resolve("mvn:org.apache.karaf/test-artifact/1.0.0");
+
+        assertNotNull(resolved);
+        assertTrue(resolved.exists());
+        assertEquals(artifactFile.getAbsolutePath(), resolved.getAbsolutePath());
+    }
+
+    @Test
+    public void testResolveFromLocalRepositoryWithoutMvnPrefix() throws Exception {
+        File artifactDir = new File(localRepo, "org/apache/karaf/test-artifact/1.0.0");
+        artifactDir.mkdirs();
+        File artifactFile = new File(artifactDir, "test-artifact-1.0.0.jar");
+        createFile(artifactFile, "fake-jar-content");
+
+        MavenConfiguration config = createConfig(localRepo, Collections.emptyList(), Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        File resolved = resolver.resolve("org.apache.karaf/test-artifact/1.0.0");
+
+        assertNotNull(resolved);
+        assertTrue(resolved.exists());
+    }
+
+    @Test
+    public void testResolveFromDefaultRepository() throws Exception {
+        File defaultRepo = new File(tempDir, "system-repo");
+        File artifactDir = new File(defaultRepo, "com/example/mylib/2.0.0");
+        artifactDir.mkdirs();
+        File artifactFile = new File(artifactDir, "mylib-2.0.0.jar");
+        createFile(artifactFile, "default-repo-content");
+
+        MavenConfiguration config = createConfig(
+                localRepo,
+                Collections.singletonList(defaultRepo.getAbsolutePath()),
+                Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        File resolved = resolver.resolve("mvn:com.example/mylib/2.0.0");
+
+        assertNotNull(resolved);
+        assertTrue(resolved.exists());
+        assertEquals(artifactFile.getAbsolutePath(), resolved.getAbsolutePath());
+    }
+
+    @Test
+    public void testResolveFromDefaultRepositoryWithFlags() throws Exception {
+        File defaultRepo = new File(tempDir, "system-repo");
+        File artifactDir = new File(defaultRepo, "com/example/mylib/2.0.0");
+        artifactDir.mkdirs();
+        File artifactFile = new File(artifactDir, "mylib-2.0.0.jar");
+        createFile(artifactFile, "default-repo-content");
+
+        MavenConfiguration config = createConfig(
+                localRepo,
+                Collections.singletonList(defaultRepo.getAbsolutePath() + "@id=system@snapshots"),
+                Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        File resolved = resolver.resolve("mvn:com.example/mylib/2.0.0");
+
+        assertNotNull(resolved);
+        assertTrue(resolved.exists());
+    }
+
+    @Test
+    public void testResolveFromFileUriDefaultRepository() throws Exception {
+        File defaultRepo = new File(tempDir, "system-repo");
+        File artifactDir = new File(defaultRepo, "com/example/mylib/2.0.0");
+        artifactDir.mkdirs();
+        File artifactFile = new File(artifactDir, "mylib-2.0.0.jar");
+        createFile(artifactFile, "file-uri-content");
+
+        MavenConfiguration config = createConfig(
+                localRepo,
+                Collections.singletonList(defaultRepo.toURI().toString() + "@id=system"),
+                Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        File resolved = resolver.resolve("mvn:com.example/mylib/2.0.0");
+
+        assertNotNull(resolved);
+        assertTrue(resolved.exists());
+    }
+
+    @Test
+    public void testDefaultRepoCheckedBeforeLocalRepo() throws Exception {
+        // Create artifact in both default and local repos with different content
+        File defaultRepo = new File(tempDir, "default-repo");
+        File defaultArtifactDir = new File(defaultRepo, "com/example/mylib/1.0.0");
+        defaultArtifactDir.mkdirs();
+        File defaultArtifact = new File(defaultArtifactDir, "mylib-1.0.0.jar");
+        createFile(defaultArtifact, "from-default");
+
+        File localArtifactDir = new File(localRepo, "com/example/mylib/1.0.0");
+        localArtifactDir.mkdirs();
+        File localArtifact = new File(localArtifactDir, "mylib-1.0.0.jar");
+        createFile(localArtifact, "from-local");
+
+        MavenConfiguration config = createConfig(
+                localRepo,
+                Collections.singletonList(defaultRepo.getAbsolutePath()),
+                Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        File resolved = resolver.resolve("mvn:com.example/mylib/1.0.0");
+
+        // Default repository should be checked first
+        assertEquals(defaultArtifact.getAbsolutePath(), resolved.getAbsolutePath());
+    }
+
+    @Test(expected = IOException.class)
+    public void testResolveNullUrlThrowsException() throws Exception {
+        MavenConfiguration config = createConfig(localRepo, Collections.emptyList(), Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        resolver.resolve((String) null);
+    }
+
+    @Test(expected = IOException.class)
+    public void testResolveNonExistentArtifactThrowsException() throws Exception {
+        MavenConfiguration config = createConfig(localRepo, Collections.emptyList(), Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        resolver.resolve("mvn:com.nonexistent/artifact/1.0.0");
+    }
+
+    @Test
+    public void testResolveByCoordinates() throws Exception {
+        File artifactDir = new File(localRepo, "org/example/coords-test/3.0.0");
+        artifactDir.mkdirs();
+        File artifactFile = new File(artifactDir, "coords-test-3.0.0.jar");
+        createFile(artifactFile, "coords-content");
+
+        MavenConfiguration config = createConfig(localRepo, Collections.emptyList(), Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        File resolved = resolver.resolve("org.example", "coords-test", "3.0.0", null, null);
+
+        assertNotNull(resolved);
+        assertTrue(resolved.exists());
+        assertEquals(artifactFile.getAbsolutePath(), resolved.getAbsolutePath());
+    }
+
+    @Test
+    public void testResolveWithType() throws Exception {
+        File artifactDir = new File(localRepo, "org/example/typed/1.0.0");
+        artifactDir.mkdirs();
+        File artifactFile = new File(artifactDir, "typed-1.0.0.xml");
+        createFile(artifactFile, "<features/>");
+
+        MavenConfiguration config = createConfig(localRepo, Collections.emptyList(), Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        File resolved = resolver.resolve("mvn:org.example/typed/1.0.0/xml");
+
+        assertNotNull(resolved);
+        assertTrue(resolved.exists());
+        assertEquals(artifactFile.getAbsolutePath(), resolved.getAbsolutePath());
+    }
+
+    @Test
+    public void testResolveWithTypeAndClassifier() throws Exception {
+        File artifactDir = new File(localRepo, "org/example/classified/1.0.0");
+        artifactDir.mkdirs();
+        File artifactFile = new File(artifactDir, "classified-1.0.0-features.xml");
+        createFile(artifactFile, "<features/>");
+
+        MavenConfiguration config = createConfig(localRepo, Collections.emptyList(), Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        File resolved = resolver.resolve("mvn:org.example/classified/1.0.0/xml/features");
+
+        assertNotNull(resolved);
+        assertTrue(resolved.exists());
+        assertEquals(artifactFile.getAbsolutePath(), resolved.getAbsolutePath());
+    }
+
+    @Test
+    public void testGetLocalRepository() {
+        MavenConfiguration config = createConfig(localRepo, Collections.emptyList(), Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        assertEquals(localRepo, resolver.getLocalRepository());
+    }
+
+    @Test
+    public void testResolveMultipleDefaultRepositories() throws Exception {
+        File repo1 = new File(tempDir, "repo1");
+        File repo2 = new File(tempDir, "repo2");
+
+        // Artifact only in second repo
+        File artifactDir = new File(repo2, "com/example/lib/1.0.0");
+        artifactDir.mkdirs();
+        File artifactFile = new File(artifactDir, "lib-1.0.0.jar");
+        createFile(artifactFile, "repo2-content");
+
+        MavenConfiguration config = createConfig(
+                localRepo,
+                Arrays.asList(repo1.getAbsolutePath(), repo2.getAbsolutePath()),
+                Collections.emptyList());
+        MavenResolverImpl resolver = new MavenResolverImpl(config);
+
+        File resolved = resolver.resolve("mvn:com.example/lib/1.0.0");
+
+        assertNotNull(resolved);
+        assertEquals(artifactFile.getAbsolutePath(), resolved.getAbsolutePath());
+    }
+
+    @Test
+    public void testStripRepositoryFlags() {
+        assertEquals("https://repo1.maven.org/maven2",
+                MavenResolverImpl.stripRepositoryFlags("https://repo1.maven.org/maven2@id=central"));
+        assertEquals("https://repo.apache.org",
+                MavenResolverImpl.stripRepositoryFlags("https://repo.apache.org@id=apache@snapshots@noreleases"));
+        assertEquals("/opt/karaf/system",
+                MavenResolverImpl.stripRepositoryFlags("/opt/karaf/system@id=system@snapshots"));
+        assertEquals("https://repo.example.com",
+                MavenResolverImpl.stripRepositoryFlags("https://repo.example.com"));
+        assertEquals("",
+                MavenResolverImpl.stripRepositoryFlags("@id=test"));
+    }
+
+    // --- helpers ---
+
+    private MavenConfiguration createConfig(File localRepo, java.util.List<String> defaultRepos, java.util.List<String> remoteRepos) {
+        MavenConfiguration config = createMock(MavenConfiguration.class);
+        expect(config.getLocalRepository()).andReturn(localRepo).anyTimes();
+        expect(config.getDefaultRepositories()).andReturn(defaultRepos).anyTimes();
+        expect(config.getRepositories()).andReturn(remoteRepos).anyTimes();
+        expect(config.getChecksumPolicy()).andReturn("ignore").anyTimes();
+        expect(config.getConnectionTimeout()).andReturn(5000).anyTimes();
+        expect(config.getReadTimeout()).andReturn(30000).anyTimes();
+        expect(config.isCertificateCheck()).andReturn(true).anyTimes();
+        expect(config.getRetryCount()).andReturn(0).anyTimes();
+        replay(config);
+        return config;
+    }
+
+    private void createFile(File file, String content) throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(content.getBytes());
+        }
+    }
+
+    private void deleteRecursive(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursive(child);
+                }
+            }
+        }
+        file.delete();
+    }
+
+}

--- a/services/url/src/test/java/org/apache/karaf/services/url/internal/MvnUrlHandlerTest.java
+++ b/services/url/src/test/java/org/apache/karaf/services/url/internal/MvnUrlHandlerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.karaf.services.url.internal;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+
+import org.apache.karaf.services.url.MavenResolver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class MvnUrlHandlerTest {
+
+    private File tempDir;
+    private File testFile;
+
+    @Before
+    public void setUp() throws Exception {
+        tempDir = new File(System.getProperty("java.io.tmpdir"), "karaf-url-handler-test-" + System.nanoTime());
+        tempDir.mkdirs();
+        testFile = new File(tempDir, "test-artifact.jar");
+        try (FileOutputStream fos = new FileOutputStream(testFile)) {
+            fos.write("test-jar-content".getBytes());
+        }
+    }
+
+    @After
+    public void tearDown() {
+        if (testFile != null) {
+            testFile.delete();
+        }
+        if (tempDir != null) {
+            tempDir.delete();
+        }
+    }
+
+    @Test
+    public void testOpenConnection() throws Exception {
+        MavenResolver resolver = createMock(MavenResolver.class);
+        replay(resolver);
+
+        MvnUrlHandler handler = new MvnUrlHandler(resolver);
+        URL url = new URL("http://localhost/mvn:org.example/test/1.0.0");
+        URLConnection connection = handler.openConnection(url);
+
+        assertNotNull(connection);
+
+        verify(resolver);
+    }
+
+    @Test
+    public void testConnectionGetInputStream() throws Exception {
+        MavenResolver resolver = createMock(MavenResolver.class);
+        expect(resolver.resolve(anyString())).andReturn(testFile);
+        replay(resolver);
+
+        URL url = new URL("http://localhost/mvn:org.example/test/1.0.0");
+        MvnUrlHandler.MvnConnection connection = new MvnUrlHandler.MvnConnection(url, resolver);
+
+        try (InputStream is = connection.getInputStream()) {
+            assertNotNull(is);
+            byte[] content = is.readAllBytes();
+            assertEquals("test-jar-content", new String(content));
+        }
+
+        verify(resolver);
+    }
+
+    @Test
+    public void testConnectionGetContentLengthLong() throws Exception {
+        MavenResolver resolver = createMock(MavenResolver.class);
+        expect(resolver.resolve(anyString())).andReturn(testFile);
+        replay(resolver);
+
+        URL url = new URL("http://localhost/mvn:org.example/test/1.0.0");
+        MvnUrlHandler.MvnConnection connection = new MvnUrlHandler.MvnConnection(url, resolver);
+
+        assertEquals(testFile.length(), connection.getContentLengthLong());
+
+        verify(resolver);
+    }
+
+    @Test
+    public void testConnectionGetContentLengthLongOnError() throws Exception {
+        MavenResolver resolver = createMock(MavenResolver.class);
+        expect(resolver.resolve(anyString())).andThrow(new IOException("not found"));
+        replay(resolver);
+
+        URL url = new URL("http://localhost/mvn:org.example/test/1.0.0");
+        MvnUrlHandler.MvnConnection connection = new MvnUrlHandler.MvnConnection(url, resolver);
+
+        assertEquals(-1, connection.getContentLengthLong());
+
+        verify(resolver);
+    }
+
+    @Test
+    public void testConnectionGetContentType() throws Exception {
+        MavenResolver resolver = createMock(MavenResolver.class);
+        replay(resolver);
+
+        URL url = new URL("http://localhost/mvn:org.example/test/1.0.0");
+        MvnUrlHandler.MvnConnection connection = new MvnUrlHandler.MvnConnection(url, resolver);
+
+        assertEquals("application/octet-stream", connection.getContentType());
+
+        verify(resolver);
+    }
+
+    @Test
+    public void testConnectionConnectIsIdempotent() throws Exception {
+        MavenResolver resolver = createMock(MavenResolver.class);
+        // resolve should only be called once even if connect is called multiple times
+        expect(resolver.resolve(anyString())).andReturn(testFile).once();
+        replay(resolver);
+
+        URL url = new URL("http://localhost/mvn:org.example/test/1.0.0");
+        MvnUrlHandler.MvnConnection connection = new MvnUrlHandler.MvnConnection(url, resolver);
+
+        connection.connect();
+        connection.connect();
+
+        verify(resolver);
+    }
+
+    @Test(expected = IOException.class)
+    public void testConnectionGetInputStreamThrowsOnResolveFailure() throws Exception {
+        MavenResolver resolver = createMock(MavenResolver.class);
+        expect(resolver.resolve(anyString())).andThrow(new IOException("artifact not found"));
+        replay(resolver);
+
+        URL url = new URL("http://localhost/mvn:org.example/test/1.0.0");
+        MvnUrlHandler.MvnConnection connection = new MvnUrlHandler.MvnConnection(url, resolver);
+
+        connection.getInputStream();
+    }
+
+}


### PR DESCRIPTION
Add a new URL handler service under services/url that provides a native replacement for pax-url-mvn. The service registers a URLStreamHandlerService for the mvn: protocol and exposes a MavenResolver API for programmatic artifact resolution from local and remote Maven repositories.