### PR TITLE
Add tx-control JDBC provider reference implementations to transaction feature (4.4.x)

### DIFF
--- a/assemblies/features/enterprise/src/main/feature/feature.xml
+++ b/assemblies/features/enterprise/src/main/feature/feature.xml
@@ -146,6 +146,8 @@ com.atomikos.icatch.log_base_dir=${karaf.data}/atomikos
         </requirement>
         <bundle>mvn:org.apache.aries.tx-control/tx-control-service-local/1.0.1</bundle>
         <bundle>mvn:org.apache.aries.tx-control/tx-control-service-xa/1.0.1</bundle>
+        <bundle>mvn:org.apache.aries.tx-control/tx-control-provider-jdbc-local/1.0.1</bundle>
+        <bundle>mvn:org.apache.aries.tx-control/tx-control-provider-jdbc-xa/1.0.1</bundle>
         <conditional>
             <condition>aries-blueprint</condition>
             <bundle dependency="true">mvn:org.apache.felix/org.apache.felix.coordinator/${felix.coordinator.version}</bundle>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1051,6 +1051,16 @@
                 <version>${aries.transaction.control.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.aries.tx-control</groupId>
+                <artifactId>tx-control-provider-jdbc-local</artifactId>
+                <version>${aries.transaction.control.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.aries.tx-control</groupId>
+                <artifactId>tx-control-provider-jdbc-xa</artifactId>
+                <version>${aries.transaction.control.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.aries.transaction</groupId>
                 <artifactId>org.apache.aries.transaction.manager</artifactId>
                 <version>${aries.transaction.manager.version}</version>


### PR DESCRIPTION
Add tx-control-provider-jdbc-local and tx-control-provider-jdbc-xa bundles to the transaction feature and BOM, providing out-of-the-box JDBC support for OSGi Transaction Control.

Fixes #2209