### PR TITLE
Prepare for Maven 4 (#2322)

### DIFF
--- a/.mvn/README
+++ b/.mvn/README
@@ -1,0 +1,1 @@
+required by Maven 4 to detect root dir; adding root=true to pom is not compatible with Maven 3

--- a/archetypes/kar/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/kar/src/main/resources/archetype-resources/pom.xml
@@ -69,6 +69,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
             </plugin>


### PR DESCRIPTION
Backport of #2322 

This basically allows building Karaf with maven4-rc5.

First addition is the directory .mvn to mark the top directory of the workspace. Not strictly necessary, but it suppresses the warning about missing top level directory marker during build with Maven 4.
The approach to add .mvn dir is the option that does not impact our standard builds with Maven 3.

The second addition is a missing version specification in a pom file. Without it, Maven4 just picks the wrong version of the maven-resources-plugin, which is built against an old API and is causing the build to fail.