### PR TITLE
Upgrade to Pax URL 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
         <pax.logging.version>2.3.3</pax.logging.version>
         <pax.base.version>1.5.1</pax.base.version>
         <pax.swissbox.version>1.9.0</pax.swissbox.version>
-        <pax.url.version>2.7.0</pax.url.version>
+        <pax.url.version>2.7.1</pax.url.version>
         <pax.web.version>8.0.35</pax.web.version>
         <jetty.version>9.4.58.v20250814</jetty.version>
         <pax.tinybundle.version>4.0.1</pax.tinybundle.version>


### PR DESCRIPTION
Pax URL 2.7.1 [announced here](https://groups.google.com/g/ops4j/c/0G754V2xmNw/m/8YpdvWTnBgAJ)

Fixes #2582