### PR TITLE
ci: fix test results not commenting on PRs (backport to 4.4.x)

### DIFF
--- a/.github/workflows/ci-test-results.yml
+++ b/.github/workflows/ci-test-results.yml
@@ -38,18 +38,25 @@ jobs:
     if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:
-      - name: Download and Extract Artifacts
+      - name: Download Test Results
         uses: dawidd6/action-download-artifact@v19
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: test-results
           path: artifacts
 
+      - name: Download Event File
+        uses: dawidd6/action-download-artifact@v19
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          name: event-file
+          path: event
+
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
-          event_file: ${{ github.event.workflow_run.event_path }}
+          event_file: event/event.json
           event_name: ${{ github.event.workflow_run.event }}
           large_files: true
           report_individual_runs: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,9 @@ jobs:
         with:
           name: test-results
           path: '**/target/surefire-reports/*.xml'
+      - name: Upload Event File
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: event-file
+          path: ${{ github.event_path }}


### PR DESCRIPTION
## Summary

Backport of #2462 to `karaf-4.4.x`.

- Upload the GitHub event payload file as an artifact in the CI workflow
- Download it in the test-results workflow and pass it to `publish-unit-test-result-action`
- Fix reference to non-existent `github.event.workflow_run.event_path` property

The `publish-unit-test-result-action` in `workflow_run` mode needs the original event file to identify the associated PR and post comments. Without it, the action creates check runs but cannot comment on PRs.

## Test plan

- [ ] Verify the CI workflow uploads the `event-file` artifact
- [ ] Verify the test-results workflow downloads and uses the event file
- [ ] Confirm PR comments appear after a test run completes