### PR TITLE
Upgrade plugin settings

### DIFF
--- a/jaas/blueprint/jasypt/pom.xml
+++ b/jaas/blueprint/jasypt/pom.xml
@@ -177,9 +177,9 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <karaf.etc>${project.build.testOutputDirectory}/karaf/etc</karaf.etc>
-                    </systemProperties>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/tooling/utils/pom.xml
+++ b/tooling/utils/pom.xml
@@ -79,7 +79,6 @@
                     <models>
                         <model>src/main/mdo/edits.mdo</model>
                     </models>
-                    <useJava5>true</useJava5>
                     <version>1.0.0</version>
                 </configuration>
             </plugin>


### PR DESCRIPTION
* remove useJava5 option from modello plugin, current mechanism derives java source from compiler setting and defaults to 8 anyway
* replace systemVaraibles by systemPropertyVariables in surefire-plugin

~~~
[WARNING] Parameter 'useJava5' is unknown for plugin 'modello-maven-plugin:2.6.0:java (default)'
[WARNING] Parameter 'useJava5' is unknown for plugin 'modello-maven-plugin:2.6.0:stax-reader (default)'
[WARNING] Parameter 'useJava5' is unknown for plugin 'modello-maven-plugin:2.6.0:stax-writer (default)'
[WARNING] Parameter 'useJava5' is unknown for plugin 'modello-maven-plugin:2.6.0:xsd (default)'
[WARNING] Parameter 'useJava5' is unknown for plugin 'modello-maven-plugin:2.6.0:xdoc (default)'

[WARNING]  Parameter 'systemProperties' is deprecated: Use systemPropertyVariables instead.
~~~

See references:
https://maven.apache.org/surefire/maven-surefire-plugin/examples/system-properties.html

https://codehaus-plexus.github.io/modello/migration-guide.html
https://codehaus-plexus.github.io/modello/modello-maven-plugin/java-mojo.html#javaSource
