### PR TITLE
Bump jackson.version from 2.21.0 to 2.21.1 (4.4.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <cglib.bundle.version>3.2.9_1</cglib.bundle.version>
         <cxf.version>3.6.9</cxf.version>
         <jackson.annotations.version>2.21</jackson.annotations.version>
-        <jackson.version>2.21.0</jackson.version>
+        <jackson.version>2.21.1</jackson.version>
         <jna.version>5.18.1</jna.version>
         <jaxb-bom.version>2.3.9</jaxb-bom.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>


### PR DESCRIPTION
Cherry-pick of #2286 for the karaf-4.4.x branch.

Bumps `jackson.version` from 2.21.0 to 2.21.1.
- Updates `com.fasterxml.jackson.core:jackson-databind` from 2.21.0 to 2.21.1
- Updates `com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider` from 2.21.0 to 2.21.1