### PR TITLE
Replace activation-api-1.2.1 by jakarta variant

### DIFF
--- a/assemblies/features/base/pom.xml
+++ b/assemblies/features/base/pom.xml
@@ -55,9 +55,9 @@
             <version>${jakarta.annotation.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.servicemix.specs</groupId>
-            <artifactId>org.apache.servicemix.specs.activation-api-1.2.1</artifactId>
-            <version>1.2.1_3</version>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <version>${spec.activation.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.specs</groupId>
@@ -176,8 +176,8 @@
                                     <outputDirectory>target/classes/resources/lib/jdk9plus</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>org.apache.servicemix.specs</groupId>
-                                    <artifactId>org.apache.servicemix.specs.activation-api-1.2.1</artifactId>
+                                    <groupId>jakarta.activation</groupId>
+                                    <artifactId>jakarta.activation-api</artifactId>
                                     <outputDirectory>target/classes/resources/lib/jdk9plus</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>


### PR DESCRIPTION
I have locally merged all open depencency PRs and created a dependency tree to identify remainders of the javax migration.
This assembly is the last place where the javax activation api is pulled in.

Not sure if this is the way to do it. Please advise.