### PR TITLE
Use upload/download-artifact for CI inter-job repo sharing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,11 @@ jobs:
       - name: Build
         run: mvn -U -B -e clean install -Prat -DskipTests "-Dinvoker.skip=true"
       - name: Save Maven Local Repository
-        uses: actions/cache/save@v5
+        uses: actions/upload-artifact@v7
         with:
+          name: maven-local-repo
           path: ~/.m2/repository
-          key: maven-local-repo-${{ github.run_id }}
+          retention-days: 1
 
   test:
     name: test
@@ -70,10 +71,10 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Restore Maven Local Repository
-        uses: actions/cache/restore@v5
+        uses: actions/download-artifact@v4
         with:
+          name: maven-local-repo
           path: ~/.m2/repository
-          key: maven-local-repo-${{ github.run_id }}
       - name: Test
         run: mvn -B -e install -Ptest
         timeout-minutes: 180


### PR DESCRIPTION
## Summary
- Replace `actions/cache/save` and `actions/cache/restore` with `actions/upload-artifact` and `actions/download-artifact` for passing the Maven local repository between the build and test CI jobs
- This fixes test job failures when re-running a workflow after GitHub's 7-day cache eviction (e.g. PR #2482 where the `apache-karaf:tar.gz` SNAPSHOT artifact couldn't be resolved)
- Set `retention-days: 1` to keep storage usage minimal

## Test plan
- [x] Verify CI build + test jobs pass on this PR
- [ ] Verify re-running the test job after some time still works