### PR TITLE
Remove unused imports in PackageCommand

### DIFF
--- a/instance/src/main/java/org/apache/karaf/instance/command/PackageCommand.java
+++ b/instance/src/main/java/org/apache/karaf/instance/command/PackageCommand.java
@@ -17,23 +17,10 @@
 package org.apache.karaf.instance.command;
 
 import org.apache.karaf.instance.command.completers.InstanceCompleter;
-import org.apache.karaf.instance.core.Instance;
 import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.Completion;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 @Command(scope = "instance", name = "package", description = "Create a .zip archive of the instance.")
 @Service


### PR DESCRIPTION
We have a chunk of imports that are not used: remove them.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
