### PR TITLE
Fix Main.LOG reference

### DIFF
--- a/main/src/main/java/org/apache/karaf/main/Main.java
+++ b/main/src/main/java/org/apache/karaf/main/Main.java
@@ -185,7 +185,7 @@ public class Main {
                 // Also log to sytem.err in case logging is not yet initialized
                 System.err.println(ex.getMessage());
 
-                main.LOG.log(Level.SEVERE, "Could not launch framework", ex);
+                LOG.log(Level.SEVERE, "Could not launch framework", ex);
                 main.destroy();
                 main.setExitCode(-1);
             }


### PR DESCRIPTION
This is a constant reference, do not use the inclosing object to
reference it.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
