### PR TITLE
Disable flaky SSH tests on Windows

### DIFF
--- a/itests/test/src/test/java/org/apache/karaf/itests/ssh/BundleSshCommandSecurityTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/ssh/BundleSshCommandSecurityTest.java
@@ -13,6 +13,7 @@
  */
 package org.apache.karaf.itests.ssh;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -32,6 +33,11 @@ public class BundleSshCommandSecurityTest extends SshCommandTestBase {
 
     @Test
     public void testBundleCommandSecurityViaSsh() throws Exception {
+        // Skip on Windows where PTY output can be garbled,
+        // when upgrading to Junit5, this can be replaced with @DisabledOnOs(OS.WINDOWS)
+        // TODO: remove this once we have a better solution for PTY output on Windows
+        Assume.assumeFalse(System.getProperty("os.name", "").toLowerCase().contains("win"));
+
         String manageruser = "man" + System.nanoTime() + "_" + counter++;
         String vieweruser = "view" + System.nanoTime() + "_" + counter++;
 

--- a/itests/test/src/test/java/org/apache/karaf/itests/ssh/ConfigSshCommandSecurityTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/ssh/ConfigSshCommandSecurityTest.java
@@ -13,6 +13,7 @@
  */
 package org.apache.karaf.itests.ssh;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -33,6 +34,10 @@ public class ConfigSshCommandSecurityTest extends SshCommandTestBase {
 
     @Test
     public void testConfigCommandSecurityViaSsh() throws Exception {
+        // Skip on Windows where PTY output can be garbled,
+        // when upgrading to Junit5, this can be replaced with @DisabledOnOs(OS.WINDOWS)
+        // TODO: remove this once we have a better solution for PTY output on Windows
+        Assume.assumeFalse(System.getProperty("os.name", "").toLowerCase().contains("win"));
         String manageruser = "man" + System.nanoTime() + "_" + counter++;
         String vieweruser = "view" + System.nanoTime() + "_" + counter++;
 
@@ -90,6 +95,11 @@ public class ConfigSshCommandSecurityTest extends SshCommandTestBase {
 
     @Test
     public void testConfigCommandSecurityWithoutEditSessionViaSsh() throws Exception {
+        // Skip on Windows where PTY output can be garbled,
+        // when upgrading to Junit5, this can be replaced with @DisabledOnOs(OS.WINDOWS)
+        // TODO: remove this once we have a better solution for PTY output on Windows
+        Assume.assumeFalse(System.getProperty("os.name", "").toLowerCase().contains("win"));
+
         String manageruser = "man" + System.nanoTime() + "_" + counter++;
         String vieweruser = "view" + System.nanoTime() + "_" + counter++;
 

--- a/itests/test/src/test/java/org/apache/karaf/itests/ssh/FeatureSshCommandSecurityTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/ssh/FeatureSshCommandSecurityTest.java
@@ -14,6 +14,7 @@
 package org.apache.karaf.itests.ssh;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 /**
@@ -26,6 +27,11 @@ public class FeatureSshCommandSecurityTest extends SshCommandTestBase {
     
     @Test
     public void testFeatureCommandSecurityViaSsh() throws Exception {
+        // Skip on Windows where PTY output can be garbled,
+        // when upgrading to Junit5, this can be replaced with @DisabledOnOs(OS.WINDOWS)
+        // TODO: remove this once we have a better solution for PTY output on Windows
+        Assume.assumeFalse(System.getProperty("os.name", "").toLowerCase().contains("win"));
+
         String vieweruser = "viewer" + System.nanoTime() + "_features";
         String feature = "wrapper";
 

--- a/itests/test/src/test/java/org/apache/karaf/itests/ssh/JaasSshCommandSecurityTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/ssh/JaasSshCommandSecurityTest.java
@@ -16,6 +16,7 @@ package org.apache.karaf.itests.ssh;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Assume;
 import org.junit.Test;
 
 /**
@@ -27,6 +28,10 @@ public class JaasSshCommandSecurityTest extends SshCommandTestBase {
         
     @Test
     public void testJaasCommandSecurityViaSsh() throws Exception {
+        // Skip on Windows where PTY output can be garbled,
+        // when upgrading to Junit5, this can be replaced with @DisabledOnOs(OS.WINDOWS)
+        // TODO: remove this once we have a better solution for PTY output on Windows
+
         String vieweruser = "viewer" + System.nanoTime() + "_jaas";
 
         addViewer(vieweruser);

--- a/itests/test/src/test/java/org/apache/karaf/itests/ssh/SystemCommandSecurityTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/ssh/SystemCommandSecurityTest.java
@@ -14,6 +14,7 @@
 package org.apache.karaf.itests.ssh;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -31,6 +32,11 @@ public class SystemCommandSecurityTest extends SshCommandTestBase {
           
     @Test
     public void testSystemCommandSecurityViaSsh() throws Exception {
+        // Skip on Windows where PTY output can be garbled,
+        // when upgrading to Junit5, this can be replaced with @DisabledOnOs(OS.WINDOWS)
+        // TODO: remove this once we have a better solution for PTY output on Windows
+        Assume.assumeFalse(System.getProperty("os.name", "").toLowerCase().contains("win"));
+
         String manageruser = "man" + System.nanoTime() + "_" + counter++;
         String vieweruser = "view" + System.nanoTime() + "_" + counter++;
 


### PR DESCRIPTION
This addresses the repeated CI failures after 1h testing on the Windows platfrom.

It is _not fixing_ it, but disables ~3~ 6 SSH tests on Windows.
It could be a viable way to get rid of the failed builds and an alterative to #2544.

@jbonofre Are you thinking of a different approach to the issue, or shall we got in this direction for now?