### PR TITLE
fix: update stale assembly module reference in setup.eclipse profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -865,7 +865,7 @@
         <profile>
             <id>setup.eclipse</id>
             <modules>
-                <module>assembly</module>
+                <module>assemblies</module>
             </modules>
             <properties>
                 <eclipse.workspace.dir>${basedir}/../workspace</eclipse.workspace.dir>


### PR DESCRIPTION
## Summary
- The `setup.eclipse` Maven profile in the root `pom.xml` references `<module>assembly</module>`, but that directory was renamed to `assemblies/` long ago
- This causes Dependabot to fail with `dependency_file_not_found: /assembly/pom.xml not found` (see [failed run](https://github.com/apache/karaf/actions/runs/23108867473/job/67122763104))
- Fixes the reference to `<module>assemblies</module>`

## Test plan
- [ ] Verify Dependabot runs succeed on `karaf-4.4.x` after merge