### PR TITLE
[KARAF-2195] Fix assembly resolution failure when feature requires wrap protocol (4.4.x)

### DIFF
--- a/assemblies/features/standard/pom.xml
+++ b/assemblies/features/standard/pom.xml
@@ -152,6 +152,11 @@
             <classifier>uber</classifier>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- config deps -->
         <dependency>

--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -1495,6 +1495,7 @@ org.apache.felix.eventadmin.AddSubject=true
     </feature>
 
     <feature name="pax-url-wrap" description="Wrap URL handler" version="${pax.url.version}">
+        <bundle dependency="true">mvn:org.ops4j.pax.logging/pax-logging-api/${pax.logging.version}</bundle>
         <bundle start-level="10">mvn:org.ops4j.pax.url/pax-url-wrap/${pax.url.version}/jar/uber</bundle>
     </feature>
 


### PR DESCRIPTION
The pax-url-wrap feature's bundle (org.ops4j.pax.url.wrap uber jar) has a mandatory Import-Package on org.osgi.service.log, but this package is not satisfiable during assembly prerequisite resolution because pax-logging-api (which provides it) is only in the framework feature and not part of the prerequisite deployment context.

Add pax-logging-api as a dependency bundle in the pax-url-wrap feature so the resolver can satisfy the org.osgi.service.log requirement when pax-url-wrap is resolved as a prerequisite without the framework feature.