### PR TITLE
Fix asciidoctor deprecation warning

### DIFF
--- a/manual/pom.xml
+++ b/manual/pom.xml
@@ -233,7 +233,6 @@
 				</executions>
 				<configuration>
 					<sourceDirectory>src/main/asciidoc</sourceDirectory>
-					<headerFooter>true</headerFooter>
 					<attributes>
 						<imagesdir>src/main/asciidoc/images</imagesdir>
 					</attributes>


### PR DESCRIPTION
removes deprecated setting, should no longer be needed as the function should be enabled by default