### PR TITLE
Bump org.jline:jline from 3.30.6 to 3.30.8 (backport to 4.4.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
         <httpclient.version>4.5.13</httpclient.version>
         <jansi.version>2.4.2</jansi.version>
         <javassist.version>3.9.0.GA</javassist.version>
-        <jline.version>3.30.6</jline.version>
+        <jline.version>3.30.8</jline.version>
         <junit.version>4.13.2</junit.version>
         <jsw.version>3.2.3</jsw.version>
         <log4j.version>2.24.3</log4j.version>


### PR DESCRIPTION
## Summary
- Cherry-pick of #2304 to karaf-4.4.x branch
- Bumps org.jline:jline from 3.30.6 to 3.30.8
- Includes fix for JNI terminal failing to load on JDK 21.0.10+ and various Windows terminal fixes