### PR TITLE
fix(shell): enable autoFlush on console PrintStream (backport #2518)

### DIFF
--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/osgi/LocalConsoleManager.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/osgi/LocalConsoleManager.java
@@ -77,7 +77,7 @@ public class LocalConsoleManager {
         final Subject subject = createLocalKarafSubject();    
         this.session = JaasHelper.doAs(subject, (PrivilegedAction<Session>) () -> {
             String encoding = getEncoding();
-            PrintStream pout = new PrintStream(terminal.output()) {
+            PrintStream pout = new PrintStream(terminal.output(), true, Charset.forName(encoding)) {
                 @Override
                 public void close() {
                     // do nothing

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/ShellCommand.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/ShellCommand.java
@@ -97,7 +97,7 @@ public class ShellCommand implements Command {
     public void run() {
         int exitStatus = 0;
         try {
-            final Session session = sessionFactory.create(in, new PrintStream(out), new PrintStream(err));
+            final Session session = sessionFactory.create(in, new PrintStream(out, true), new PrintStream(err, true));
             for (Map.Entry<String,String> e : env.getEnv().entrySet()) {
                 session.put(e.getKey(), e.getValue());
             }


### PR DESCRIPTION
Backport of #2518 to `karaf-4.4.x`.

`System.out.print()` without a newline was not displayed immediately on the Karaf console because the `PrintStream` wrapping the terminal output was created without autoFlush. Enable autoFlush on the local console and SSH command `PrintStream`s, consistent with `ShellFactoryImpl`.

> **Note:** Minor conflict resolved — on `karaf-4.4.x` the `session` variable in `ShellCommand` is a local `final` variable rather than a field, so the fix was applied accordingly.