### PR TITLE
Migrate to Jackson 3.1.2

### DIFF
--- a/assemblies/features/enterprise/src/main/feature/feature.xml
+++ b/assemblies/features/enterprise/src/main/feature/feature.xml
@@ -173,7 +173,7 @@ com.atomikos.icatch.log_base_dir=${karaf.data}/atomikos
         <bundle>mvn:jakarta.transaction/jakarta.transaction-api/2.0.1</bundle>
         <bundle>mvn:io.smallrye/jandex/3.2.0</bundle>
         <bundle>mvn:com.fasterxml/classmate/1.5.1</bundle>
-        <bundle>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/${jackson.version}</bundle>
+        <bundle>mvn:tools.jackson.dataformat/jackson-dataformat-xml/${jackson.version}</bundle>
         <bundle>mvn:org.codehaus.woodstox/stax2-api/4.2.2</bundle>
         <bundle>mvn:com.fasterxml.woodstox/woodstox-core/7.1.0</bundle>
         <bundle>mvn:jakarta.json/jakarta.json-api/2.1.3</bundle>
@@ -181,7 +181,7 @@ com.atomikos.icatch.log_base_dir=${karaf.data}/atomikos
         <bundle>mvn:jakarta.json.bind/jakarta.json.bind-api/3.0.1</bundle>
         <bundle>mvn:org.eclipse/yasson/3.0.4</bundle>
         <bundle>wrap:mvn:org.hibernate.models/hibernate-models/1.1.0</bundle>
-        <bundle>wrap:mvn:org.hibernate.orm/hibernate-core/${hibernate.version}$overwrite=merge&amp;Import-Package=oracle.jdbc.*;resolution:=optional,oracle.sql.*;resolution:=optional,org.postgresql.*;resolution:=optional,tools.jackson.*;resolution:=optional,*</bundle>
+        <bundle>wrap:mvn:org.hibernate.orm/hibernate-core/${hibernate.version}$overwrite=merge&amp;Import-Package=oracle.jdbc.*;resolution:=optional,oracle.sql.*;resolution:=optional,org.postgresql.*;resolution:=optional,com.fasterxml.jackson.*;resolution:=optional,javax.transaction.*;resolution:=optional,*</bundle>
         <bundle>mvn:jakarta.interceptor/jakarta.interceptor-api/2.2.0</bundle>
         <bundle>mvn:jakarta.validation/jakarta.validation-api/3.1.0</bundle>
         <bundle>mvn:jakarta.xml.bind/jakarta.xml.bind-api/${spec.jaxb-api.version}</bundle>
@@ -193,8 +193,8 @@ com.atomikos.icatch.log_base_dir=${karaf.data}/atomikos
 
     <feature name="hibernate-envers" version="${hibernate.version}" description="Feature for easily adding Envers support to hibernate">
         <feature version="${hibernate.version}">hibernate</feature>
-        <bundle>mvn:org.hibernate.orm/hibernate-envers/${hibernate.version}</bundle>
-    </feature>
+        <bundle>wrap:mvn:org.hibernate.orm/hibernate-envers/${hibernate.version}$overwrite=merge&amp;Import-Package=javax.transaction.*;resolution:=optional,*</bundle>
+        </feature>
 
     <feature name="hibernate-validator" version="${hibernate.validator.version}">
         <bundle>mvn:org.hibernate.validator/hibernate-validator/${hibernate.validator.version}</bundle>

--- a/assemblies/features/specs/src/main/feature/feature.xml
+++ b/assemblies/features/specs/src/main/feature/feature.xml
@@ -74,38 +74,22 @@
         <bundle start-level="10" dependency="true">mvn:jakarta.mail/jakarta.mail-api/${spec.mail.version}</bundle>
     </feature>
 
-    <!-- jackson 2.18 -->
-    <feature name="jackson" version="2.18.3">
-        <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-core/2.18.3</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-annotations/2.18.3</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-databind/2.18.3</bundle>
-    </feature>
-
-    <feature name="jackson-jaxrs" version="2.18.3">
-        <feature>jackson</feature>
-        <feature>jaxrs</feature>
-        <feature>jakarta.annotation</feature>
-        <bundle start-level="35">mvn:org.yaml/snakeyaml/2.5</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.3</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.18.3</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.18.3</bundle>
-    </feature>
-
-    <!-- jackson 2.20 -->
+    <!-- jackson 3 -->
     <feature name="jackson" version="${jackson.version}">
-        <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
+        <bundle start-level="35">mvn:tools.jackson.core/jackson-core/${jackson.version}</bundle>
         <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.annotations.version}</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
+        <bundle start-level="35">mvn:tools.jackson.core/jackson-databind/${jackson.version}</bundle>
     </feature>
 
     <feature name="jackson-jaxrs" version="${jackson.version}">
         <feature>jackson</feature>
         <feature>jaxrs</feature>
         <feature>jakarta.annotation</feature>
-        <bundle start-level="35">mvn:org.yaml/snakeyaml/2.5</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson.version}</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${jackson.version}</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson.version}</bundle>
+        <bundle start-level="35">mvn:jakarta.ws.rs/jakarta.ws.rs-api/3.1.0</bundle>
+        <bundle start-level="35">mvn:org.snakeyaml/snakeyaml-engine/3.0.1</bundle>
+        <bundle start-level="35">mvn:tools.jackson.dataformat/jackson-dataformat-yaml/${jackson.version}</bundle>
+        <bundle start-level="35">mvn:tools.jackson.jakarta.rs/jackson-jakarta-rs-base/${jackson.version}</bundle>
+        <bundle start-level="35">mvn:tools.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${jackson.version}</bundle>
     </feature>
 
     <!-- stax -->

--- a/assemblies/features/spring/src/main/feature/feature.xml
+++ b/assemblies/features/spring/src/main/feature/feature.xml
@@ -108,9 +108,9 @@
         <feature version="[6.1,6.2)">spring-tx</feature>
         <feature version="[6.1,6.2)">spring-web</feature>
         <bundle dependency="true">mvn:jakarta.annotation/jakarta.annotation-api/${jakarta.annotation.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.core/jackson-core/${jackson.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.annotations.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.core/jackson-databind/${jackson.version}</bundle>
         <bundle dependency="true">mvn:io.micrometer/micrometer-commons/1.12.4</bundle>
         <bundle dependency="true">mvn:io.micrometer/micrometer-observation/1.12.4</bundle>
         <bundle dependency="true">mvn:jakarta.annotation/jakarta.annotation-api/2.1.1</bundle>
@@ -123,6 +123,11 @@
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-web/${spring.security62.version}</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-acl/${spring.security62.version}</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-taglibs/${spring.security62.version}</bundle>
+        <!-- jackson 2 compat, deprecated -->
+        <bundle start-level="30">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.annotations.version}</bundle>
+        <bundle start-level="30">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.deprecated.version}</bundle>
+        <bundle start-level="30">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.deprecated.version}</bundle>
+        <!-- /jackson 2 compat -->
     </feature>
 
     <!-- Aries Blueprint Spring support -->

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -55,7 +55,7 @@
             <artifactId>org.osgi.framework</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
@@ -104,7 +104,8 @@
                             org.apache.karaf.docker;-noimport:=true
                         </Export-Package>
                         <Import-Package>
-                            com.fasterxml.jackson*;version="[2,3)",
+                            tools.jackson*;version="[3,4)",
+                            com.fasterxml.jackson.annotation;version="[2,3)",
                             org.osgi.framework;version="[1,3)",
                             *
                         </Import-Package>

--- a/docker/src/main/java/org/apache/karaf/docker/DockerClient.java
+++ b/docker/src/main/java/org/apache/karaf/docker/DockerClient.java
@@ -16,8 +16,8 @@
  */
 package org.apache.karaf.docker;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/examples/karaf-graphql-example/karaf-graphql-example-features/src/main/feature/feature.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-features/src/main/feature/feature.xml
@@ -30,9 +30,13 @@
         <bundle dependency="true">mvn:org.reactivestreams/reactive-streams/1.0.4</bundle>
         <bundle dependency="true">mvn:com.graphql-java/graphql-java/22.3</bundle>
 
-        <bundle dependency="true">mvn:tools.jackson.core/jackson-core/${jackson.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.annotations.version}</bundle>
+        <!-- Jackson 3.x for example code -->
+        <bundle dependency="true">mvn:tools.jackson.core/jackson-core/${jackson.version}</bundle>
         <bundle dependency="true">mvn:tools.jackson.core/jackson-databind/${jackson.version}</bundle>
+        <!-- Jackson 2.x compatibility, transitive dependencies -->
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.deprecated.version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.deprecated.version}</bundle>
         <bundle dependency="true">mvn:jakarta.servlet/jakarta.servlet-api/6.1.0</bundle>
         <bundle dependency="true">mvn:jakarta.websocket/jakarta.websocket-api/2.2.0</bundle>
         <bundle dependency="true">mvn:jakarta.websocket/jakarta.websocket-client-api/2.2.0</bundle>

--- a/examples/karaf-graphql-example/karaf-graphql-example-features/src/main/feature/feature.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-features/src/main/feature/feature.xml
@@ -30,10 +30,9 @@
         <bundle dependency="true">mvn:org.reactivestreams/reactive-streams/1.0.4</bundle>
         <bundle dependency="true">mvn:com.graphql-java/graphql-java/22.3</bundle>
 
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.core/jackson-core/${jackson.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.annotations.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jdk8/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.core/jackson-databind/${jackson.version}</bundle>
         <bundle dependency="true">mvn:jakarta.servlet/jakarta.servlet-api/6.1.0</bundle>
         <bundle dependency="true">mvn:jakarta.websocket/jakarta.websocket-api/2.2.0</bundle>
         <bundle dependency="true">mvn:jakarta.websocket/jakarta.websocket-client-api/2.2.0</bundle>

--- a/examples/karaf-rest-example/karaf-rest-example-blueprint/src/main/resources/OSGI-INF/blueprint/rest.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-blueprint/src/main/resources/OSGI-INF/blueprint/rest.xml
@@ -37,7 +37,7 @@
             <ref component-id="bookingBean" />
         </jaxrs:serviceBeans>
         <jaxrs:providers>
-            <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
+            <bean class="tools.jackson.jakarta.rs.json.JacksonJsonProvider"/>
         </jaxrs:providers>
     </jaxrs:server>
 

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/pom.xml
@@ -54,7 +54,7 @@
             <version>4.1.2</version>
         </dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+			<groupId>tools.jackson.jakarta.rs</groupId>
 			<artifactId>jackson-jakarta-rs-json-provider</artifactId>
 			<version>${jackson.version}</version>
 		</dependency>

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/src/main/java/org/apache/karaf/examples/rest/client/cxf/AddBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/src/main/java/org/apache/karaf/examples/rest/client/cxf/AddBookingCommand.java
@@ -16,7 +16,7 @@
  */
 package org.apache.karaf.examples.rest.client.cxf;
 
-import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.karaf.examples.rest.api.Booking;
 import org.apache.karaf.shell.api.action.Action;

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/src/main/java/org/apache/karaf/examples/rest/client/cxf/ListAllBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/src/main/java/org/apache/karaf/examples/rest/client/cxf/ListAllBookingCommand.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
-import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.karaf.examples.rest.api.Booking;

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/src/main/java/org/apache/karaf/examples/rest/client/cxf/ListBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/src/main/java/org/apache/karaf/examples/rest/client/cxf/ListBookingCommand.java
@@ -16,7 +16,7 @@
  */
 package org.apache.karaf.examples.rest.client.cxf;
 
-import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.karaf.examples.rest.api.Booking;
 import org.apache.karaf.shell.api.action.Action;

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/pom.xml
@@ -51,8 +51,8 @@
             <version>4.0.0</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <groupId>tools.jackson.jakarta.rs</groupId>
+            <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson.version}</version>
         </dependency>
         <dependency>

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/AddBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/AddBookingCommand.java
@@ -16,7 +16,7 @@
  */
 package org.apache.karaf.examples.rest.client.jersey;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
 import org.apache.karaf.examples.rest.api.Booking;
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.Argument;

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/ListBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/ListBookingCommand.java
@@ -16,7 +16,7 @@
  */
 package org.apache.karaf.examples.rest.client.jersey;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
 import org.apache.karaf.examples.rest.api.Booking;
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.Command;

--- a/examples/karaf-rest-example/karaf-rest-example-features/src/main/feature/feature.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-features/src/main/feature/feature.xml
@@ -30,11 +30,11 @@
         <requirement>osgi.service;effective:=active;filter:=(objectClass=org.osgi.service.http.HttpService)</requirement>
         <feature dependency="true">aries-blueprint</feature>
         <feature version="${cxf.version}" dependency="true">cxf-jaxrs</feature>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.core/jackson-core/${jackson.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.annotations.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.core/jackson-databind/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.jakarta.rs/jackson-jakarta-rs-base/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${jackson.version}</bundle>
         <bundle>mvn:org.apache.karaf.examples/karaf-rest-example-blueprint/${project.version}</bundle>
     </feature>
 
@@ -66,12 +66,12 @@
         <requirement>osgi.service;effective:=active;filter:=(objectClass=org.osgi.service.http.HttpService)</requirement>
         <feature dependency="true">scr</feature>
         <feature version="${cxf.version}" dependency="true">cxf-jaxrs</feature>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.core/jackson-core/${jackson.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.annotations.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.core/jackson-databind/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.module/jackson-module-jakarta-xmlbind-annotations/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.jakarta.rs/jackson-jakarta-rs-base/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:tools.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${jackson.version}</bundle>
         <bundle>mvn:org.apache.karaf.examples/karaf-rest-example-scr/${project.version}</bundle>
     </feature>
 

--- a/examples/karaf-rest-example/karaf-rest-example-scr/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-scr/pom.xml
@@ -71,7 +71,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <groupId>tools.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson.version}</version>
         </dependency>

--- a/examples/karaf-rest-example/karaf-rest-example-scr/src/main/java/org/apache/karaf/examples/rest/scr/RestService.java
+++ b/examples/karaf-rest-example/karaf-rest-example-scr/src/main/java/org/apache/karaf/examples/rest/scr/RestService.java
@@ -16,7 +16,7 @@
  */
 package org.apache.karaf.examples.rest.scr;
 
-import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
 import org.apache.cxf.BusFactory;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;

--- a/features/core/pom.xml
+++ b/features/core/pom.xml
@@ -180,7 +180,7 @@
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
 	    <version>${jackson.version}</version>
         </dependency>
@@ -251,7 +251,8 @@
                             org.ops4j.pax.swissbox.*,
                             org.ops4j.util.*,
                             org.ops4j.lang.*,
-                            com.fasterxml.jackson*
+                            com.fasterxml.jackson*,
+                            tools.jackson*
                         </Private-Package>
                         <Embed-Dependency>
                             org.apache.karaf.util;inline="org/apache/karaf/util/XmlUtils*.class"

--- a/features/core/src/main/java/org/apache/karaf/features/internal/model/JacksonUtil.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/model/JacksonUtil.java
@@ -16,7 +16,7 @@
  */
 package org.apache.karaf.features.internal.model;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/itests/test/src/test/java/org/apache/karaf/itests/examples/GraphQLExampleTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/examples/GraphQLExampleTest.java
@@ -13,8 +13,8 @@
  */
 package org.apache.karaf.itests.examples;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 import org.apache.karaf.itests.BaseTest;
 import org.apache.karaf.itests.util.SimpleSocket;
 import org.eclipse.jetty.websocket.client.WebSocketClient;

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <cxf.version>3.6.10</cxf.version>
         <jackson.annotations.version>2.21</jackson.annotations.version>
         <jackson.version>3.1.2</jackson.version>
-        <jackson.deprecated.version>2.21.2</jackson.deprecated.version>
+        <jackson.deprecated.version>2.21.3</jackson.deprecated.version>
         <jna.version>5.18.1</jna.version>
         <jaxb-bom.version>4.0.7</jaxb-bom.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,8 @@
         <cglib.bundle.version>3.2.9_1</cglib.bundle.version>
         <cxf.version>3.6.10</cxf.version>
         <jackson.annotations.version>2.21</jackson.annotations.version>
-        <jackson.version>2.21.3</jackson.version>
+        <jackson.version>3.1.2</jackson.version>
+        <jackson.deprecated.version>2.21.2</jackson.deprecated.version>
         <jna.version>5.18.1</jna.version>
         <jaxb-bom.version>4.0.7</jaxb-bom.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>


### PR DESCRIPTION
* migrate Jackson packages from com.fasterxml.jackson namespace to tools.jackson namespace
* suppress com.fasterxml for hibernate to avoid double inclusion (hibernate should then select tools.jackson packages)
* change of jackson related features

This PR basically tries to remove jackson 2. We still need it for spring.security and two transitive dependencies in examples.