### PR TITLE
Remove unused imports

### DIFF
--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/jdbc/JDBCUtils.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/jdbc/JDBCUtils.java
@@ -16,7 +16,6 @@
 package org.apache.karaf.jaas.modules.jdbc;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapPropsUpdater.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapPropsUpdater.java
@@ -17,7 +17,6 @@ package org.apache.karaf.jaas.modules.ldap;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapSpecialCharsInPasswordTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapSpecialCharsInPasswordTest.java
@@ -33,7 +33,6 @@ import org.apache.directory.server.core.annotations.ApplyLdifFiles;
 import org.apache.directory.server.core.annotations.CreateDS;
 import org.apache.directory.server.core.annotations.CreatePartition;
 import org.apache.felix.utils.properties.Properties;
-import org.apache.karaf.jaas.modules.ldap.LdapLoginModuleTest;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/syncope/SyncopeLoginModuleTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/syncope/SyncopeLoginModuleTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/main/src/test/java/org/apache/karaf/main/lock/StatementsTest.java
+++ b/main/src/test/java/org/apache/karaf/main/lock/StatementsTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.karaf.main.lock;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
-import org.apache.karaf.main.lock.Statements;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
This cleans up unused imports and a drive-by elimination of
star-imports.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
