### PR TITLE
ci(dependabot): include major version updates for Maven dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,9 +30,6 @@ updates:
       interval: "daily"
     target-branch: "main"
     open-pull-requests-limit: 50
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -44,6 +41,3 @@ updates:
       interval: "daily"
     target-branch: "karaf-4.4.x"
     open-pull-requests-limit: 50
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
- Remove the `ignore` rules that excluded `semver-major` updates from Dependabot's Maven ecosystem configuration
- Dependabot will now propose all Maven dependency updates (major, minor, and patch) on both `main` and `karaf-4.4.x` branches