### PR TITLE
Remove Aries Blueprint Web feature

### DIFF
--- a/assemblies/features/standard/pom.xml
+++ b/assemblies/features/standard/pom.xml
@@ -470,8 +470,8 @@
                                 <feature>framework</feature>
                             </framework>
                             <features>
-                                <!-- webconsole, blueprint-web and jolokia features use requirement -->
-                                <feature>(?!(webconsole|blueprint-web|jolokia))*</feature>
+                                <!-- webconsole and jolokia features use requirement -->
+                                <feature>(?!(webconsole|jolokia))*</feature>
                             </features>
                             <ignoreMissingConditions>true</ignoreMissingConditions>
                         </configuration>

--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -1490,13 +1490,6 @@ org.apache.felix.eventadmin.AddSubject=true
         </capability>
     </feature>
 
-    <feature name="blueprint-web" description="Provides an OSGI-aware Servlet ContextListener for bootstrapping
-        blueprint inside web-bundle containers" version="${project.version}">
-        <feature>aries-blueprint</feature>
-        <bundle>mvn:org.apache.aries.blueprint/org.apache.aries.blueprint.webosgi/${aries.blueprint.webosgi.version}</bundle>
-        <requirement>osgi.implementation;osgi.implementation="osgi.http";version:Version="2.0"</requirement>
-    </feature>
-
     <feature name="pax-url-wrap" description="Wrap URL handler" version="${pax.url.version}">
         <bundle start-level="10">mvn:org.ops4j.pax.url/pax-url-wrap/${pax.url.version}/jar/uber</bundle>
     </feature>

--- a/itests/test/src/test/filtered-resources/etc/feature.xml
+++ b/itests/test/src/test/filtered-resources/etc/feature.xml
@@ -927,13 +927,6 @@
         </capability>
     </feature>
 
-    <feature name="blueprint-web" description="Provides an OSGI-aware Servlet ContextListener for bootstrapping
-        blueprint inside web-bundle containers" version="${project.version}">
-        <feature>war</feature>
-        <feature>aries-blueprint</feature>
-        <bundle>mvn:org.apache.aries.blueprint/org.apache.aries.blueprint.webosgi/${aries.blueprint.web.version}</bundle>
-    </feature>
-
     <feature name="wrap" description="Wrap URL handler">
         <bundle start="true" start-level="10">mvn:org.ops4j.pax.url/pax-url-wrap/${pax.url.version}/jar/uber</bundle>
     </feature>

--- a/itests/test/src/test/java/org/apache/karaf/itests/features/StandardFeaturesTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/features/StandardFeaturesTest.java
@@ -15,7 +15,6 @@ package org.apache.karaf.itests.features;
 
 import org.apache.karaf.itests.BaseTest;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,12 +51,6 @@ public class StandardFeaturesTest extends BaseTest {
         installAssertAndUninstallFeatures("service-security");
     }
 
-    @Test
-    @Ignore("Aries Blueprint Web 1.0.1 requires javax.servlet, incompatible with Jakarta Servlet 6.x")
-    public void installAriesBlueprintWebFeature() throws Exception {
-        installAssertAndUninstallFeatures("pax-web-http", "blueprint-web");
-    }
-    
     @Test
     public void installWrapperFeature() throws Exception {
         installAssertAndUninstallFeatures("wrapper");

--- a/pom.xml
+++ b/pom.xml
@@ -243,8 +243,6 @@
         <aries.blueprint.core.version>1.10.3</aries.blueprint.core.version>
         <aries.blueprint.core.compatibility.version>1.0.0</aries.blueprint.core.compatibility.version>
         <aries.blueprint.cm.version>1.3.2</aries.blueprint.cm.version>
-        <aries.blueprint.web.version>1.1.1</aries.blueprint.web.version>
-        <aries.blueprint.webosgi.version>1.0.1</aries.blueprint.webosgi.version>
         <aries.blueprint.spring.version>0.6.0</aries.blueprint.spring.version>
         <aries.blueprint.spring.extender.version>0.4.0</aries.blueprint.spring.extender.version>
         <aries.jax.rs.whiteboard.version>2.0.2</aries.jax.rs.whiteboard.version>


### PR DESCRIPTION
## Summary
- Remove the `blueprint-web` feature definition from standard and test feature files
- Remove `aries.blueprint.web.version` and `aries.blueprint.webosgi.version` properties from root POM
- Remove the already-ignored `installAriesBlueprintWebFeature` integration test
- Clean up the feature verification exclusion regex in standard features POM

Aries Blueprint Web 1.0.1 requires `javax.servlet`, which is incompatible with Jakarta Servlet 6.x used in Karaf. The integration test was already `@Ignore`d for this reason.

## Test plan
- [ ] Verify the build compiles successfully
- [ ] Verify no remaining references to blueprint-web