### PR TITLE
Upgrade examples to cxf 4.2.0

### DIFF
--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-client</artifactId>
-            <version>4.1.2</version>
+            <version>${cxf.version}</version>
         </dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.jakarta.rs</groupId>

--- a/examples/karaf-rest-example/karaf-rest-example-scr/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-scr/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>4.2.0</version>
+            <version>${cxf.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.activation</groupId>
@@ -74,6 +74,12 @@
             <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>4.0.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <bouncycastle.version>1.84</bouncycastle.version>
         <camel.version>4.18.1</camel.version>
         <cglib.bundle.version>3.2.9_1</cglib.bundle.version>
-        <cxf.version>3.6.10</cxf.version>
+        <cxf.version>4.2.0</cxf.version>
         <jackson.annotations.version>2.21</jackson.annotations.version>
         <jackson.version>2.21.3</jackson.version>
         <jna.version>5.18.1</jna.version>


### PR DESCRIPTION
This removes cxf 3.6 and aligns cxf 4 version to 4.2.0