### PR TITLE
[dependabot] Tune 4.4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,9 +35,17 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "karaf-4.4.x"
+    commit-message:
+      prefix: "[4.4.x] "
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"
     target-branch: "karaf-4.4.x"
     open-pull-requests-limit: 50
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    commit-message:
+      prefix: "[4.4.x] "


### PR DESCRIPTION
This PR tunes the behaviour of dependabot for the 4.4.x branch.

* Introduce prefix "[4.4.x] " for PR titles
* maven package updates: ignore new major versions

For my old 4.4.x test branch, it looks like this:

<img width="1394" height="1003" alt="grafik" src="https://github.com/user-attachments/assets/49340f15-d1c5-473e-8d66-08733997e700" />

Observations:
* PAX URL now used the 2.x version.
* Some dependencies use new patch versions (hidden by a proposed update to next major release)
* Some packages try to upgrade to a new minor version and we do not want this on 4.4.x. I think we have a trade-off here: either we block minor-versions as well, or we manually handle those proposed updates (checking for possible patch level upgrades, closing the ticket).