### PR TITLE
Bump org.apache.sling.commons.johnzon from 1.2.16 to 2.0.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1238,6 +1238,11 @@
                 <version>${spec.annotation.version}</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>${jakarta.json.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
                 <version>${spec.jaxb.version}</version>

--- a/config/core/pom.xml
+++ b/config/core/pom.xml
@@ -86,11 +86,6 @@
             <artifactId>org.apache.sling.commons.johnzon</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-json_1.1_spec</artifactId>
-            <version>1.5</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.fileinstall</artifactId>
         </dependency>

--- a/config/core/src/main/java/org/apache/karaf/config/core/impl/ConfigRepositoryImpl.java
+++ b/config/core/src/main/java/org/apache/karaf/config/core/impl/ConfigRepositoryImpl.java
@@ -30,7 +30,7 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Map;
 
-import org.apache.felix.cm.json.Configurations;
+import org.apache.felix.cm.json.io.Configurations;
 import org.apache.felix.utils.properties.TypedProperties;
 import org.apache.karaf.config.core.ConfigRepository;
 import org.osgi.framework.Constants;

--- a/config/core/src/main/java/org/apache/karaf/config/core/impl/JsonConfigInstaller.java
+++ b/config/core/src/main/java/org/apache/karaf/config/core/impl/JsonConfigInstaller.java
@@ -16,7 +16,7 @@
  */
 package org.apache.karaf.config.core.impl;
 
-import org.apache.felix.cm.json.Configurations;
+import org.apache.felix.cm.json.io.Configurations;
 import org.apache.felix.fileinstall.ArtifactInstaller;
 import org.apache.felix.fileinstall.internal.DirectoryWatcher;
 import org.apache.felix.utils.collections.DictionaryAsMap;

--- a/features/core/pom.xml
+++ b/features/core/pom.xml
@@ -97,9 +97,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-json_1.1_spec</artifactId>
-            <version>1.5</version>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.Pattern;
 
-import org.apache.felix.cm.json.Configurations;
+import org.apache.felix.cm.json.io.Configurations;
 import org.apache.felix.utils.properties.InterpolationHelper;
 import org.apache.felix.utils.properties.TypedProperties;
 import org.apache.karaf.features.ConfigFileInfo;

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
         <aspectj.bundle.version>1.9.21.1_1</aspectj.bundle.version>
         <asm.version>9.9.1</asm.version>
         <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
+        <jakarta.json.version>2.1.3</jakarta.json.version>
         <awaitility.version>3.1.6</awaitility.version>
         <bouncycastle.version>1.84</bouncycastle.version>
         <camel.version>4.14.5</camel.version>
@@ -207,10 +208,10 @@
         <equinox.coordinator.version>1.5.500</equinox.coordinator.version>
 
         <felix.bundlerepository.version>2.0.10</felix.bundlerepository.version>
-        <felix.cm.json.version>1.0.8</felix.cm.json.version>
+        <felix.cm.json.version>2.0.6</felix.cm.json.version>
         <felix.configadmin.version>1.9.26</felix.configadmin.version>
         <felix.configadmin.interpolation.plugin.version>1.2.8</felix.configadmin.interpolation.plugin.version>
-        <felix.configurator.version>1.0.16</felix.configurator.version>
+        <felix.configurator.version>1.0.18</felix.configurator.version>
         <felix.connect.version>0.2.0</felix.connect.version>
         <felix.coordinator.version>1.0.2</felix.coordinator.version>
         <felix.converter.version>1.0.14</felix.converter.version>
@@ -362,7 +363,7 @@
         <spring.security57.version>5.7.12_4</spring.security57.version>
         <spring.security62.version>6.2.7_3</spring.security62.version>
 
-        <sling.commons.johnzon.version>1.2.16</sling.commons.johnzon.version>
+        <sling.commons.johnzon.version>2.0.0</sling.commons.johnzon.version>
         <sshd.version>2.17.1</sshd.version>
         <struts.bundle.version>1.3.10_1</struts.bundle.version>
         <xbean.version>4.30</xbean.version>


### PR DESCRIPTION
Supersedes #2345.

The `sling.commons.johnzon` 2.0.0 release wraps Apache Johnzon 2.x, which migrates from `javax.json` to `jakarta.json`. The Dependabot PR alone breaks the build with _Unable to resolve framework features_ because the dependent stack also needs updating.

## Changes

**Version bumps (`pom.xml`)**
- `org.apache.sling.commons.johnzon`: 1.2.16 → 2.0.0
- `org.apache.felix.cm.json`: 1.0.8 → 2.0.6 (exports `org.apache.felix.cm.json.io`, uses `jakarta.json`)
- `org.apache.felix.configurator`: 1.0.16 → 1.0.18 (imports `org.apache.felix.cm.json.io`)

**BOM / deps**
- Added `jakarta.json:jakarta.json-api` 2.1.3 to `bom/pom.xml` and as a `provided` dependency in `features/core`
- Removed `geronimo-json_1.1_spec` from `config/core` and `features/core` (superseded by `jakarta.json-api`)

**Java sources** — update import from `org.apache.felix.cm.json.Configurations` → `org.apache.felix.cm.json.io.Configurations`
- `config/core/.../JsonConfigInstaller.java`
- `config/core/.../ConfigRepositoryImpl.java`
- `features/core/.../FeatureConfigInstaller.java`