### PR TITLE
Relocate slf4j-log4j12 to slf4j-reload4j

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -657,7 +657,7 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
+                <artifactId>slf4j-reload4j</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
 

--- a/features/core/pom.xml
+++ b/features/core/pom.xml
@@ -155,7 +155,7 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/itests/test/pom.xml
+++ b/itests/test/pom.xml
@@ -211,7 +211,7 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/jaas/blueprint/jasypt/pom.xml
+++ b/jaas/blueprint/jasypt/pom.xml
@@ -130,7 +130,7 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/jaas/jasypt/pom.xml
+++ b/jaas/jasypt/pom.xml
@@ -118,7 +118,7 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/jaas/spring-security-crypto/pom.xml
+++ b/jaas/spring-security-crypto/pom.xml
@@ -119,7 +119,7 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/management/server/pom.xml
+++ b/management/server/pom.xml
@@ -103,7 +103,7 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/maven/core/pom.xml
+++ b/maven/core/pom.xml
@@ -84,7 +84,7 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/profile/pom.xml
+++ b/profile/pom.xml
@@ -147,7 +147,7 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Address warning
```
[WARNING] The artifact org.slf4j:slf4j-log4j12:jar:2.0.17 has been relocated to org.slf4j:slf4j-reload4j:jar:2.0.17
```

<img width="355" height="312" alt="grafik" src="https://github.com/user-attachments/assets/f07ce0df-9304-4480-86c9-63af78f917f9" />
