### PR TITLE
Bump commons-logging:commons-logging from 1.3.5 to 1.3.6 (4.4.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <commons-compress.version>1.27.1</commons-compress.version>
         <commons-fileupload.version>1.6.0</commons-fileupload.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
-        <commons-logging.version>1.3.5</commons-logging.version>
+        <commons-logging.version>1.3.6</commons-logging.version>
         <commons-pool2.version>2.12.0</commons-pool2.version>
         <commons-io.version>2.21.0</commons-io.version>
         <eclipselink.version>2.7.15</eclipselink.version>


### PR DESCRIPTION
Cherry-pick of #2302 for the `karaf-4.4.x` branch.

Bumps `commons-logging:commons-logging` from 1.3.5 to 1.3.6.