### PR TITLE
Filter out empty repository entries in feature descriptors

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/model/Features.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/model/Features.java
@@ -188,7 +188,12 @@ public class Features implements Blacklisting {
     private static void trim(List<String> list) {
         if (list != null) {
             for (ListIterator<String> it = list.listIterator(); it.hasNext();) {
-                it.set(it.next().trim());
+                String trimmed = it.next().trim();
+                if (trimmed.isEmpty()) {
+                    it.remove();
+                } else {
+                    it.set(trimmed);
+                }
             }
         }
     }

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/RepositoryImpl.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/RepositoryImpl.java
@@ -77,6 +77,7 @@ public class RepositoryImpl implements Repository {
     public URI[] getRepositories() {
         return features.getRepository().stream()
                 .map(String::trim)
+                .filter(s -> !s.isEmpty())
                 .map(URI::create)
                 .toArray(URI[]::new);
     }
@@ -85,6 +86,7 @@ public class RepositoryImpl implements Repository {
     public URI[] getResourceRepositories() {
         return features.getResourceRepository().stream()
                 .map(String::trim)
+                .filter(s -> !s.isEmpty())
                 .map(URI::create)
                 .toArray(URI[]::new);
     }

--- a/features/core/src/test/java/org/apache/karaf/features/RepositoryTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/RepositoryTest.java
@@ -175,6 +175,21 @@ public class RepositoryTest extends TestCase {
         assertEquals(1, res.getRequirements("req").size());
     }
 
+    public void testLoadRepoWithEmptyRepositoryEntries() throws Exception {
+        RepositoryImpl r = new RepositoryImpl(getClass().getResource("repo5.xml").toURI());
+        // Empty and whitespace-only repository entries should be filtered out
+        URI[] repos = r.getRepositories();
+        assertNotNull(repos);
+        assertEquals(2, repos.length);
+        assertEquals(URI.create("urn:r1"), repos[0]);
+        assertEquals(URI.create("urn:r2"), repos[1]);
+        // Check features still load correctly
+        Feature[] features = r.getFeatures();
+        assertNotNull(features);
+        assertEquals(1, features.length);
+        assertEquals("f1", features[0].getName());
+    }
+
     public void testShowWrongUriInException() throws Exception {
         String uri = "src/test/resources/org/apache/karaf/shell/features/repo1.xml";
         try {

--- a/features/core/src/test/resources/org/apache/karaf/features/repo5.xml
+++ b/features/core/src/test/resources/org/apache/karaf/features/repo5.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<features name="test" xmlns="http://karaf.apache.org/xmlns/features/v1.1.0">
+    <repository>urn:r1</repository>
+    <repository></repository>
+    <repository>  </repository>
+    <repository>urn:r2</repository>
+    <feature name="f1">
+        <bundle>b1</bundle>
+    </feature>
+</features>


### PR DESCRIPTION
Empty or whitespace-only `<repository>` elements in feature XML descriptors cause a `RuntimeException` from pax-url-mvn (`NullArgumentException: Repository spec is empty string`) during boot feature installation.

The `Features.trim()` method only trimmed whitespace but kept empty strings in the list. Similarly, `RepositoryImpl.getRepositories()` and `getResourceRepositories()` passed blank entries straight to `URI.create()`, which then failed downstream in pax-url-mvn.