### PR TITLE
fix(tooling): use LinkedHashSet for deterministic option ordering (backport to 4.4.x)

### DIFF
--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/AsciiDoctorCommandHelpPrinter.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/AsciiDoctorCommandHelpPrinter.java
@@ -36,7 +36,7 @@ public class AsciiDoctorCommandHelpPrinter extends AbstractCommandHelpPrinter {
     @Override
     public void printHelp(Action action, PrintStream out, boolean includeHelpOption) {
         Command command = action.getClass().getAnnotation(Command.class);
-        Set<Option> options = new HashSet<>();
+        Set<Option> options = new LinkedHashSet<>();
         List<Argument> arguments = new ArrayList<>();
         Map<Argument, Field> argFields = new HashMap<>();
         Map<Option, Field> optFields = new HashMap<>();

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/DocBookCommandHelpPrinter.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/DocBookCommandHelpPrinter.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,7 +42,7 @@ public class DocBookCommandHelpPrinter extends AbstractCommandHelpPrinter {
     @Override
     public void printHelp(Action action, PrintStream out, boolean includeHelpOption) {
         Command command = action.getClass().getAnnotation(Command.class);
-        Set<Option> options = new HashSet<>();
+        Set<Option> options = new LinkedHashSet<>();
         List<Argument> arguments = new ArrayList<>();
         Map<Argument, Field> argFields = new HashMap<>();
         Map<Option, Field> optFields = new HashMap<>();

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/MarkdownCommandHelpPrinter.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/MarkdownCommandHelpPrinter.java
@@ -31,7 +31,7 @@ public class MarkdownCommandHelpPrinter extends AbstractCommandHelpPrinter {
     @Override
     public void printHelp(Action action, PrintStream out, boolean includeHelpOption) {
         Command command = action.getClass().getAnnotation(Command.class);
-        Set<Option> options = new HashSet<>();
+        Set<Option> options = new LinkedHashSet<>();
         List<Argument> arguments = new ArrayList<>();
         Map<Argument, Field> argFields = new HashMap<>();
         Map<Option, Field> optFields = new HashMap<>();

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/UserConfCommandHelpPrinter.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/commands/UserConfCommandHelpPrinter.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,7 +42,7 @@ public class UserConfCommandHelpPrinter extends AbstractCommandHelpPrinter {
     @Override
     public void printHelp(Action action, PrintStream out, boolean includeHelpOption) {
         Command command = action.getClass().getAnnotation(Command.class);
-        Set<Option> options = new HashSet<>();
+        Set<Option> options = new LinkedHashSet<>();
         List<Argument> arguments = new ArrayList<>();
         Map<Argument, Field> argFields = new HashMap<>();
         Map<Option, Field> optFields = new HashMap<>();


### PR DESCRIPTION
## Summary
- Cherry-pick of #2306 to karaf-4.4.x branch
- Replaces HashSet with LinkedHashSet in all CommandHelpPrinter implementations to preserve insertion order of options
- Fixes the flaky `test-commands-generate-help` invoker test that is also causing #2335 to fail