### PR TITLE
ci: use workflow_run to publish test results on fork PRs (backport #2450)

### DIFF
--- a/.github/workflows/ci-test-results.yml
+++ b/.github/workflows/ci-test-results.yml
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: CI Test Results
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  test-results:
+    name: Publish Test Results
+    runs-on: ubuntu-24.04
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download and Extract Artifacts
+        uses: dawidd6/action-download-artifact@v8
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          name: test-results
+          path: artifacts
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: ${{ github.event.workflow_run.event_path }}
+          event_name: ${{ github.event.workflow_run.event }}
+          large_files: true
+          report_individual_runs: true
+          report_suite_logs: error
+          files: 'artifacts/**/*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,6 @@ jobs:
 
     permissions:
       contents: read
-      checks: write
-      pull-requests: write
 
     runs-on: ubuntu-24.04
 
@@ -85,11 +83,3 @@ jobs:
         with:
           name: test-results
           path: '**/target/surefire-reports/*.xml'
-      - name: Publish Test Results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          large_files: true
-          report_individual_runs: true
-          report_suite_logs: error
-          files: '**/target/surefire-reports/*.xml'


### PR DESCRIPTION
## Summary

Backport of #2450 to `karaf-4.4.x`.

- Move test result publishing from the CI workflow to a separate `ci-test-results.yml` workflow triggered by `workflow_run`
- This runs in the base repo context with write access, fixing fork PR test result publishing
- Remove now-unnecessary `checks: write` and `pull-requests: write` permissions from the test job