### PR TITLE
Downgrade felix.webconsole.plugins.ds to 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <felix.eventadmin.webconsole.plugin.version>1.1.8</felix.eventadmin.webconsole.plugin.version>
         <felix.obr.version>1.0.2</felix.obr.version>
         <felix.scr.version>2.2.18</felix.scr.version>
-        <felix.scr.webconsole.plugin.version>2.3.0</felix.scr.webconsole.plugin.version>
+        <felix.scr.webconsole.plugin.version>2.2.0</felix.scr.webconsole.plugin.version>
         <felix.scr.annotation.version>1.12.0</felix.scr.annotation.version>
         <felix.resolver.version>2.0.4</felix.resolver.version>
 


### PR DESCRIPTION
Reverts #2431.
This brought new dependencies to jakarta, which is unintended on the 4.4.x branch.
https://mvnrepository.com/artifact/org.apache.felix/org.apache.felix.webconsole.plugins.ds/2.3.0/changes?compare=2.2.0