### PR TITLE
Clean up LogDumpProvider

### DIFF
--- a/diagnostic/core/src/main/java/org/apache/karaf/diagnostic/common/LogDumpProvider.java
+++ b/diagnostic/core/src/main/java/org/apache/karaf/diagnostic/common/LogDumpProvider.java
@@ -15,18 +15,13 @@
  */
 package org.apache.karaf.diagnostic.common;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.OutputStream;
-import java.util.Dictionary;
-import java.util.Enumeration;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.karaf.diagnostic.core.DumpDestination;
 import org.apache.karaf.diagnostic.core.DumpProvider;
-import org.apache.karaf.util.StreamUtils;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceReference;
-import org.osgi.service.cm.Configuration;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
@@ -44,38 +39,34 @@ public class LogDumpProvider implements DumpProvider {
     /**
      * Attach log entries from directory.
      */
+    @Override
     public void createDump(DumpDestination destination) throws Exception {
         // get the ConfigAdmin service
-        ServiceReference ref = bundleContext.getServiceReference(ConfigurationAdmin.class.getName());
+        var ref = bundleContext.getServiceReference(ConfigurationAdmin.class);
         if (ref == null) {
             return;
         }
 
         // get the PAX Logging configuration
-        ConfigurationAdmin configurationAdmin = (ConfigurationAdmin) bundleContext.getService(ref);
+        var configurationAdmin = bundleContext.getService(ref);
         try {
-            Configuration configuration = configurationAdmin.getConfiguration("org.ops4j.pax.logging", null);
+            var configuration = configurationAdmin.getConfiguration("org.ops4j.pax.logging", null);
 
             // get the ".file" Pax Logging properties
-            Dictionary dictionary = configuration.getProcessedProperties(null);
-            for (Enumeration e = dictionary.keys(); e.hasMoreElements(); ) {
-                String property = (String) e.nextElement();
+            for (var entry : FrameworkUtil.asMap(configuration.getProcessedProperties(null)).entrySet()) {
+                var property = entry.getKey();
                 if (property.endsWith(".fileName")) {
                     // it's a file appender, get the file location
-                    String location = (String) dictionary.get(property);
-                    File file = new File(location);
-                    if (file.exists()) {
-                        FileInputStream inputStream = new FileInputStream(file);
-                        OutputStream outputStream = destination.add("log/" + file.getName());
-                        StreamUtils.copy(inputStream, outputStream);
+                    var location = Path.of((String) entry.getValue());
+                    if (Files.exists(location)) {
+                        try (var os = destination.add("log/" + location.getFileName())) {
+                            Files.copy(location, os);
+                        }
                     }
                 }
             }
-        } catch (Exception e) {
-            throw e;
         } finally {
             bundleContext.ungetService(ref);
         }
     }
-
 }


### PR DESCRIPTION
This a deep modernization:
- use local variable type inference to shorten declarations
- use type-safe framework interfaces and utilities
- use NIO2 to perform file-to-OutputStream

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
