### PR TITLE
Fix 'occured' -> 'occurred' typos in user-visible log messages

### DIFF
--- a/main/src/main/java/org/apache/karaf/main/lock/DefaultJDBCLock.java
+++ b/main/src/main/java/org/apache/karaf/main/lock/DefaultJDBCLock.java
@@ -91,7 +91,7 @@ public class DefaultJDBCLock implements Lock {
             createDatabase();
             createSchema();
         } catch (Exception e) {
-            LOG.log(Level.SEVERE, "Error occured while attempting to obtain connection", e);
+            LOG.log(Level.SEVERE, "Error occurred while attempting to obtain connection", e);
         }
     }
 
@@ -298,7 +298,7 @@ public class DefaultJDBCLock implements Lock {
             try {
                 rs.close();
             } catch (SQLException e) {
-                LOG.log(Level.SEVERE, "Error occured while releasing ResultSet", e);
+                LOG.log(Level.SEVERE, "Error occurred while releasing ResultSet", e);
             }
         }
     }
@@ -333,7 +333,7 @@ public class DefaultJDBCLock implements Lock {
         try {
             return doCreateConnection(driver, url, username, password);
         } catch (Exception e) {
-            LOG.log(Level.SEVERE, "Error occured while setting up JDBC connection", e);
+            LOG.log(Level.SEVERE, "Error occurred while setting up JDBC connection", e);
             throw e; 
         }
     }

--- a/wrapper/src/main/java/org/apache/karaf/wrapper/internal/service/Main.java
+++ b/wrapper/src/main/java/org/apache/karaf/wrapper/internal/service/Main.java
@@ -97,7 +97,7 @@ public class Main extends Thread implements WrapperListener, ShutdownCallback {
                 return -3;
             }
         } catch (Throwable ex) {
-            System.err.println("Error occured shutting down framework: " + ex);
+            System.err.println("Error occurred shutting down framework: " + ex);
             ex.printStackTrace();
             return -2;
         }


### PR DESCRIPTION
Trivial spelling fix in two source files — `occured` → `occurred`.

All four occurrences are in user-visible output:

- `main/src/main/java/org/apache/karaf/main/lock/DefaultJDBCLock.java` — three SEVERE-level log messages emitted when the JDBC lock fails to obtain a connection, set up the connection, or release a `ResultSet`.
- `wrapper/src/main/java/org/apache/karaf/wrapper/internal/service/Main.java` — `System.err` message printed when the wrapper fails to shut the OSGi framework down cleanly.

No functional changes.