### PR TITLE
Remove use of File{Input,Ouput}Stream

### DIFF
--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/Update.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/Update.java
@@ -17,11 +17,10 @@
 package org.apache.karaf.bundle.command;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
 
 import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
@@ -65,12 +64,12 @@ public class Update extends BundleCommand {
     }
 
     private void update(Bundle bundle, URL location) throws IOException, BundleException {
-        try (InputStream is = location.openStream()) {
+        try (var is = location.openStream()) {
             if (raw) {
                 bundle.update(is);
             } else {
                 File file = BundleUtils.fixBundleWithUpdateLocation(is, location.toString());
-                try (FileInputStream fis = new FileInputStream(file)) {
+                try (var fis = Files.newInputStream(file.toPath())) {
                     bundle.update(fis);
                 }
                 file.delete();

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/BundleWatcherImpl.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/BundleWatcherImpl.java
@@ -17,10 +17,9 @@
 package org.apache.karaf.bundle.core.internal;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -151,7 +150,7 @@ public class BundleWatcherImpl implements Runnable, BundleListener, BundleWatche
         throws BundleException, IOException {
         File location = getBundleExternalLocation(localRepository, bundle);
         if (location != null && location.exists() && location.lastModified() > bundle.getLastModified()) {
-            try (InputStream is = new FileInputStream(location)) {
+            try (var is = Files.newInputStream(location.toPath())) {
                 logger.info("[Watch] Updating watched bundle: {} ({})", bundle.getSymbolicName(), bundle.getVersion());
                 if (bundle.getHeaders().get(Constants.FRAGMENT_HOST) != null) {
                     logger.info("[Watch] Bundle {} is a fragment, so it's not stopped", bundle.getSymbolicName());
@@ -162,7 +161,7 @@ public class BundleWatcherImpl implements Runnable, BundleListener, BundleWatche
                 String updateLocation = getLocation(bundle);
                 if (!updateLocation.equals(bundle.getLocation())) {
                     File file = BundleUtils.fixBundleWithUpdateLocation(is, updateLocation);
-                    try (FileInputStream fis = new FileInputStream(file)) {
+                    try (var fis = Files.newInputStream(file.toPath())) {
                         bundle.update(fis);
                     }
                     file.delete();

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/MavenConfigService.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/MavenConfigService.java
@@ -17,8 +17,8 @@
 package org.apache.karaf.bundle.core.internal;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Dictionary;
 
 import javax.xml.stream.XMLInputFactory;
@@ -76,20 +76,20 @@ public class MavenConfigService {
             if (path == null) {
                 String settings = (String) dict.get("org.ops4j.pax.url.mvn.settings");
                 if (settings != null) {
-                    path = getLocalRepositoryFromSettings(new File(settings));
+                    path = getLocalRepositoryFromSettings(Path.of(settings));
                 }
             }
         }
         return path;
     }
 
-	private static String getLocalRepositoryFromSettings(File file) {
+	private static String getLocalRepositoryFromSettings(Path file) {
 		XMLStreamReader reader = null;
-		try (InputStream fin = new FileInputStream(file)) {
+		try (var is = Files.newInputStream(file)) {
 			XMLInputFactory factory = XMLInputFactory.newFactory();
 			factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 			factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-			reader = factory.createXMLStreamReader(fin);
+			reader = factory.createXMLStreamReader(is);
 		    int event;
 		    String elementName = null;
 		    while ((event = reader.next()) != XMLStreamConstants.END_DOCUMENT) {

--- a/client/src/main/java/org/apache/karaf/client/Main.java
+++ b/client/src/main/java/org/apache/karaf/client/Main.java
@@ -19,13 +19,13 @@ package org.apache.karaf.client;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.Console;
-import java.io.FileInputStream;
 import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.Reader;
 import java.lang.reflect.Proxy;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.time.Duration;
@@ -76,7 +76,7 @@ public class Main {
         if (config.getFile() != null) {
             StringBuilder sb = new StringBuilder();
             sb.setLength(0);
-            try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(config.getFile())))) {
+            try (var reader = Files.newBufferedReader(Path.of(config.getFile()))) {
                 for (int c = reader.read(); c >= 0; c = reader.read()) {
                     sb.append((char) c);
                 }
@@ -85,7 +85,7 @@ public class Main {
         } else if (config.isBatch()) {
             StringBuilder sb = new StringBuilder();
             sb.setLength(0);
-            Reader reader = new BufferedReader(new InputStreamReader(System.in));
+            var reader = new BufferedReader(new InputStreamReader(System.in));
             for (int c = reader.read(); c >= 0; c = reader.read()) {
                 sb.append((char) c);
             }
@@ -106,6 +106,7 @@ public class Main {
                     public void welcome(ClientSession s, String banner, String lang) {
                         System.out.println(banner);
                     }
+
                     @Override
                     public String[] interactive(ClientSession s, String name, String instruction, String lang, String[] prompt, boolean[] echo) {
                         String[] answers = new String[prompt.length];
@@ -125,13 +126,16 @@ public class Main {
                             return null;
                         }
                     }
+
                     @Override
                     public boolean isInteractionAllowed(ClientSession session) {
                         return true;
                     }
+
                     @Override
                     public void serverVersionInfo(ClientSession session, List<String> lines) {
                     }
+
                     @Override
                     public String getUpdatedPassword(ClientSession session, String prompt, String lang) {
                         return null;

--- a/config/command/src/main/java/org/apache/karaf/config/command/InstallCommand.java
+++ b/config/command/src/main/java/org/apache/karaf/config/command/InstallCommand.java
@@ -21,14 +21,11 @@ import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
-import org.apache.karaf.util.StreamUtils;
 
-import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 
 @Command(scope = "config", name = "install", description = "Install a cfg file in the Karaf etc folder.")
 @Service
@@ -60,7 +57,7 @@ public class InstallCommand implements Action {
             System.out.println("Creating configuration file " + finalname);
         }
 
-        try (InputStream is = new BufferedInputStream(new URL(url).openStream())) {
+        try (var is = new URL(url).openStream()) {
             if (!file.exists()) {
                 File parentFile = file.getParentFile();
                 if (parentFile != null) {
@@ -68,9 +65,7 @@ public class InstallCommand implements Action {
                 }
                 file.createNewFile();
             }
-            try (FileOutputStream fop = new FileOutputStream(file)) {
-                StreamUtils.copy(is, fop);
-            }
+            Files.copy(is, file.toPath());
         } catch (RuntimeException | MalformedURLException e) {
             throw e;
         }

--- a/config/core/src/main/java/org/apache/karaf/config/core/impl/ConfigMBeanImpl.java
+++ b/config/core/src/main/java/org/apache/karaf/config/core/impl/ConfigMBeanImpl.java
@@ -13,9 +13,11 @@
  */
 package org.apache.karaf.config.core.impl;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.HashMap;
@@ -31,7 +33,6 @@ import javax.management.StandardMBean;
 import org.apache.felix.utils.properties.TypedProperties;
 import org.apache.karaf.config.core.ConfigMBean;
 import org.apache.karaf.config.core.ConfigRepository;
-import org.apache.karaf.util.StreamUtils;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
 
@@ -96,7 +97,7 @@ public class ConfigMBeanImpl extends StandardMBean implements ConfigMBean {
                 }
             }
 
-            try (InputStream is = new BufferedInputStream(new URL(url).openStream())) {
+            try (var is = new URL(url).openStream()) {
                 if (!file.exists()) {
                     File parentFile = file.getParentFile();
                     if (parentFile != null) {
@@ -104,9 +105,7 @@ public class ConfigMBeanImpl extends StandardMBean implements ConfigMBean {
                     }
                     file.createNewFile();
                 }
-                try (FileOutputStream fop = new FileOutputStream(file)) {
-                    StreamUtils.copy(is, fop);
-                }
+                Files.copy(is, file.toPath());
             } catch (RuntimeException | MalformedURLException e) {
                 throw e;
             }

--- a/config/core/src/main/java/org/apache/karaf/config/core/impl/ConfigRepositoryImpl.java
+++ b/config/core/src/main/java/org/apache/karaf/config/core/impl/ConfigRepositoryImpl.java
@@ -17,7 +17,6 @@
 package org.apache.karaf.config.core.impl;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -128,7 +127,7 @@ public class ConfigRepositoryImpl implements ConfigRepository {
         return true;
     }
 
-    private File getCfgFileFromProperties(Dictionary<String, Object> properties) throws URISyntaxException, MalformedURLException {
+    private static File getCfgFileFromProperties(Dictionary<String, Object> properties) throws URISyntaxException, MalformedURLException {
         if (properties != null) {
             Object val = properties.get(FILEINSTALL_FILE_NAME);
             return getCfgFileFromProperty(val);
@@ -136,7 +135,7 @@ public class ConfigRepositoryImpl implements ConfigRepository {
         return null;
     }
 
-    private File getCfgFileFromProperty(Object val) throws URISyntaxException, MalformedURLException {
+    private static File getCfgFileFromProperty(Object val) throws URISyntaxException, MalformedURLException {
         if (val instanceof URL) {
             return new File(((URL) val).toURI());
         }
@@ -227,7 +226,9 @@ public class ConfigRepositoryImpl implements ConfigRepository {
     static TypedProperties load(File file) throws IOException {
         TypedProperties props = new TypedProperties();
         if (file.toURI().toString().endsWith(".json")) {
-            Hashtable<String, Object> configuration = Configurations.buildReader().build(new FileReader(file)).readConfiguration();
+            Hashtable<String, Object> configuration = Configurations.buildReader()
+                .build(Files.newBufferedReader(file.toPath()))
+                .readConfiguration();
             for (String key : configuration.keySet()) {
                 props.put(key, configuration.get(key));
             }
@@ -239,7 +240,7 @@ public class ConfigRepositoryImpl implements ConfigRepository {
 
     void store(TypedProperties properties, File file) throws IOException {
         if (file.toURI().toString().endsWith(".json")) {
-            Configurations.buildWriter().build(new FileWriter(file)).writeConfiguration(new Hashtable<>(properties));
+            Configurations.buildWriter().build(Files.newBufferedWriter(file.toPath())).writeConfiguration(new Hashtable<>(properties));
         } else {
             properties.save(file);
         }

--- a/config/core/src/main/java/org/apache/karaf/config/core/impl/JsonConfigInstaller.java
+++ b/config/core/src/main/java/org/apache/karaf/config/core/impl/JsonConfigInstaller.java
@@ -30,12 +30,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
@@ -61,7 +61,7 @@ public class JsonConfigInstaller implements ArtifactInstaller, ConfigurationList
         return artifact.getName().endsWith("." + getExtension());
     }
 
-    private String getExtension() {
+    private static String getExtension() {
         String extension = (System.getenv(EXT_ENV_VAR) != null) ? System.getenv(EXT_ENV_VAR) : null;
         extension = (System.getProperty(EXT_SYS_PROP) != null) ? System.getProperty(EXT_SYS_PROP) : extension;
         if (extension == null) {
@@ -91,7 +91,9 @@ public class JsonConfigInstaller implements ArtifactInstaller, ConfigurationList
         Configuration configuration = getConfiguration(toConfigKey(artifact), configurationPID);
         Dictionary<String, Object> props = configuration.getProperties();
         Hashtable<String, Object> old = props != null ? new Hashtable<>(new DictionaryAsMap<>(props)) : null;
-        Hashtable<String, Object> properties = Configurations.buildReader().build(new FileReader(artifact)).readConfiguration();
+        Hashtable<String, Object> properties = Configurations.buildReader()
+            .build(Files.newBufferedReader(artifact.toPath()))
+            .readConfiguration();
         if (old != null) {
             old.remove(DirectoryWatcher.FILENAME);
             old.remove(Constants.SERVICE_PID);
@@ -162,7 +164,7 @@ public class JsonConfigInstaller implements ArtifactInstaller, ConfigurationList
         }
     }
 
-    private File getCfgFileFromProperty(Object val) throws URISyntaxException, MalformedURLException {
+    private static File getCfgFileFromProperty(Object val) throws URISyntaxException, MalformedURLException {
         if (val instanceof URL) {
             return new File(((URL) val).toURI());
         }
@@ -210,7 +212,7 @@ public class JsonConfigInstaller implements ArtifactInstaller, ConfigurationList
         }
     }
 
-    private String escapeFilterValue(String s) {
+    private static String escapeFilterValue(String s) {
         return s.replaceAll("[(]", "\\\\(").
                 replaceAll("[)]", "\\\\)").
                 replaceAll("[=]", "\\\\=").

--- a/config/core/src/test/java/org/apache/karaf/config/core/impl/ConfigMBeanImplTest.java
+++ b/config/core/src/test/java/org/apache/karaf/config/core/impl/ConfigMBeanImplTest.java
@@ -16,9 +16,8 @@ package org.apache.karaf.config.core.impl;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.nio.file.Files;
 
 public class ConfigMBeanImplTest {
 
@@ -44,10 +43,11 @@ public class ConfigMBeanImplTest {
         Assert.assertTrue(output.exists());
 
         StringBuilder builder = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new FileReader(output));
-        String line = null;
-        while ((line = reader.readLine()) != null) {
-            builder.append(line).append("\n");
+        try (var reader = Files.newBufferedReader(output.toPath())) {
+            String line = null;
+            while ((line = reader.readLine()) != null) {
+                builder.append(line).append("\n");
+            }
         }
         Assert.assertTrue(builder.toString().contains("foo=bar"));
     }

--- a/deployer/blueprint/src/test/java/org/apache/karaf/deployer/blueprint/BlueprintDeploymentListenerTest.java
+++ b/deployer/blueprint/src/test/java/org/apache/karaf/deployer/blueprint/BlueprintDeploymentListenerTest.java
@@ -18,10 +18,7 @@
 package org.apache.karaf.deployer.blueprint;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.jar.JarInputStream;
@@ -32,8 +29,8 @@ import javax.xml.transform.dom.DOMSource;
 import junit.framework.TestCase;
 
 public class BlueprintDeploymentListenerTest extends TestCase {
-	
-	private static final String BLUEPRINT_ENTRY = "OSGI-INF/blueprint/";
+
+    private static final String BLUEPRINT_ENTRY = "OSGI-INF/blueprint/";
 
     public void testPackagesExtraction() throws Exception {
         BlueprintDeploymentListener l = new BlueprintDeploymentListener();
@@ -48,13 +45,12 @@ public class BlueprintDeploymentListenerTest extends TestCase {
     public void testCustomManifest() throws Exception {
         File f = File.createTempFile("smx", ".jar");
         try {
-            OutputStream os = new FileOutputStream(f);
-            BlueprintTransformer.transform(getClass().getClassLoader().getResource("test.xml"), os);
-            os.close();
-            InputStream is = new FileInputStream(f);
-            JarInputStream jar = new JarInputStream(is);
-            jar.getManifest().write(System.err);
-            is.close();
+            try (var os = Files.newOutputStream(f.toPath())) {
+                BlueprintTransformer.transform(getClass().getClassLoader().getResource("test.xml"), os);
+            }
+            try (var jar = new JarInputStream(Files.newInputStream(f.toPath()))) {
+                jar.getManifest().write(System.err);
+            }
         } finally {
             f.delete();
         }
@@ -62,58 +58,54 @@ public class BlueprintDeploymentListenerTest extends TestCase {
 
     // KARAF-1617
     public void testAppendDescriptorFileExtension() throws Exception {
-    	final String expectedFileName = "test-fileextension";
+        final String expectedFileName = "test-fileextension";
         File f = File.createTempFile("smx", ".jar");
         try {
-        	ZipEntry zipEntry = null;
-            OutputStream os = new FileOutputStream(f);
-			BlueprintTransformer.transform(getClass().getClassLoader().getResource(expectedFileName), os);
-            os.close();
-            InputStream is = new FileInputStream(f);
-            JarInputStream jar = new JarInputStream(is);
-            while(true) {
-                zipEntry = jar.getNextEntry();
-                if( null == zipEntry) {
-                    break;
-                }
-                if ( zipEntry.getName() != null && zipEntry.getName().contains(expectedFileName)) {
-                	break;
+            try (var os = Files.newOutputStream(f.toPath())) {
+                BlueprintTransformer.transform(getClass().getClassLoader().getResource(expectedFileName), os);
+            }
+            ZipEntry zipEntry = null;
+            try (var jar = new JarInputStream(Files.newInputStream(f.toPath()))) {
+                while (true) {
+                    zipEntry = jar.getNextEntry();
+                    if (zipEntry == null) {
+                        break;
+                    }
+                    if (zipEntry.getName() != null && zipEntry.getName().contains(expectedFileName)) {
+                        break;
+                    }
                 }
             }
-            is.close();
-            assertNotNull("blueprint service descriptor JAR file entry",zipEntry);
-        	assertEquals(BLUEPRINT_ENTRY+expectedFileName+".xml",zipEntry.getName());
+            assertNotNull("blueprint service descriptor JAR file entry", zipEntry);
+            assertEquals(BLUEPRINT_ENTRY + expectedFileName + ".xml", zipEntry.getName());
         } finally {
             f.delete();
         }
-        
     }
 
     public void testAppendNotTwiceDescriptorFileExtension() throws Exception {
-    	final String expectedFileName = "test.xml";
+        final String expectedFileName = "test.xml";
         File f = File.createTempFile("smx", ".jar");
         try {
-        	ZipEntry zipEntry = null;
-            OutputStream os = new FileOutputStream(f);
-			BlueprintTransformer.transform(getClass().getClassLoader().getResource(expectedFileName), os);
-            os.close();
-            InputStream is = new FileInputStream(f);
-            JarInputStream jar = new JarInputStream(is);
-            while(true) {
-                zipEntry = jar.getNextEntry();
-                if( null == zipEntry) {
-                    break;
-                }
-                if ( zipEntry.getName() != null && zipEntry.getName().contains(expectedFileName)) {
-                	break;
+            try (var os = Files.newOutputStream(f.toPath())) {
+                BlueprintTransformer.transform(getClass().getClassLoader().getResource(expectedFileName), os);
+            }
+            ZipEntry zipEntry = null;
+            try (var jar = new JarInputStream(Files.newInputStream(f.toPath()))) {
+                while (true) {
+                    zipEntry = jar.getNextEntry();
+                    if (zipEntry == null) {
+                        break;
+                    }
+                    if (zipEntry.getName() != null && zipEntry.getName().contains(expectedFileName)) {
+                        break;
+                    }
                 }
             }
-            is.close();
-            assertNotNull("blueprint service descriptor JAR file entry",zipEntry);
-        	assertEquals(BLUEPRINT_ENTRY+expectedFileName,zipEntry.getName());
+            assertNotNull("blueprint service descriptor JAR file entry", zipEntry);
+            assertEquals(BLUEPRINT_ENTRY + expectedFileName, zipEntry.getName());
         } finally {
             f.delete();
         }
-        
     }
 }

--- a/deployer/features/src/main/java/org/apache/karaf/deployer/features/FeatureDeploymentListener.java
+++ b/deployer/features/src/main/java/org/apache/karaf/deployer/features/FeatureDeploymentListener.java
@@ -16,9 +16,11 @@
  */
 package org.apache.karaf.deployer.features;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -112,8 +114,8 @@ public class FeatureDeploymentListener implements ArtifactUrlTransformer, Bundle
         File file = getPropertiesFile();
         if (file != null) {
             if (file.exists()) {
-                try (InputStream input = new FileInputStream(file)) {
-                    properties.load(input);
+                try (var is = Files.newInputStream(file.toPath())) {
+                    properties.load(is);
                 }
             }
         }
@@ -122,8 +124,8 @@ public class FeatureDeploymentListener implements ArtifactUrlTransformer, Bundle
     private void saveProperties() throws IOException {
         File file = getPropertiesFile();
         if (file != null) {
-            try (OutputStream output = new FileOutputStream(file)) {
-                properties.store(output, null);
+            try (var os = Files.newOutputStream(file.toPath())) {
+                properties.store(os, null);
             }
         }
     }
@@ -141,7 +143,7 @@ public class FeatureDeploymentListener implements ArtifactUrlTransformer, Bundle
     public boolean canHandle(File artifact) {
         try {
             if (artifact.isFile() && artifact.getName().endsWith(".json")) {
-                try (BufferedReader reader = new BufferedReader(new FileReader(artifact))) {
+                try (var reader = Files.newBufferedReader(artifact.toPath())) {
                     String line;
                     while ((line = reader.readLine()) != null) {
                         if (line.contains("\"feature\"")) {
@@ -269,7 +271,7 @@ public class FeatureDeploymentListener implements ArtifactUrlTransformer, Bundle
             xif.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
             xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
         }
-        try (InputStream is = new FileInputStream(artifact)) {
+        try (var is = Files.newInputStream(artifact.toPath())) {
             XMLStreamReader sr = xif.createXMLStreamReader(is);
             sr.nextTag();
             return sr.getName();

--- a/deployer/features/src/main/java/org/apache/karaf/deployer/features/FeatureTransformer.java
+++ b/deployer/features/src/main/java/org/apache/karaf/deployer/features/FeatureTransformer.java
@@ -17,7 +17,6 @@
  */
 package org.apache.karaf.deployer.features;
 
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.util.jar.JarFile;
@@ -26,7 +25,6 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
 import org.apache.karaf.util.DeployerUtils;
-import org.apache.karaf.util.StreamUtils;
 import org.osgi.framework.Constants;
 
 /**
@@ -49,25 +47,23 @@ public class FeatureTransformer {
         m.getMainAttributes().putValue(Constants.BUNDLE_SYMBOLICNAME, str[0]);
         m.getMainAttributes().putValue(Constants.BUNDLE_VERSION, str[1]);
         // Put content
-        JarOutputStream out = new JarOutputStream(os);
-        ZipEntry e = new ZipEntry(JarFile.MANIFEST_NAME);
-        out.putNextEntry(e);
-        m.write(out);
-        out.closeEntry();
-        e = new ZipEntry("META-INF/");
-        out.putNextEntry(e);
-        e = new ZipEntry("META-INF/" + FeatureDeploymentListener.FEATURE_PATH + "/");
-        out.putNextEntry(e);
-        out.closeEntry();
-        e = new ZipEntry("META-INF/" + FeatureDeploymentListener.FEATURE_PATH + "/" + name);
-        out.putNextEntry(e);
-        try (
-            InputStream fis = url.openStream()
-        ) {
-            StreamUtils.copy(fis, out);
+        try (var out = new JarOutputStream(os)) {
+            ZipEntry e = new ZipEntry(JarFile.MANIFEST_NAME);
+            out.putNextEntry(e);
+            m.write(out);
+            out.closeEntry();
+            e = new ZipEntry("META-INF/");
+            out.putNextEntry(e);
+            e = new ZipEntry("META-INF/" + FeatureDeploymentListener.FEATURE_PATH + "/");
+            out.putNextEntry(e);
+            out.closeEntry();
+            e = new ZipEntry("META-INF/" + FeatureDeploymentListener.FEATURE_PATH + "/" + name);
+            out.putNextEntry(e);
+            try (var is = url.openStream()) {
+                is.transferTo(out);
+            }
+            out.closeEntry();
         }
-        out.closeEntry();
-        out.close();
         os.close();
     }
 

--- a/deployer/kar/src/test/java/org/apache/karaf/deployer/kar/KarArtifactInstallerTest.java
+++ b/deployer/kar/src/test/java/org/apache/karaf/deployer/kar/KarArtifactInstallerTest.java
@@ -18,15 +18,16 @@
  */
 package org.apache.karaf.deployer.kar;
 
-import static org.easymock.EasyMock.*;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
+import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.FileVisitResult;
@@ -58,7 +59,7 @@ public class KarArtifactInstallerTest {
 		File karFile = new File("target/test-classes/goodKarFile.kar");
 		karFile.getParentFile().mkdirs();
 
-		URL karFileResource = getClass().getClassLoader().getResource("goodKarFile");	
+		URL karFileResource = getClass().getClassLoader().getResource("goodKarFile");
 		File karFileSourceDir = new File(karFileResource.toURI());
 		createJarFromFolder(karFileSourceDir.toPath(), karFile);
 
@@ -69,8 +70,7 @@ public class KarArtifactInstallerTest {
 		zipFile.getParentFile().mkdirs();
 
 		URL karFileAsZipResource = getClass().getClassLoader().getResource("karFileAsZip");
-		File karFileAsZipSourceDir = new File(karFileAsZipResource.toURI());
-		createZipFromFolder(karFileAsZipSourceDir.toPath(), zipFile);
+		createZipFromFolder(Path.of(karFileAsZipResource.toURI()), zipFile);
 
 		zipFileWithKarafManifest = zipFile.toURI();
 
@@ -79,35 +79,24 @@ public class KarArtifactInstallerTest {
 		zipFileWithoutKarafManifestFile.getParentFile().mkdirs();
 
 		URL karFileAsZipNoManifestResource = getClass().getClassLoader().getResource("karFileAsZipNoManifest");
-		File karFileAsZipNoManifestSourceDir = new File(karFileAsZipNoManifestResource.toURI());
-		createZipFromFolder(karFileAsZipNoManifestSourceDir.toPath(), zipFileWithoutKarafManifestFile);
+		createZipFromFolder(Path.of(karFileAsZipNoManifestResource.toURI()), zipFileWithoutKarafManifestFile);
 
 		zipFileWithoutKarafManifest = zipFileWithoutKarafManifestFile.toURI();
 
 		// create badZipFile.zip
-		File badZipFileFile = new File("target/test-classes/badZipFile.zip");
-		
-		try (FileOutputStream fos = new FileOutputStream(badZipFileFile)) {
-			fos.write("Not a valid zip file".getBytes());
-		}
-
-		badZipFile = badZipFileFile.toURI();
+		Path badZipFileFile = Path.of("target/test-classes/badZipFile.zip");
+		Files.writeString(badZipFileFile, "Not a valid zip file");
+		badZipFile = badZipFileFile.toUri();
 	}
 
 	private static void createJarFromFolder(Path sourceDir, File jarFile) throws Exception {
-		try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarFile))) {
+		try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarFile.toPath()))) {
 			Files.walkFileTree(sourceDir, new SimpleFileVisitor<Path>() {
 				@Override
 				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 					String entryName = sourceDir.relativize(file).toString().replace(File.separator, "/");
 					jos.putNextEntry(new ZipEntry(entryName));
-					try (InputStream in = new FileInputStream(file.toFile())) {
-						byte[] buf = new byte[4096];
-						int len;
-						while ((len = in.read(buf)) > 0) {
-							jos.write(buf, 0, len);
-						}
-					}
+					Files.copy(file, jos);
 					jos.closeEntry();
 					return FileVisitResult.CONTINUE;
 				}
@@ -116,19 +105,13 @@ public class KarArtifactInstallerTest {
 	}
 
 	private static void createZipFromFolder(Path sourceDir, File zipFile) throws Exception {
-		try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))) {
+		try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zipFile.toPath()))) {
 			Files.walkFileTree(sourceDir, new SimpleFileVisitor<Path>() {
 				@Override
 				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 					String entryName = sourceDir.relativize(file).toString().replace(File.separator, "/");
 					zos.putNextEntry(new ZipEntry(entryName));
-					try (InputStream in = new FileInputStream(file.toFile())) {
-						byte[] buf = new byte[4096];
-						int len;
-						while ((len = in.read(buf)) > 0) {
-							zos.write(buf, 0, len);
-						}
-					}
+					Files.copy(file, zos);
 					zos.closeEntry();
 					return FileVisitResult.CONTINUE;
 				}
@@ -145,7 +128,7 @@ public class KarArtifactInstallerTest {
 		karArtifactInstaller = new KarArtifactInstaller();
 
 		karArtifactInstaller.setKarService(karService);
-		
+
 		zipFileWithKarafManifest = getClass().getClassLoader().getResource("karFileAsZip.zip").toURI();
 		zipFileWithoutKarafManifest = getClass().getClassLoader().getResource("karFileAsZipNoManifest.zip").toURI();
 		badZipFile = getClass().getClassLoader().getResource("badZipFile.zip").toURI();
@@ -155,19 +138,19 @@ public class KarArtifactInstallerTest {
 	public void shouldHandleKarFile() throws Exception {
 		assertTrue(karArtifactInstaller.canHandle(new File(goodKarFile)));
 	}
-	
+
 	@Test
 	public void shouldHandleZipFileWithKarafManifest() throws Exception {
 		assertTrue(karArtifactInstaller.canHandle(new File(zipFileWithKarafManifest)));
 	}
 
 	@Test
-	public void shouldIgnoreZipFileWithoutKarafManifest() throws Exception { 		
+	public void shouldIgnoreZipFileWithoutKarafManifest() throws Exception {
 		assertFalse(karArtifactInstaller.canHandle(new File(zipFileWithoutKarafManifest)));
 	}
 
 	@Test
-	public void shouldIgnoreBadZipFile() throws Exception { 		
+	public void shouldIgnoreBadZipFile() throws Exception {
 		assertFalse(karArtifactInstaller.canHandle(new File(badZipFile)));
 	}
 

--- a/deployer/spring/src/main/java/org/apache/karaf/deployer/spring/SpringDeploymentListener.java
+++ b/deployer/spring/src/main/java/org/apache/karaf/deployer/spring/SpringDeploymentListener.java
@@ -18,9 +18,9 @@
 package org.apache.karaf.deployer.spring;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
@@ -37,11 +37,11 @@ import org.slf4j.LoggerFactory;
  * and creates bundles for these.
  */
 public class SpringDeploymentListener implements ArtifactUrlTransformer {
-	private static final QName SPRING_DM_ROOT = new QName("http://www.springframework.org/schema/beans", "beans");
+    private static final QName SPRING_DM_ROOT = new QName("http://www.springframework.org/schema/beans", "beans");
 
     private final Logger logger = LoggerFactory.getLogger(SpringDeploymentListener.class);
-	private XMLInputFactory factory;
-	
+    private XMLInputFactory factory;
+
     public boolean canHandle(File artifact) {
         try {
             if (artifact.isFile() && artifact.getName().endsWith(".xml")) {
@@ -65,32 +65,32 @@ public class SpringDeploymentListener implements ArtifactUrlTransformer {
         }
     }
 
-	protected StartElement getRootElement(File artifact) throws Exception {
-    	XMLEventReader parser = null;
-    	InputStream in = null;
-    	try {
-			if (factory == null) {
-				factory = XMLInputFactory.newInstance();
-				factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-				factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-			}
-			in = new FileInputStream(artifact);
-			parser = factory.createXMLEventReader(in);
-			while (parser.hasNext()) {
-				XMLEvent event = parser.nextEvent();
-				if (event.isStartElement()) {
-					return event.asStartElement();
-				}
-			}
-			return null;
-		} finally {
-			if (parser != null) {
-				parser.close();
-			}
-			if (in != null) {
-				in.close();
-			}
-		}
+    protected StartElement getRootElement(File artifact) throws Exception {
+        XMLEventReader parser = null;
+        InputStream in = null;
+        try {
+            if (factory == null) {
+                factory = XMLInputFactory.newInstance();
+                factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            }
+            in = Files.newInputStream(artifact.toPath());
+            parser = factory.createXMLEventReader(in);
+            while (parser.hasNext()) {
+                XMLEvent event = parser.nextEvent();
+                if (event.isStartElement()) {
+                    return event.asStartElement();
+                }
+            }
+            return null;
+        } finally {
+            if (parser != null) {
+                parser.close();
+            }
+            if (in != null) {
+                in.close();
+            }
+        }
     }
 
 }

--- a/deployer/spring/src/test/java/org/apache/karaf/deployer/spring/SpringDeploymentListenerTest.java
+++ b/deployer/spring/src/test/java/org/apache/karaf/deployer/spring/SpringDeploymentListenerTest.java
@@ -18,10 +18,7 @@
 package org.apache.karaf.deployer.spring;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.jar.JarInputStream;
@@ -45,13 +42,12 @@ public class SpringDeploymentListenerTest extends TestCase {
     public void testCustomManifest() throws Exception {
         File f = File.createTempFile("smx", ".jar");
         try {
-            OutputStream os = new FileOutputStream(f);
-            SpringTransformer.transform(getClass().getClassLoader().getResource("test.xml"), os);
-            os.close();
-            InputStream is = new FileInputStream(f);
-            JarInputStream jar = new JarInputStream(is);
-            jar.getManifest().write(System.err);
-            is.close();
+            try (var os = Files.newOutputStream(f.toPath())) {
+                SpringTransformer.transform(getClass().getClassLoader().getResource("test.xml"), os);
+            }
+            try (var jar = new JarInputStream(Files.newInputStream(f.toPath()))) {
+                jar.getManifest().write(System.err);
+            }
         } finally {
             f.delete();
         }

--- a/diagnostic/boot/src/main/java/org/apache/karaf/diagnostic/core/common/DirectoryDumpDestination.java
+++ b/diagnostic/boot/src/main/java/org/apache/karaf/diagnostic/core/common/DirectoryDumpDestination.java
@@ -16,8 +16,8 @@
 package org.apache.karaf.diagnostic.core.common;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 
 import org.apache.karaf.diagnostic.core.DumpDestination;
 
@@ -36,7 +36,7 @@ public class DirectoryDumpDestination implements DumpDestination {
 
 		if (!file.exists()) {
 			file.mkdirs();
-		} 
+		}
 	}
 
 	public OutputStream add(String name) throws Exception {
@@ -45,7 +45,7 @@ public class DirectoryDumpDestination implements DumpDestination {
 			// if name contains slashes we need to create sub directory
 			destination.getParentFile().mkdirs();
 		}
-		return new FileOutputStream(destination);
+		return Files.newOutputStream(destination.toPath());
 	}
 
 	public void save() throws Exception {

--- a/diagnostic/boot/src/main/java/org/apache/karaf/diagnostic/core/common/ZipDumpDestination.java
+++ b/diagnostic/boot/src/main/java/org/apache/karaf/diagnostic/core/common/ZipDumpDestination.java
@@ -16,9 +16,10 @@
 package org.apache.karaf.diagnostic.core.common;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -53,12 +54,11 @@ public class ZipDumpDestination implements DumpDestination {
     public ZipDumpDestination(File file) {
         try {
             this.file = file;
-            outputStream = new ZipOutputStream(new FileOutputStream(
-                file));
-        } catch (FileNotFoundException e) {
+            outputStream = new ZipOutputStream(Files.newOutputStream(file.toPath()));
+        } catch (IOException e) {
             // sometimes this can occur, but we simply re throw and let 
             // caller handle exception
-            throw new RuntimeException("Unable to create dump destination", e);
+            throw new UncheckedIOException("Unable to create dump destination", e);
         }
     }
 

--- a/diagnostic/boot/src/main/java/org/apache/karaf/diagnostic/core/providers/HeapDumpProvider.java
+++ b/diagnostic/boot/src/main/java/org/apache/karaf/diagnostic/core/providers/HeapDumpProvider.java
@@ -21,7 +21,7 @@ import org.apache.karaf.diagnostic.core.DumpProvider;
 
 import javax.management.MBeanServer;
 import java.io.File;
-import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
@@ -34,7 +34,7 @@ public class HeapDumpProvider implements DumpProvider {
 
     public void createDump(DumpDestination destination) throws Exception {
         File heapDumpFile = null;
-        FileInputStream in = null;
+        InputStream in = null;
         OutputStream out = null;
         try {
             MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
@@ -49,7 +49,7 @@ public class HeapDumpProvider implements DumpProvider {
             method.invoke(diagnosticMXBean, heapDumpFile.getAbsolutePath(), false);
 
             // copy the dump in the destination
-            in = new FileInputStream(heapDumpFile);
+            in = Files.newInputStream(heapDumpFile.toPath());
             out = destination.add("heapdump.hprof");
             byte[] buffer = new byte[2048];
             int l;

--- a/features/core/src/main/java/org/apache/karaf/features/internal/download/impl/AbstractDownloadTask.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/download/impl/AbstractDownloadTask.java
@@ -17,9 +17,9 @@
 package org.apache.karaf.features.internal.download.impl;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.karaf.features.internal.download.StreamProvider;
@@ -51,7 +51,7 @@ public abstract class AbstractDownloadTask extends DefaultFuture<AbstractDownloa
 
     @Override
     public InputStream open() throws IOException {
-        return new FileInputStream(getFile());
+        return Files.newInputStream(getFile().toPath());
     }
 
     public void setFile(File file) {

--- a/features/core/src/main/java/org/apache/karaf/features/internal/download/impl/SimpleDownloadTask.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/download/impl/SimpleDownloadTask.java
@@ -17,15 +17,11 @@
 package org.apache.karaf.features.internal.download.impl;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.concurrent.ScheduledExecutorService;
 
-import org.apache.karaf.util.StreamUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,9 +71,8 @@ public class SimpleDownloadTask extends AbstractRetryableDownloadTask {
             File tmpFile = Files.createTempFile(dir.toPath(), "download-", null).toFile();
             
             urlObj = new URL(DownloadManagerHelper.stripStartLevel(urlObj.toString()));
-            try (InputStream is = urlObj.openStream();
-                 OutputStream os = new FileOutputStream(tmpFile)) {
-                StreamUtils.copy(is, os);
+            try (var is = urlObj.openStream()) {
+                Files.copy(is, tmpFile.toPath());
             }
 
             if (file.exists() && !file.delete()) {
@@ -112,10 +107,8 @@ public class SimpleDownloadTask extends AbstractRetryableDownloadTask {
         File dir = new File(System.getProperty("karaf.data"), "tmp");
         dir.mkdirs();
         File tmpFile = Files.createTempFile(dir.toPath(), "download-", null).toFile();
-        try (InputStream is = new URL(url).openStream();
-             OutputStream os = new FileOutputStream(tmpFile))
-        {
-            StreamUtils.copy(is, os);
+        try (var is = new URL(url).openStream()) {
+            Files.copy(is, tmpFile.toPath());
         }
         return tmpFile;
     }

--- a/features/core/src/main/java/org/apache/karaf/features/internal/osgi/Activator.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/osgi/Activator.java
@@ -17,12 +17,11 @@
 package org.apache.karaf.features.internal.osgi;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.Hashtable;
@@ -119,7 +118,7 @@ public class Activator extends BaseActivator {
         File configFile = new File(System.getProperty("karaf.etc"), FEATURES_SERVICE_CONFIG_FILE);
         if (configFile.isFile() && configFile.canRead()) {
             try {
-                configuration.load(new FileReader(configFile));
+                configuration.load(Files.newBufferedReader(configFile.toPath()));
             } catch (IOException e) {
                 logger.warn("Error reading configuration file " + configFile.toString(), e);
             }
@@ -268,18 +267,17 @@ public class Activator extends BaseActivator {
         StateStorage stateStorage = new StateStorage() {
             @Override
             protected InputStream getInputStream() throws IOException {
-                File file = bundleContext.getDataFile(STATE_FILE);
-                if (file.exists()) {
-                    return new FileInputStream(file);
-                } else {
-                    return null;
+                var file = bundleContext.getDataFile(STATE_FILE).toPath();
+                if (Files.exists(file)) {
+                    return Files.newInputStream(file);
                 }
+                return null;
             }
     
             @Override
             protected OutputStream getOutputStream() throws IOException {
-                File file = bundleContext.getDataFile(STATE_FILE);
-                return new FileOutputStream(file);
+                var file = bundleContext.getDataFile(STATE_FILE).toPath();
+                return Files.newOutputStream(file);
             }
         };
         return stateStorage;

--- a/features/core/src/main/java/org/apache/karaf/features/internal/region/DigraphHelper.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/region/DigraphHelper.java
@@ -20,11 +20,10 @@ import static org.apache.karaf.features.internal.util.MapUtils.addToMapSet;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -66,9 +65,7 @@ public final class DigraphHelper {
         if (digraphFile == null || !digraphFile.exists()) {
             digraph = new StandardRegionDigraph(bundleContext, threadLocal);
         } else {
-            try (
-                    InputStream in = new FileInputStream(digraphFile)
-            ) {
+            try (var in = Files.newInputStream(digraphFile.toPath())) {
                 digraph = readDigraph(new DataInputStream(in), bundleContext, threadLocal);
             }
         }
@@ -76,9 +73,7 @@ public final class DigraphHelper {
     }
 
     public static void saveDigraph(File outFile, RegionDigraph digraph) {
-        try (
-            FileOutputStream out = new FileOutputStream(outFile)
-        ) {
+        try (var out = Files.newOutputStream(outFile.toPath())) {
             saveDigraph(digraph, out);
         } catch (Exception e) {
             // Ignore

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/BundleInstallSupportImpl.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/BundleInstallSupportImpl.java
@@ -17,9 +17,9 @@
 package org.apache.karaf.features.internal.service;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -144,7 +144,7 @@ public class BundleInstallSupportImpl implements BundleInstallSupport {
         // We need to wrap the bundle to insert a Bundle-UpdateLocation header
         try {
             file = BundleUtils.fixBundleWithUpdateLocation(is, uri);
-            bundle.update(new FileInputStream(file));
+            bundle.update(Files.newInputStream(file.toPath()));
         } catch (IOException e) {
             throw new BundleException("Unable to update bundle", e);
         } finally {

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/Deployer.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/Deployer.java
@@ -16,12 +16,13 @@
  */
 package org.apache.karaf.features.internal.service;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1441,8 +1442,7 @@ public class Deployer {
                                         String jarUrl = ((URL) method.invoke(con)).toExternalForm();
                                         if (jarUrl.startsWith("jar:")) {
                                             String jar = jarUrl.substring("jar:".length(), jarUrl.indexOf("!/"));
-                                            jar = new URL(jar).getFile();
-                                            try (InputStream is = new FileInputStream(jar)) {
+                                            try (var is = Files.newInputStream(Path.of(new URL(jar).getFile()))) {
                                                 oldCrc = ChecksumUtils.checksum(is);
                                             }
                                             result.bundleChecksums.put(bundleId, oldCrc);

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
@@ -16,12 +16,20 @@
  */
 package org.apache.karaf.features.internal.service;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.apache.felix.cm.json.io.Configurations;
@@ -30,7 +38,6 @@ import org.apache.felix.utils.properties.TypedProperties;
 import org.apache.karaf.features.ConfigFileInfo;
 import org.apache.karaf.features.ConfigInfo;
 import org.apache.karaf.features.Feature;
-import org.apache.karaf.util.StreamUtils;
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
@@ -73,10 +80,10 @@ public class FeatureConfigInstaller {
         return cid;
     }
 
-    private Configuration createConfiguration(ConfigurationAdmin configurationAdmin, ConfigId cid)
+    private static Configuration createConfiguration(ConfigurationAdmin configurationAdmin, ConfigId cid)
         throws IOException, InvalidSyntaxException {
         if (cid.isFactoryPid) {
-            if (Objects.nonNull(cid.name)) {
+            if (cid.name != null) {
                 return configurationAdmin.getFactoryConfiguration(cid.factoryPid, cid.name, null);
             } else {
                 return configurationAdmin.createFactoryConfiguration(cid.factoryPid, null);
@@ -113,7 +120,8 @@ public class FeatureConfigInstaller {
             }
             if (JSON_PATTERN.matcher(configValue).matches()) {
                 // json format
-                properties = convertToTypedProperties(Configurations.buildReader().build(new StringReader(configValue)).readConfiguration());
+                properties = convertToTypedProperties(Configurations.buildReader().build(new StringReader(configValue))
+                    .readConfiguration());
                 jsonFormat = true;
             } else {
                 // properties format
@@ -173,12 +181,8 @@ public class FeatureConfigInstaller {
         }
     }
 
-    private String loadConfiguration(final URL url) throws IOException {
-        try (final InputStream inputStream = new BufferedInputStream(url.openStream())) {
-            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            StreamUtils.copy(inputStream, outputStream);
-            return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
-        }
+    private static String loadConfiguration(final URL url) throws IOException {
+        return new String(url.openStream().readAllBytes(), StandardCharsets.UTF_8);
     }
 
     public void uninstallFeatureConfigs(Feature feature) throws IOException, InvalidSyntaxException {
@@ -298,9 +302,7 @@ public class FeatureConfigInstaller {
         }
 
         // TODO: use download manager to download the configuration
-        try (
-                InputStream is = new BufferedInputStream(new URL(fileLocation).openStream())
-        ) {
+        try (var is = new URL(fileLocation).openStream()) {
             if (!file.exists()) {
                 File parentFile = file.getParentFile();
                 if (parentFile != null) {
@@ -308,11 +310,7 @@ public class FeatureConfigInstaller {
                 }
                 file.createNewFile();
             }
-            try (
-                    FileOutputStream fop = new FileOutputStream(file)
-            ) {
-                StreamUtils.copy(is, fop);
-            }
+            Files.copy(is, file.toPath());
         } catch (RuntimeException | MalformedURLException e) {
             LOGGER.error(e.getMessage());
             throw e;
@@ -326,7 +324,8 @@ public class FeatureConfigInstaller {
             if (!cfgFile.exists()) {
                 File tmpCfgFile = File.createTempFile(cfgFile.getName(), ".tmp", cfgFile.getParentFile());
                 if (jsonFormat) {
-                    Configurations.buildWriter().build(new FileWriter(tmpCfgFile)).writeConfiguration(convertToDict(props));
+                    Configurations.buildWriter().build(Files.newBufferedWriter(tmpCfgFile.toPath()))
+                        .writeConfiguration(convertToDict(props));
                 } else {
                     props.save(tmpCfgFile);
                 }
@@ -366,10 +365,13 @@ public class FeatureConfigInstaller {
         return cfgFile;
     }
 
-    private void updateExistingConfig(TypedProperties props, boolean append, File cfgFile, boolean jsonFormat) throws IOException {
+    private void updateExistingConfig(TypedProperties props, boolean append, File cfgFile, boolean jsonFormat)
+            throws IOException {
         TypedProperties properties = new TypedProperties();
         if (jsonFormat) {
-            properties = convertToTypedProperties(Configurations.buildReader().build(new FileReader(cfgFile)).readConfiguration());
+            properties = convertToTypedProperties(Configurations.buildReader()
+                .build(Files.newBufferedReader(cfgFile.toPath()))
+                .readConfiguration());
         } else {
             properties.load(cfgFile);
         }
@@ -401,13 +403,14 @@ public class FeatureConfigInstaller {
         }
         storage.mkdirs();
         if (jsonFormat) {
-            Configurations.buildWriter().build(new FileWriter(cfgFile)).writeConfiguration(new Hashtable(properties));
+            Configurations.buildWriter().build(Files.newBufferedWriter(cfgFile.toPath()))
+                .writeConfiguration(new Hashtable(properties));
         } else {
             properties.save(cfgFile);
         }
     }
 
-    private boolean isInternalKey(String key) {
+    private static boolean isInternalKey(String key) {
         return Constants.SERVICE_PID.equals(key)
             || ConfigurationAdmin.SERVICE_FACTORYPID.equals(key)
             || FILEINSTALL_FILE_NAME.equals(key);

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/FeaturesServiceImpl.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/FeaturesServiceImpl.java
@@ -17,12 +17,11 @@
 package org.apache.karaf.features.internal.service;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -173,9 +172,7 @@ public class FeaturesServiceImpl implements FeaturesService, Deployer.DeployCall
             return;
         }
         Map<String, Object> request;
-        try (
-                FileInputStream fis = new FileInputStream(resolveFile)
-        ) {
+        try (var fis = Files.newInputStream(resolveFile.toPath())) {
             request = (Map<String, Object>) JsonReader.read(fis);
         } catch (IOException e) {
             LOGGER.warn("Error reading resolution request", e);
@@ -205,9 +202,7 @@ public class FeaturesServiceImpl implements FeaturesService, Deployer.DeployCall
         }
         request.put("features", requestedFeatures);
         request.put("options", opts);
-        try (
-                FileOutputStream fos = new FileOutputStream(resolveFile)
-        ) {
+        try (var fos = Files.newOutputStream(resolveFile.toPath())) {
             JsonWriter.write(fos, request);
         }
     }

--- a/features/core/src/test/java/org/apache/karaf/features/AppendTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/AppendTest.java
@@ -23,9 +23,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Properties;
@@ -99,7 +99,7 @@ public class AppendTest {
         c.verify();
         assertEquals("data/pax-web-jsp", captured.getValue().get("jakarta.servlet.context.tempdir"));
         Properties props = new Properties();
-        props.load(new FileInputStream(cfgFile));
+        props.load(Files.newInputStream(cfgFile.toPath()));
         String v = props.getProperty("jakarta.servlet.context.tempdir");
         assertTrue("${karaf.data}/pax-web-jsp".equals(v) || "data/pax-web-jsp".equals(v));
 //        assertEquals("${karaf.data}/pax-web-jsp", props.getProperty("jakarta.servlet.context.tempdir"));

--- a/features/core/src/test/java/org/apache/karaf/features/internal/repository/RepositoryTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/repository/RepositoryTest.java
@@ -19,15 +19,12 @@
 package org.apache.karaf.features.internal.repository;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.zip.GZIPOutputStream;
 
 import org.apache.felix.utils.repository.BaseRepository;
-import org.apache.karaf.util.StreamUtils;
 import org.junit.Test;
 import org.osgi.resource.Resource;
 
@@ -80,13 +77,12 @@ public class RepositoryTest {
         assertEquals(1, resource.getRequirements(PACKAGE_NAMESPACE).size());
     }
 
-    private URL gzip(URL url) throws IOException {
+    private static URL gzip(URL url) throws IOException {
         File temp = File.createTempFile("repo", ".tmp");
-        try (
-            OutputStream os = new GZIPOutputStream(new FileOutputStream(temp));
-            InputStream is = url.openStream()
-        ) {
-            StreamUtils.copy(is, os);
+        try (var os = new GZIPOutputStream(Files.newOutputStream(temp.toPath()))) {
+            try (var is = url.openStream()) {
+                is.transferTo(os);
+            }
         }
         return temp.toURI().toURL();
     }

--- a/features/core/src/test/java/org/apache/karaf/features/internal/service/BlacklistTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/service/BlacklistTest.java
@@ -17,11 +17,11 @@
 package org.apache.karaf.features.internal.service;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.stream.Stream;
@@ -80,9 +80,8 @@ public class BlacklistTest {
             throw new RuntimeException(e);
         }
         File blacklistedProperties = File.createTempFile("blacklisted-", ".properties", new File("target"));
-        try (FileOutputStream fos = new FileOutputStream(blacklistedProperties)) {
-            fos.write(blacklistClause.getBytes(StandardCharsets.UTF_8));
-        }
+        Files.writeString(blacklistedProperties.toPath(), blacklistClause, StandardCharsets.UTF_8);
+
         RepositoryImpl features = new RepositoryImpl(uri, true);
         FeaturesServiceConfig config = new FeaturesServiceConfig(null, FeaturesService.DEFAULT_FEATURE_RESOLUTION_RANGE, FeaturesService.DEFAULT_BUNDLE_UPDATE_RANGE, null, 1, 0, 0, blacklistedProperties.toURI().toString(), null, null, null, true);
         features.processFeatures(new FeaturesProcessorImpl(config));

--- a/instance/src/main/java/org/apache/karaf/instance/core/internal/InstanceImpl.java
+++ b/instance/src/main/java/org/apache/karaf/instance/core/internal/InstanceImpl.java
@@ -18,7 +18,6 @@ package org.apache.karaf.instance.core.internal;
 
 import org.apache.karaf.instance.core.Instance;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -126,7 +125,7 @@ public class InstanceImpl implements Instance {
     public void packageInZip(String destination) throws Exception {
         Path sourcePath = Paths.get(getLocation());
         Path destinationPath = Paths.get(destination).normalize();
-        try (ZipOutputStream zOut = new ZipOutputStream(new FileOutputStream(destination.toString()))) {
+        try (ZipOutputStream zOut = new ZipOutputStream(Files.newOutputStream(destinationPath))) {
             Files.walkFileTree(sourcePath, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {

--- a/instance/src/main/java/org/apache/karaf/instance/core/internal/InstanceServiceImpl.java
+++ b/instance/src/main/java/org/apache/karaf/instance/core/internal/InstanceServiceImpl.java
@@ -16,13 +16,9 @@
  */
 package org.apache.karaf.instance.core.internal;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.Socket;
@@ -54,7 +50,6 @@ import org.apache.karaf.profile.Profile;
 import org.apache.karaf.profile.ProfileBuilder;
 import org.apache.karaf.profile.ProfileService;
 import org.apache.karaf.shell.support.ansi.SimpleAnsi;
-import org.apache.karaf.util.StreamUtils;
 import org.apache.karaf.util.config.PropertiesLoader;
 import org.apache.karaf.util.locks.FileLockUtils;
 import org.osgi.framework.BundleContext;
@@ -849,9 +844,8 @@ public class InstanceServiceImpl implements InstanceService {
             String portFile = props.getProperty(KARAF_SHUTDOWN_PORT_FILE);
             String shutdown = props.getProperty(KARAF_SHUTDOWN_COMMAND, DEFAULT_SHUTDOWN_COMMAND);
             if (port == 0 && portFile != null) {
-                try (BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(portFile)))) {
-                    String portStr = r.readLine();
-                    port = Integer.parseInt(portStr);
+                try (var reader = Files.newBufferedReader(Path.of(portFile))) {
+                    port = Integer.parseInt(reader.readLine());
                 }
             }
             // We found the port, try to send the command
@@ -1086,7 +1080,7 @@ public class InstanceServiceImpl implements InstanceService {
             logDebug("Creating file: %s", printOutput, outFile.getPath());
             try (
                 InputStream is = getResourceStream(resource, resources);
-                OutputStream os = new FileOutputStream(outFile)
+                OutputStream os = Files.newOutputStream(outFile.toPath())
             ) {
                 if (is == null) {
                     logInfo("\tWARNING: unable to find %s", true, resource);
@@ -1147,7 +1141,7 @@ public class InstanceServiceImpl implements InstanceService {
         // rename the file to the backup one
         file.renameTo(bak);
         // copy and filter the bak file back to the original name
-        copyAndFilterResource(new FileInputStream(bak), new FileOutputStream(file), props);
+        copyAndFilterResource(Files.newInputStream(bak.toPath()), Files.newOutputStream(file.toPath()), props);
         // remove the bak file
         bak.delete();
     }
@@ -1164,7 +1158,7 @@ public class InstanceServiceImpl implements InstanceService {
             logDebug("Creating file: %s", printOutput, outFile.getPath());
             try (
                 InputStream is = getResourceStream(resource, resources);
-                OutputStream os = new FileOutputStream(outFile)
+                OutputStream os = Files.newOutputStream(outFile.toPath())
             ) {
                 copyAndFilterResource(is, os, props);
             }
@@ -1187,11 +1181,8 @@ public class InstanceServiceImpl implements InstanceService {
         File outFile = new File(target, resource);
         if( !outFile.exists() ) {
             logDebug("Creating file: %s", printOutput, outFile.getPath());
-            try (
-                InputStream is = getResourceStream(resource, resources);
-                OutputStream os = new FileOutputStream(outFile)
-            ) {
-                StreamUtils.copy(is, os);
+            try (var is = getResourceStream(resource, resources)) {
+                Files.copy(is, outFile.toPath());
             }
         }
     }
@@ -1261,12 +1252,7 @@ public class InstanceServiceImpl implements InstanceService {
                     copy(new File(source, child), new File(destination, child));
             }
         } else {
-            try(
-                InputStream in = new FileInputStream(source);
-                OutputStream out = new FileOutputStream(destination)
-            ) {
-                StreamUtils.copy(in, out);
-            }
+            Files.copy(source.toPath(), destination.toPath());
         }
     }
 

--- a/instance/src/test/java/org/apache/karaf/instance/core/internal/InstanceServiceImplTest.java
+++ b/instance/src/test/java/org/apache/karaf/instance/core/internal/InstanceServiceImplTest.java
@@ -17,12 +17,9 @@
 package org.apache.karaf.instance.core.internal;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -63,18 +60,13 @@ public class InstanceServiceImplTest {
         Properties p = new Properties();
         p.put("featuresBoot", "abc,def ");
         p.put("featuresRepositories", "somescheme://xyz");
-        try (OutputStream os = new FileOutputStream(f)) {
-            p.store(os, "Test comment");
-        }
+        saveStorage(p, f, "Test comment");
 
         InstanceSettings s = new InstanceSettings(8122, 1122, 44444, null, null, null,
             Collections.singletonList("test"));
         as.addFeaturesFromSettings(f, s);
 
-        Properties p2 = new Properties();
-        try (InputStream is = new FileInputStream(f)) {
-            p2.load(is);
-        }
+        Properties p2 = loadStorage(f);
         assertEquals(2, p2.size());
         assertEquals("abc,def,test", p2.get("featuresBoot"));
         assertEquals("somescheme://xyz", p2.get("featuresRepositories"));
@@ -170,8 +162,7 @@ public class InstanceServiceImplTest {
         service.changeInstanceSshPort(getName(), 9999);
 
         File shellCfg = new File(new File(new File(storageLocation, getName()), "etc"), "org.apache.karaf.shell.cfg");
-        Properties props = new Properties();
-        props.load(new FileInputStream(shellCfg));
+        Properties props = loadStorage(shellCfg);
         assertEquals("9999", props.get("sshPort"));
     }
 
@@ -180,13 +171,13 @@ public class InstanceServiceImplTest {
     }
 
     private static void saveStorage(Properties props, File location, String comment) throws IOException {
-        try (OutputStream os = new FileOutputStream(location)) {
+        try (var os = Files.newOutputStream(location.toPath())) {
             props.store(os, comment);
         }
     }
     
     private static Properties loadStorage(File location) throws IOException {
-        try (InputStream is = new FileInputStream(location)) {
+        try (var is = Files.newInputStream(location.toPath())) {
             Properties props = new Properties();
             props.load(is);
             return props;

--- a/itests/test/src/test/java/org/apache/karaf/itests/examples/ServletExampleTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/examples/ServletExampleTest.java
@@ -28,13 +28,13 @@ import org.ops4j.pax.exam.spi.reactors.PerMethod;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.EnumSet;
 
 @RunWith(PaxExam.class)
@@ -141,10 +141,7 @@ public class ServletExampleTest extends BaseTest {
 
         // Build the entire multipart body as bytes to avoid PrintWriter/OutputStream mixing issues
         ByteArrayOutputStream body = new ByteArrayOutputStream();
-        byte[] fileContent;
-        try (FileInputStream fileInputStream = new FileInputStream(file)) {
-            fileContent = fileInputStream.readAllBytes();
-        }
+        byte[] fileContent = Files.readAllBytes(file.toPath());
         String header = "--" + boundary + "\r\n"
                 + "Content-Disposition: form-data; name=\"test\"; filename=\"test.txt\"\r\n"
                 + "Content-Type: text/plain; charset=UTF-8\r\n"

--- a/jaas/blueprint/jasypt/pom.xml
+++ b/jaas/blueprint/jasypt/pom.xml
@@ -139,12 +139,6 @@
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.karaf</groupId>
-            <artifactId>org.apache.karaf.util</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/jaas/blueprint/jasypt/src/test/java/org/apache/karaf/jaas/blueprint/jasypt/handler/EncryptableConfigAdminPropertyPlaceholderTest.java
+++ b/jaas/blueprint/jasypt/src/test/java/org/apache/karaf/jaas/blueprint/jasypt/handler/EncryptableConfigAdminPropertyPlaceholderTest.java
@@ -14,13 +14,25 @@
  */
 package org.apache.karaf.jaas.blueprint.jasypt.handler;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.jar.JarInputStream;
+
 import junit.framework.TestCase;
 import org.apache.felix.connect.PojoServiceRegistryFactoryImpl;
 import org.apache.felix.connect.launch.BundleDescriptor;
 import org.apache.felix.connect.launch.ClasspathScanner;
 import org.apache.felix.connect.launch.PojoServiceRegistry;
 import org.apache.felix.connect.launch.PojoServiceRegistryFactory;
-import org.apache.karaf.util.StreamUtils;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.jasypt.encryption.pbe.config.EnvironmentStringPBEConfig;
 import org.junit.After;
@@ -28,14 +40,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.ops4j.pax.tinybundles.TinyBundle;
 import org.ops4j.pax.tinybundles.TinyBundles;
-import org.osgi.framework.*;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.util.tracker.ServiceTracker;
-
-import java.io.*;
-import java.util.*;
-import java.util.jar.JarInputStream;
 
 public class EncryptableConfigAdminPropertyPlaceholderTest extends TestCase {
 
@@ -85,18 +99,17 @@ public class EncryptableConfigAdminPropertyPlaceholderTest extends TestCase {
     }
 
     private BundleDescriptor getBundleDescriptor(String path, TinyBundle bundle) throws Exception {
-        File file = new File(path);
-        FileOutputStream fos = new FileOutputStream(file);
-        StreamUtils.copy(bundle.build(), fos);
-        fos.close();
-        JarInputStream jis = new JarInputStream(new FileInputStream(file));
+        Path file = Path.of(path);
+        Files.copy(bundle.build(), file);
         Map<String, String> headers = new HashMap<>();
-        for (Map.Entry entry : jis.getManifest().getMainAttributes().entrySet()) {
-            headers.put(entry.getKey().toString(), entry.getValue().toString());
+        try (var jis = new JarInputStream(Files.newInputStream(file))) {
+            for (var entry : jis.getManifest().getMainAttributes().entrySet()) {
+                headers.put(entry.getKey().toString(), entry.getValue().toString());
+            }
         }
         return new BundleDescriptor(
                 getClass().getClassLoader(),
-                "jar:" + file.toURI().toString() + "!/",
+                "jar:" + file.toUri().toString() + "!/",
                 headers);
     }
 

--- a/jaas/blueprint/jasypt/src/test/java/org/apache/karaf/jaas/blueprint/jasypt/handler/EncryptablePropertyPlaceholderTest.java
+++ b/jaas/blueprint/jasypt/src/test/java/org/apache/karaf/jaas/blueprint/jasypt/handler/EncryptablePropertyPlaceholderTest.java
@@ -14,9 +14,8 @@
  */
 package org.apache.karaf.jaas.blueprint.jasypt.handler;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Dictionary;
@@ -34,7 +33,6 @@ import org.apache.felix.connect.launch.ClasspathScanner;
 import org.apache.felix.connect.launch.PojoServiceRegistry;
 import org.apache.felix.connect.launch.PojoServiceRegistryFactory;
 import org.apache.karaf.jaas.blueprint.jasypt.handler.beans.Bean;
-import org.apache.karaf.util.StreamUtils;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.jasypt.encryption.pbe.config.EnvironmentStringPBEConfig;
 import org.junit.After;
@@ -96,18 +94,17 @@ public class EncryptablePropertyPlaceholderTest extends TestCase {
     }
 
     private BundleDescriptor getBundleDescriptor(String path, TinyBundle bundle) throws Exception {
-        File file = new File(path);
-        FileOutputStream fos = new FileOutputStream(file);
-        StreamUtils.copy(bundle.build(), fos);
-        fos.close();
-        JarInputStream jis = new JarInputStream(new FileInputStream(file));
+        Path file = Path.of(path);
+        Files.copy(bundle.build(), file);
         Map<String, String> headers = new HashMap<>();
-        for (Map.Entry entry : jis.getManifest().getMainAttributes().entrySet()) {
-            headers.put(entry.getKey().toString(), entry.getValue().toString());
+        try (var jis = new JarInputStream(Files.newInputStream(file))) {
+            for (var entry : jis.getManifest().getMainAttributes().entrySet()) {
+                headers.put(entry.getKey().toString(), entry.getValue().toString());
+            }
         }
         return new BundleDescriptor(
                 getClass().getClassLoader(),
-                "jar:" + file.toURI().toString() + "!/",
+                "jar:" + file.toUri().toString() + "!/",
                 headers);
     }
 

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapPoolingTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapPoolingTest.java
@@ -15,9 +15,10 @@
  */
 package org.apache.karaf.jaas.modules.ldap;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.util.Hashtable;
@@ -57,7 +58,8 @@ public class LdapPoolingTest extends AbstractLdapTestUnit {
         KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-        ks.load(new FileInputStream("src/test/resources/org/apache/karaf/jaas/modules/ldap/ldaps.jks"), "123456".toCharArray());
+        ks.load(Files.newInputStream(Path.of("src/test/resources/org/apache/karaf/jaas/modules/ldap/ldaps.jks")),
+            "123456".toCharArray());
         kmf.init(ks, "123456".toCharArray());
         tmf.init(ks);
 

--- a/kar/src/main/java/org/apache/karaf/kar/internal/Kar.java
+++ b/kar/src/main/java/org/apache/karaf/kar/internal/Kar.java
@@ -17,11 +17,11 @@
 package org.apache.karaf.kar.internal;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,7 +31,6 @@ import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
-import org.apache.karaf.util.StreamUtils;
 import org.apache.karaf.util.maven.Parser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -161,9 +160,7 @@ public class Kar {
             dest.mkdirs();
         } else {
             dest.getParentFile().mkdirs();
-            FileOutputStream out = new FileOutputStream(dest);
-            StreamUtils.copy(is, out);
-            out.close();
+            Files.copy(is, dest.toPath());
         }
         return dest;
     }

--- a/kar/src/main/java/org/apache/karaf/kar/internal/KarServiceImpl.java
+++ b/kar/src/main/java/org/apache/karaf/kar/internal/KarServiceImpl.java
@@ -19,18 +19,15 @@
 package org.apache.karaf.kar.internal;
 
 import java.io.BufferedOutputStream;
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -45,10 +42,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
-
-import org.apache.karaf.features.*;
+import org.apache.karaf.features.BundleInfo;
+import org.apache.karaf.features.Conditional;
+import org.apache.karaf.features.ConfigFileInfo;
+import org.apache.karaf.features.Dependency;
+import org.apache.karaf.features.Feature;
+import org.apache.karaf.features.FeaturesService;
+import org.apache.karaf.features.Repository;
 import org.apache.karaf.kar.KarService;
-import org.apache.karaf.util.StreamUtils;
 import org.apache.karaf.util.maven.Parser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -190,42 +191,24 @@ public class KarServiceImpl implements KarService {
 
     private static List<URI> readFromFile(File repoListFile) {
         ArrayList<URI> uriList = new ArrayList<>();
-        FileReader fr = null;
-        try {
-            fr = new FileReader(repoListFile);
-            BufferedReader br = new BufferedReader(fr);
+        try (var reader = Files.newBufferedReader(repoListFile.toPath())) {
             String line;
-            while ((line = br.readLine()) != null) {
+            while ((line = reader.readLine()) != null) {
                 uriList.add(new URI(line));
             }
         } catch (Exception e) {
             throw new RuntimeException("Error reading repo list from file " + repoListFile.getAbsolutePath(), e);
-        } finally {
-            try {
-                fr.close();
-            } catch (IOException e) {
-                LOGGER.warn("Error closing reader for file " + repoListFile, e);
-            }
         }
         return uriList;
     }
     
     private static void writeToFile(List<URI> featuresRepositoriesInKar, File repoListFile) {
-        FileOutputStream fos = null;
-        PrintStream ps = null;
-        try {
-            fos = new FileOutputStream(repoListFile);
-            ps = new PrintStream(fos);
-            for (URI uri : featuresRepositoriesInKar) {
+        try (var ps = new PrintStream(Files.newOutputStream(repoListFile.toPath()))) {
+            for (var uri : featuresRepositoriesInKar) {
                 ps.println(uri);
             }
-            ps.close();
-            fos.close();
         } catch (Exception e) {
             throw new RuntimeException("Error writing feature repo list to file " + repoListFile.getAbsolutePath(), e);
-        } finally {
-            closeStream(ps);
-            closeStream(fos);
         }
     }
 
@@ -330,8 +313,6 @@ public class KarServiceImpl implements KarService {
     
     @Override
     public void create(String repoName, List<String> features, PrintStream console) {
-        FileOutputStream fos = null;
-        JarOutputStream jos = null;
         try {
             Repository repo = featuresService.getRepository(repoName);
             if (repo == null) {
@@ -340,33 +321,32 @@ public class KarServiceImpl implements KarService {
             String karPath = storage + File.separator + repoName + ".kar";
             File karFile = new File(karPath);
             karFile.getParentFile().mkdirs();
-            fos = new FileOutputStream(karFile);
             Manifest manifest = createNonAutoStartManifest(repo.getURI());
-            jos = new JarOutputStream(new BufferedOutputStream(fos, 100000), manifest);
             
-            Map<URI, Integer> locationMap = new HashMap<>();
-            copyResourceToJar(jos, repo.getURI(), locationMap);
-        
-            Map<String, Feature> featureMap = new HashMap<>();
-            for (Feature feature : repo.getFeatures()) {
-                featureMap.put(feature.getName(), feature);
-            }
+            try (var jos = new JarOutputStream(
+                new BufferedOutputStream(Files.newOutputStream(karFile.toPath()), 100_000), manifest)) {
             
-            Set<Feature> featuresToCopy = getFeatures(featureMap, features, 1);
-            
-            for (Feature feature : featuresToCopy) {
-                if (console != null)
-                    console.println("Adding feature " + feature.getName());
-                copyFeatureToJar(jos, feature, locationMap);
+                Map<URI, Integer> locationMap = new HashMap<>();
+                copyResourceToJar(jos, repo.getURI(), locationMap);
+
+                Map<String, Feature> featureMap = new HashMap<>();
+                for (Feature feature : repo.getFeatures()) {
+                    featureMap.put(feature.getName(), feature);
+                }
+
+                Set<Feature> featuresToCopy = getFeatures(featureMap, features, 1);
+
+                for (Feature feature : featuresToCopy) {
+                    if (console != null)
+                        console.println("Adding feature " + feature.getName());
+                    copyFeatureToJar(jos, feature, locationMap);
+                }
             }
 
             if (console != null)
                 console.println("Kar file created : " + karPath);
         } catch (Exception e) {
             throw new RuntimeException("Error creating kar: " + e.getMessage(), e);
-        } finally {
-            closeStream(jos);
-            closeStream(fos);
         }
         
     }
@@ -408,16 +388,6 @@ public class KarServiceImpl implements KarService {
         return manifest;
     }
 
-    private static void closeStream(OutputStream os) {
-        if (os != null) {
-            try {
-                os.close();
-            } catch (IOException e) {
-                LOGGER.warn("Error closing stream", e);
-            }
-        }
-    }
-
     private static void copyFeatureToJar(JarOutputStream jos, Feature feature, Map<URI, Integer> locationMap)
         throws URISyntaxException {
         // add bundles
@@ -452,10 +422,8 @@ public class KarServiceImpl implements KarService {
             Parser parser = new Parser(noPrefixLocation);
             String path = "repository/" + parser.getArtifactPath();
             jos.putNextEntry(new JarEntry(path));
-            try (
-                InputStream is = location.toURL().openStream()
-            ) {
-                StreamUtils.copy(is, jos);
+            try (var is = location.toURL().openStream()) {
+                is.transferTo(jos);
             }
             locationMap.put(location, 1);
         } catch (Exception e) {

--- a/kar/src/test/java/org/apache/karaf/kar/internal/KarTest.java
+++ b/kar/src/test/java/org/apache/karaf/kar/internal/KarTest.java
@@ -22,8 +22,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -54,14 +54,14 @@ public class KarTest {
         File base = new File("target/test");
         base.mkdirs();
         File badKarFile = new File(base,"bad.kar");
-        ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(badKarFile));
-        ZipEntry entry = new ZipEntry("../../../../foo.bar");
-        zos.putNextEntry(entry);
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(badKarFile.toPath()))) {
+            ZipEntry entry = new ZipEntry("../../../../foo.bar");
+            zos.putNextEntry(entry);
 
-        byte[] data = "Test Data".getBytes();
-        zos.write(data, 0, data.length);
-        zos.closeEntry();
-        zos.close();
+            byte[] data = "Test Data".getBytes();
+            zos.write(data, 0, data.length);
+            zos.closeEntry();
+        }
 
         Kar kar = new Kar(new URI("file:target/test/bad.kar"));
         File repoDir = new File("target/test/repo");
@@ -83,15 +83,15 @@ public class KarTest {
         File base = new File("target/test");
         base.mkdirs();
         File badKarFile = new File(base,"badencoded.kar");
-        ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(badKarFile));
-        // Use the encoded form of ".." here
-        ZipEntry entry = new ZipEntry("%2e%2e/%2e%2e/%2e%2e/%2e%2e/foo.bar");
-        zos.putNextEntry(entry);
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(badKarFile.toPath()))) {
+            // Use the encoded form of ".." here
+            ZipEntry entry = new ZipEntry("%2e%2e/%2e%2e/%2e%2e/%2e%2e/foo.bar");
+            zos.putNextEntry(entry);
 
-        byte[] data = "Test Data".getBytes();
-        zos.write(data, 0, data.length);
-        zos.closeEntry();
-        zos.close();
+            byte[] data = "Test Data".getBytes();
+            zos.write(data, 0, data.length);
+            zos.closeEntry();
+        }
 
         Kar kar = new Kar(new URI("file:target/test/badencoded.kar"));
         File repoDir = new File("target/test/repo");

--- a/main/src/main/java/org/apache/karaf/main/InstanceHelper.java
+++ b/main/src/main/java/org/apache/karaf/main/InstanceHelper.java
@@ -19,14 +19,13 @@
 package org.apache.karaf.main;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.OutputStreamWriter;
 import java.io.RandomAccessFile;
-import java.io.Writer;
 import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -123,9 +122,7 @@ public class InstanceHelper {
         try {
             if (pidFile != null) {
                 int pid = Integer.parseInt(getPid());
-                Writer w = new OutputStreamWriter(new FileOutputStream(pidFile));
-                w.write(Integer.toString(pid));
-                w.close();
+                Files.writeString(Path.of(pidFile), Integer.toString(pid));
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -146,9 +143,7 @@ public class InstanceHelper {
                 if (portFile != null) {
                     File portF = new File(portFile);
                     portF.getParentFile().mkdirs();
-                    Writer w = new OutputStreamWriter(new FileOutputStream(portF));
-                    w.write(Integer.toString(port));
-                    w.close();
+                    Files.writeString(portF.toPath(), Integer.toString(port));
                 }
                 ShutdownSocketThread thread = new ShutdownSocketThread(shutdown, shutdownSocket, framework);
                 thread.start();

--- a/main/src/main/java/org/apache/karaf/main/Status.java
+++ b/main/src/main/java/org/apache/karaf/main/Status.java
@@ -19,10 +19,12 @@
 package org.apache.karaf.main;
 
 import org.apache.karaf.jpm.impl.ProcessBuilderFactoryImpl;
-
-import java.io.*;
+import java.io.IOException;
 import java.net.ConnectException;
 import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 
 /**
  * Main class used to check the status of the root Karaf instance.
@@ -44,11 +46,11 @@ public class Status {
         if (config.shutdownPort == 0 && config.portFile != null) {
             try {
                 config.shutdownPort = getPortFromShutdownPortFile(config.portFile);
-            } catch (FileNotFoundException fnfe) {
+            } catch (NoSuchFileException e) {
                 System.out.println(NOT_RUNNING);
                 // cause with exit code 3: shutdown port file doesn't exist. The container is not running.
                 System.exit(3);
-            } catch (IOException ioe) {
+            } catch (IOException e) {
                 System.out.println(NOT_RUNNING);
                 // cause with exit code 4: can't read port file
                 System.exit(4);
@@ -84,21 +86,15 @@ public class Status {
     }
 
     private static int getPortFromShutdownPortFile(String portFile) throws IOException {
-        int port;
-        BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(portFile)));
-        String portStr = r.readLine();
-        port = Integer.parseInt(portStr);
-        r.close();
-        return port;
+        try (var reader = Files.newBufferedReader(Path.of(portFile))) {
+            return Integer.parseInt(reader.readLine());
+        }
     }
 
     private static int getPidFromPidFile(String pidFile) throws IOException {
-        int pid;
-        BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(pidFile)));
-        String pidString = r.readLine();
-        pid = Integer.parseInt(pidString);
-        r.close();
-        return pid;
+        try (var reader = Files.newBufferedReader(Path.of(pidFile))) {
+            return Integer.parseInt(reader.readLine());
+        }
     }
 
 }

--- a/main/src/main/java/org/apache/karaf/main/Stop.java
+++ b/main/src/main/java/org/apache/karaf/main/Stop.java
@@ -20,13 +20,12 @@ package org.apache.karaf.main;
 
 import org.apache.karaf.jpm.impl.ProcessBuilderFactoryImpl;
 
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.ConnectException;
 import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 
 /**
  * Main class used to stop the root Karaf instance
@@ -45,11 +44,11 @@ public class Stop {
         if (config.shutdownPort == 0 && config.portFile != null) {
             try {
                 config.shutdownPort = getPortFromShutdownPortFile(config.portFile);
-            } catch (FileNotFoundException fnfe) {
+            } catch (NoSuchFileException e) {
                 System.err.println(config.portFile + " shutdown port file doesn't exist. The container is not running.");
                 System.exit(3);
-            } catch (IOException ioe) {
-                System.err.println("Can't read " + config.portFile + " shutdown port file: " + ioe.getMessage());
+            } catch (IOException e) {
+                System.err.println("Can't read " + config.portFile + " shutdown port file: " + e.getMessage());
                 System.exit(4);
             }
         }
@@ -79,21 +78,15 @@ public class Stop {
     }
 
     private static int getPortFromShutdownPortFile(String portFile) throws IOException {
-        int port;
-        BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(portFile)));
-        String portStr = r.readLine();
-        port = Integer.parseInt(portStr);
-        r.close();
-        return port;
+        try (var reader = Files.newBufferedReader(Path.of(portFile))) {
+            return Integer.parseInt(reader.readLine());
+        }
     }
 
     private static int getPidFromPidFile(String pidFile) throws IOException {
-        int pid;
-        BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(pidFile)));
-        String pidString = r.readLine();
-        pid = Integer.parseInt(pidString);
-        r.close();
-        return pid;
+        try (var reader = Files.newBufferedReader(Path.of(pidFile))) {
+            return Integer.parseInt(reader.readLine());
+        }
     }
 
 }

--- a/main/src/main/java/org/apache/karaf/main/util/BootstrapLogManager.java
+++ b/main/src/main/java/org/apache/karaf/main/util/BootstrapLogManager.java
@@ -18,12 +18,16 @@
  */
 package org.apache.karaf.main.util;
 
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
+
 import java.io.BufferedOutputStream;
-import java.io.Closeable;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.apache.felix.utils.properties.Properties;
 import org.apache.felix.utils.properties.InterpolationHelper;
 
@@ -139,28 +143,14 @@ public class BootstrapLogManager {
 
 	private Properties loadPaxLoggingConfig() {
     	Properties props = new Properties();
-        FileInputStream fis = null;
-        try {
-            fis = new FileInputStream(log4jConfigPath);
+        try (var fis = Files.newInputStream(Path.of(log4jConfigPath))) {
             props.load(fis);
         } catch (Exception e) {
         	// Ignore
-		} finally {
-        	close(fis);
         }
         return props;
     }
 
-	private static void close(Closeable closeable) {
-		try {
-			if (closeable != null) {
-				closeable.close();
-			}
-		} catch (IOException e) {
-		    // Ignore
-		}
-	}
-    
     String getLogFilePath() {
     	String filename = configProps == null ? null : configProps.getProperty(KARAF_BOOTSTRAP_LOG);
     	if (filename != null) {
@@ -190,9 +180,8 @@ public class BootstrapLogManager {
                     throw new IOException(se.getMessage());
                 }
             }
-            FileOutputStream fout = new FileOutputStream(logfile, append);
-            BufferedOutputStream out = new BufferedOutputStream(fout);
-            setOutputStream(out);
+            setOutputStream(new BufferedOutputStream(
+                Files.newOutputStream(logfile.toPath(), WRITE, CREATE, append ? APPEND : TRUNCATE_EXISTING)));
         }
 
         public synchronized void publish (LogRecord record) {

--- a/obr/src/main/java/org/apache/karaf/obr/command/ObrCommandSupport.java
+++ b/obr/src/main/java/org/apache/karaf/obr/command/ObrCommandSupport.java
@@ -16,14 +16,9 @@
  */
 package org.apache.karaf.obr.command;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.io.PrintStream;
+import java.nio.file.Files;
 import java.util.List;
 
 import org.apache.felix.bundlerepository.Reason;
@@ -240,9 +235,9 @@ public abstract class ObrCommandSupport implements Action {
             File sysTmp = new File(etc, "config.properties.tmp");
 
             boolean modified = false;
-            try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(sysTmp)))) {
+            try (var writer = Files.newBufferedWriter(sysTmp.toPath())) {
                 if (sys.exists()) {
-                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(sys)))) {
+                    try (var reader = Files.newBufferedReader(sys.toPath())) {
                         String line = reader.readLine();
                         while (line != null) {
                             if (line.matches("obr\\.repository\\.url[:= ].*")) {

--- a/obr/src/main/java/org/apache/karaf/obr/command/util/FileUtil.java
+++ b/obr/src/main/java/org/apache/karaf/obr/command/util/FileUtil.java
@@ -18,16 +18,13 @@
  */
 package org.apache.karaf.obr.command.util;
 
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
@@ -53,10 +50,8 @@ public class FileUtil
             }
             File file = new File(dir, fileName);
 
-            OutputStream os = new FileOutputStream(file);
             URLConnection conn = srcURL.openConnection();
             int total = conn.getContentLength();
-            InputStream is = conn.getInputStream();
 
             if (total > 0)
             {
@@ -67,20 +62,13 @@ public class FileUtil
             {
                 out.println("Downloading " + fileName + ".");
             }
-            byte[] buffer = new byte[4096];
-            int count = 0;
-            for (int len = is.read(buffer); len > 0; len = is.read(buffer))
-            {
-                count += len;
-                os.write(buffer, 0, len);
+            try (var is = conn.getInputStream()) {
+                Files.copy(is, file.toPath());
             }
-
-            os.close();
-            is.close();
 
             if (extract)
             {
-                try (JarInputStream jis = new JarInputStream(new FileInputStream(file))) {
+                try (JarInputStream jis = new JarInputStream(Files.newInputStream(file.toPath()))) {
                     out.println("Extracting...");
                     unjar(jis, dir);
                 }
@@ -170,14 +158,6 @@ public class FileUtil
             throw new IOException("Target is not a directory: "
                 + targetDir);
         }
-
-        BufferedOutputStream bos = new BufferedOutputStream(
-            new FileOutputStream(new File(targetDir, destName)));
-        int count = 0;
-        while ((count = is.read(buffer)) > 0)
-        {
-            bos.write(buffer, 0, count);
-        }
-        bos.close();
+        Files.copy(is, new File(targetDir, destName).toPath());
     }
 }

--- a/obr/src/test/java/org/apache/karaf/obr/command/util/FileUtilTest.java
+++ b/obr/src/test/java/org/apache/karaf/obr/command/util/FileUtilTest.java
@@ -23,8 +23,7 @@ import org.junit.Test;
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.util.jar.JarInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -36,17 +35,18 @@ public class FileUtilTest {
         File base = new File("target/test");
         base.mkdirs();
         File goodKarFile = new File(base, "good.kar");
-        ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(goodKarFile));
-        ZipEntry entry = new ZipEntry("foo.bar");
-        zos.putNextEntry(entry);
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(goodKarFile.toPath()))) {
+            ZipEntry entry = new ZipEntry("foo.bar");
+            zos.putNextEntry(entry);
 
-        byte[] data = "Test Data".getBytes();
-        zos.write(data, 0, data.length);
-        zos.closeEntry();
-        zos.close();
+            byte[] data = "Test Data".getBytes();
+            zos.write(data, 0, data.length);
+            zos.closeEntry();
+        }
 
-        JarInputStream jis = new JarInputStream(new FileInputStream(goodKarFile));
-        FileUtil.unjar(jis, base);
+        try (JarInputStream jis = new JarInputStream(Files.newInputStream(goodKarFile.toPath()))) {
+            FileUtil.unjar(jis, base);
+        }
 
         goodKarFile.delete();
     }
@@ -56,17 +56,16 @@ public class FileUtilTest {
         File base = new File("target/test");
         base.mkdirs();
         File badKarFile = new File(base, "bad.kar");
-        ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(badKarFile));
-        ZipEntry entry = new ZipEntry("../../../../../../../../../tmp/foo.bar");
-        zos.putNextEntry(entry);
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(badKarFile.toPath()))) {
+            ZipEntry entry = new ZipEntry("../../../../../../../../../tmp/foo.bar");
+            zos.putNextEntry(entry);
 
-        byte[] data = "Test Data".getBytes();
-        zos.write(data, 0, data.length);
-        zos.closeEntry();
-        zos.close();
+            byte[] data = "Test Data".getBytes();
+            zos.write(data, 0, data.length);
+            zos.closeEntry();
+        }
 
-        JarInputStream jis = new JarInputStream(new FileInputStream(badKarFile));
-        try {
+        try (JarInputStream jis = new JarInputStream(Files.newInputStream(badKarFile.toPath()))) {
             FileUtil.unjar(jis, base);
             fail("Failure expected on extracting a jar with relative file paths");
         } catch (Exception ex) {

--- a/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
+++ b/profile/src/main/java/org/apache/karaf/profile/assembly/Builder.java
@@ -1151,9 +1151,9 @@ public class Builder {
             Path featuresProcessingXml = etcDirectory.resolve("org.apache.karaf.features.xml");
             if (hasOwnInstructions() || overrides.size() > 0) {
                 // just generate new etc/org.apache.karaf.features.xml file (with external config + builder config)
-                try (FileOutputStream fos = new FileOutputStream(featuresProcessingXml.toFile())) {
+                try (var os = Files.newOutputStream(featuresProcessingXml)) {
                     LOGGER.info("Generating features processor configuration: {}", homeDirectory.relativize(featuresProcessingXml));
-                    processor.writeInstructions(fos);
+                    processor.writeInstructions(os);
                 }
             } else if (needFeaturesProcessorFileCopy) {
                 // we may simply copy configured features processor XML configuration
@@ -1226,7 +1226,7 @@ public class Builder {
         if (result == null) {
             return;
         }
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(result))) {
+        try (var writer = Files.newBufferedWriter(result.toPath())) {
             writer.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
             writer.write("<?xml-stylesheet type=\"text/xsl\" href=\"bundle-report.xslt\"?>\n");
             writer.write("<consistency-report xmlns=\"urn:apache:karaf:consistency:1.0\" project=\"" + consistencyReportProjectName + "\" version=\"" + consistencyReportProjectVersion + "\">\n");

--- a/services/staticcm/src/main/java/org/apache/karaf/services/staticcm/Configurations.java
+++ b/services/staticcm/src/main/java/org/apache/karaf/services/staticcm/Configurations.java
@@ -20,9 +20,8 @@ package org.apache.karaf.services.staticcm;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -49,7 +48,7 @@ public class Configurations {
         if (files != null) {
             for (File file : files) {
                 if (file.getName().endsWith(".cfg")) {
-                    try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
+                    try (var in = new BufferedInputStream(Files.newInputStream(file.toPath()))) {
                        
                         in.mark(1);
                         boolean isXml = in.read() == '<';

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/Branding.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/Branding.java
@@ -21,9 +21,11 @@ package org.apache.karaf.shell.impl.console;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Properties;
-
 
 public final class Branding {
     static final Logger LOGGER = LoggerFactory.getLogger(Branding.class);
@@ -46,7 +48,7 @@ public final class Branding {
     }
 
     private static void loadPropsFromFile(Properties props, String fileName) {
-        try (FileInputStream is = new FileInputStream(fileName)) {
+        try (InputStream is = Files.newInputStream(Path.of(fileName))) {
             loadProps(props, is);
         } catch (IOException e) {
             LOGGER.trace("Could not load branding.", e);

--- a/shell/core/src/main/java/org/apache/karaf/shell/impl/console/standalone/Main.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/impl/console/standalone/Main.java
@@ -20,16 +20,16 @@ package org.apache.karaf.shell.impl.console.standalone;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -114,14 +114,14 @@ public class Main {
         }
 
         if (file != null) {
-            try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file)))) {
+            try (var reader = Files.newBufferedReader(Path.of(file))) {
                 sb.setLength(0);
                 for (int c = reader.read(); c >= 0; c = reader.read()) {
                     sb.append((char) c);
                 }
             }
         } else if (batch) {
-            Reader reader = new BufferedReader(new InputStreamReader(System.in));
+            var reader = new BufferedReader(new InputStreamReader(System.in));
             sb.setLength(0);
             for (int c = reader.read(); c >= 0; reader.read()) {
                 sb.append((char) c);

--- a/shell/core/src/main/java/org/apache/karaf/shell/support/ShellUtil.java
+++ b/shell/core/src/main/java/org/apache/karaf/shell/support/ShellUtil.java
@@ -18,10 +18,10 @@
  */
 package org.apache.karaf.shell.support;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.AccessControlContext;
 import java.security.AccessController;
@@ -250,8 +250,8 @@ public class ShellUtil {
     }
 
     public static <T> T loadPropertyFromShellCfg(String key, Function<String, T> parser, T defaultValue) {
-        File shellCfg = Paths.get(System.getProperty("karaf.etc"), "org.apache.karaf.shell.cfg").toFile();
-        try (FileInputStream fis = new FileInputStream(shellCfg)) {
+        Path shellCfg = Paths.get(System.getProperty("karaf.etc"), "org.apache.karaf.shell.cfg");
+        try (var fis = Files.newInputStream(shellCfg)) {
             Properties properties = new Properties();
             properties.load(fis);
 

--- a/system/src/main/java/org/apache/karaf/system/internal/SystemServiceImpl.java
+++ b/system/src/main/java/org/apache/karaf/system/internal/SystemServiceImpl.java
@@ -17,9 +17,9 @@
 package org.apache.karaf.system.internal;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
@@ -167,16 +167,15 @@ public class SystemServiceImpl implements SystemService {
     public void setName(String name) {
         try {
             String karafEtc = bundleContext.getProperty("karaf.etc");
-            File etcDir = new File(karafEtc);
-            File syspropsFile = new File(etcDir, "system.properties");
-            FileInputStream fis = new FileInputStream(syspropsFile);
+            Path syspropsFile = Path.of(karafEtc).resolve("system.properties");
             Properties props = new Properties();
-            props.load(fis);
-            fis.close();
+            try (var fis = Files.newInputStream(syspropsFile)) {
+                props.load(fis);
+            }
             props.setProperty("karaf.name", name);
-            FileOutputStream fos = new FileOutputStream(syspropsFile);
-            props.store(fos, "");
-            fos.close();
+            try (var fos = Files.newOutputStream(syspropsFile)) {
+                props.store(fos, "");
+            }
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/AssemblyMojo.java
@@ -23,9 +23,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
@@ -791,9 +789,9 @@ public class AssemblyMojo extends MojoSupport {
     private KarafPropertyEdits configurePropertyEdits() throws IOException, XMLStreamException {
         KarafPropertyEdits edits = null;
         if (propertyFileEdits != null) {
-            File file = new File(propertyFileEdits);
-            if (file.exists()) {
-                try (InputStream editsStream = new FileInputStream(propertyFileEdits)) {
+            Path file = Path.of(propertyFileEdits);
+            if (Files.exists(file)) {
+                try (var editsStream = Files.newInputStream(file)) {
                     KarafPropertyInstructionsModelStaxReader kipmsr = new KarafPropertyInstructionsModelStaxReader();
                     edits = kipmsr.read(editsStream, true);
                 }
@@ -842,7 +840,7 @@ public class AssemblyMojo extends MojoSupport {
             return "features";
         }
         if ("xml".equals(artifact.getType())) {
-            try (InputStream is = new FileInputStream(artifact.getFile())) {
+            try (var is = Files.newInputStream(artifact.getFile().toPath())) {
                 XMLInputFactory xif = XMLInputFactory.newFactory();
                 xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
                 xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/RunMojo.java
@@ -43,7 +43,12 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Files;
@@ -403,13 +408,13 @@ public class RunMojo extends MojoSupport {
 
     private static void extractTarGzDistribution(File sourceDistribution, File _targetFolder) throws IOException {
         File uncompressedFile = Files.createTempFile("uncompressedTarGz-", ".tar").toFile();
-        extractGzArchive(new FileInputStream(sourceDistribution), uncompressedFile);
-        extract(new TarArchiveInputStream(new FileInputStream(uncompressedFile)), _targetFolder);
+        extractGzArchive(Files.newInputStream(sourceDistribution.toPath()), uncompressedFile);
+        extract(new TarArchiveInputStream(Files.newInputStream(uncompressedFile.toPath())), _targetFolder);
         FileUtils.forceDelete(uncompressedFile);
     }
 
     private static void extractZipDistribution(File sourceDistribution, File _targetFolder) throws IOException {
-        extract(new ZipArchiveInputStream(new FileInputStream(sourceDistribution)), _targetFolder);
+        extract(new ZipArchiveInputStream(Files.newInputStream(sourceDistribution.toPath())), _targetFolder);
     }
 
     private static void extractGzArchive(InputStream tarGz, File tar) throws IOException {
@@ -425,7 +430,7 @@ public class RunMojo extends MojoSupport {
         gzIn.close();
     }
 
-    private static void extract(ArchiveInputStream is, File targetDir) throws IOException {
+    private static void extract(ArchiveInputStream<?> is, File targetDir) throws IOException {
         try {
             if (targetDir.exists()) {
                 FileUtils.forceDelete(targetDir);

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/VerifyMojo.java
@@ -28,6 +28,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -247,9 +248,9 @@ public class VerifyMojo extends MojoSupport {
         Hashtable<String, String> properties = new Hashtable<>();
 
         if (additionalMetadata != null) {
-            try (Reader reader = new FileReader(additionalMetadata)) {
+            try (var is = Files.newInputStream(additionalMetadata.toPath())) {
                 Properties metadata = new Properties();
-                metadata.load(reader);
+                metadata.load(is);
                 for (Enumeration<?> e = metadata.propertyNames(); e.hasMoreElements(); ) {
                     Object key = e.nextElement();
                     Object val = metadata.get(key);

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/client/ClientMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/client/ClientMojo.java
@@ -36,18 +36,16 @@ import org.apache.sshd.common.RuntimeSshException;
 import org.apache.sshd.common.keyprovider.FileKeyPairProvider;
 import org.fusesource.jansi.Ansi;
 import org.fusesource.jansi.Ansi.Color;
-import org.fusesource.jansi.AnsiConsole;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Console;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOError;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Files;
 import java.security.KeyPair;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -104,11 +102,10 @@ public class ClientMojo extends AbstractMojo {
         SortedSet<CommandDescriptor> sortedCommands = new TreeSet<>(comparator);
         if (scripts != null) {
             for (ScriptDescriptor script : scripts) {
-                File file = script.getScript();
-                try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+                try (var reader = Files.newBufferedReader(script.getScript().toPath())) {
                     String line;
                     int lineIndex = 0;
-                    while ((line = br.readLine()) != null) {
+                    while ((line = reader.readLine()) != null) {
                         line = line.trim();
                         if (line.isEmpty()) {
                             continue;

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/ExportFeatureMetaDataMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/ExportFeatureMetaDataMojo.java
@@ -18,10 +18,10 @@
 package org.apache.karaf.tooling.features;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -30,7 +30,11 @@ import java.util.jar.Attributes;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 
-import org.apache.karaf.features.internal.model.*;
+import org.apache.karaf.features.internal.model.Bundle;
+import org.apache.karaf.features.internal.model.Feature;
+import org.apache.karaf.features.internal.model.Features;
+import org.apache.karaf.features.internal.model.JacksonUtil;
+import org.apache.karaf.features.internal.model.JaxbUtil;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -157,7 +161,7 @@ public class ExportFeatureMetaDataMojo extends AbstractFeatureMojo {
             if (artifact.getFile() == null) {
                 resolveArtifact(artifact, remoteRepos);
             }
-            try (JarInputStream jis = new JarInputStream(new FileInputStream(artifact.getFile()))) {
+            try (JarInputStream jis = new JarInputStream(Files.newInputStream(artifact.getFile().toPath()))) {
                 Manifest manifest = jis.getManifest();
                 if (manifest != null) {
                     attributes = manifest.getMainAttributes();

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/features/GenerateDescriptorMojo.java
@@ -20,7 +20,18 @@ package org.apache.karaf.tooling.features;
 import static java.lang.String.format;
 import static org.apache.karaf.deployer.kar.KarArtifactInstaller.FEATURE_CLASSIFIER;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.ArrayList;
@@ -39,7 +50,14 @@ import jakarta.xml.bind.JAXBException;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLStreamException;
 
-import org.apache.karaf.features.internal.model.*;
+import org.apache.karaf.features.internal.model.ConfigFile;
+import org.apache.karaf.features.internal.model.Bundle;
+import org.apache.karaf.features.internal.model.Dependency;
+import org.apache.karaf.features.internal.model.Feature;
+import org.apache.karaf.features.internal.model.Features;
+import org.apache.karaf.features.internal.model.JacksonUtil;
+import org.apache.karaf.features.internal.model.JaxbUtil;
+import org.apache.karaf.features.internal.model.ObjectFactory;
 import org.apache.karaf.tooling.utils.Dependency31Helper;
 import org.apache.karaf.tooling.utils.DependencyHelper;
 import org.apache.karaf.tooling.utils.DependencyHelperFactory;
@@ -720,7 +738,7 @@ public class GenerateDescriptorMojo extends MojoSupport {
             File manifestFile = new File(file, "META-INF/MANIFEST.MF");
             if(manifestFile.exists() && manifestFile.isFile()) {
                 try {
-                    InputStream manifestInputStream = new FileInputStream(manifestFile);
+                    InputStream manifestInputStream = Files.newInputStream(manifestFile.toPath());
                     return new Manifest(manifestInputStream);
                 } catch (IOException e) {
                     getLog().warn("Error while reading artifact from directory", e);
@@ -769,7 +787,7 @@ public class GenerateDescriptorMojo extends MojoSupport {
         ObjectFactory objectFactory = new ObjectFactory();
         Features merged = objectFactory.createFeaturesRoot();
         merged.setName(karFile.getName());
-        try (JarInputStream jar = new JarInputStream(new FileInputStream(karFile))) {
+        try (JarInputStream jar = new JarInputStream(Files.newInputStream(karFile.toPath()))) {
             ZipEntry entry;
             while ((entry = jar.getNextEntry()) != null) {
                 String entryName = entry.getName();

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/Dependency31Helper.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/Dependency31Helper.java
@@ -39,21 +39,31 @@ import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.util.graph.selector.AndDependencySelector;
 import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
 import org.eclipse.aether.util.graph.selector.OptionalDependencySelector;
-import org.eclipse.aether.util.graph.transformer.*;
+import org.eclipse.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
+import org.eclipse.aether.util.graph.transformer.ConflictMarker;
+import org.eclipse.aether.util.graph.transformer.ConflictResolver;
+import org.eclipse.aether.util.graph.transformer.JavaDependencyContextRefiner;
+import org.eclipse.aether.util.graph.transformer.JavaScopeDeriver;
+import org.eclipse.aether.util.graph.transformer.JavaScopeSelector;
+import org.eclipse.aether.util.graph.transformer.NearestVersionSelector;
+import org.eclipse.aether.util.graph.transformer.SimpleOptionalitySelector;
 import org.codehaus.plexus.util.StringUtils;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
 
-import static java.lang.String.*;
 import static org.apache.commons.lang3.reflect.MethodUtils.invokeMethod;
 import static org.apache.karaf.deployer.kar.KarArtifactInstaller.FEATURE_CLASSIFIER;
 
@@ -301,7 +311,7 @@ public class Dependency31Helper implements DependencyHelper {
     }
 
     public static boolean isFeaturesXml(File file) {
-        try (InputStream is = new FileInputStream(file)) {
+        try (var is = Files.newInputStream(file.toPath())) {
             XMLInputFactory xif = XMLInputFactory.newFactory();
             xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
             xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
@@ -402,7 +412,7 @@ public class Dependency31Helper implements DependencyHelper {
             result = resolveArtifact(MavenUtil.aetherToArtifact(id));
         } catch (ArtifactResolutionException e) {
             log.warn("Could not resolve " + id, e);
-            throw new MojoFailureException(format("Couldn't resolve artifact %s", id), e);
+            throw new MojoFailureException(String.format("Couldn't resolve artifact %s", id), e);
         }
 
         if (log.isDebugEnabled()) {

--- a/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MojoSupport.java
+++ b/tooling/karaf-maven-plugin/src/main/java/org/apache/karaf/tooling/utils/MojoSupport.java
@@ -18,9 +18,8 @@
 package org.apache.karaf.tooling.utils;
 
 import java.io.File;
-import java.io.InputStream;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -29,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.karaf.util.StreamUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
@@ -91,13 +89,13 @@ public abstract class MojoSupport extends AbstractMojo {
 
     @Component
     protected ArtifactFactory factory;
-    
+
     /**
      * The artifact type of a feature.
      */
     @Parameter(defaultValue = "xml")
     private String featureArtifactType = "xml";
-    
+
     /**
      * The Maven session.
      */
@@ -165,7 +163,7 @@ public abstract class MojoSupport extends AbstractMojo {
         }
         return map;
     }
-    
+
     protected String translateFromMaven(String uri) {
         if (uri.startsWith("mvn:")) {
             String[] parts = uri.substring("mvn:".length()).split("/");
@@ -221,12 +219,12 @@ public abstract class MojoSupport extends AbstractMojo {
             throw new RuntimeException("Repository URL is not valid", e);
         }
     }
-    
+
     private Dependency findDependency(List<Dependency> dependencies, String artifactId, String groupId) {
         for(Dependency dep : dependencies) {
             if (artifactId.equals(dep.getArtifactId()) && groupId.equals(dep.getGroupId()) &&
                     featureArtifactType.equals(dep.getType())) {
-                if (dep.getVersion() != null) 
+                if (dep.getVersion() != null)
                     return dep;
             }
         }
@@ -325,7 +323,7 @@ public abstract class MojoSupport extends AbstractMojo {
         artifact.setRepository(repo);
         return artifact;
     }
-    
+
     private org.apache.maven.repository.Proxy configureProxyToInlineRepo() {
         if (mavenSession != null && mavenSession.getSettings() != null) {
             Proxy proxy = mavenSession.getSettings().getActiveProxy();
@@ -341,7 +339,7 @@ public abstract class MojoSupport extends AbstractMojo {
             } else {
                 return null;
             }
-            
+
         } else {
             return null;
         }
@@ -351,15 +349,12 @@ public abstract class MojoSupport extends AbstractMojo {
         File targetDir = destFile.getParentFile();
         ensureDirExists(targetDir);
 
-        try (InputStream is = Files.newInputStream(sourceFile.toPath())) {
-            try (OutputStream bos = Files.newOutputStream(destFile.toPath())) {
-                StreamUtils.copy(is, bos);
-            }
+        try {
+            Files.copy(sourceFile.toPath(), destFile.toPath());
         } catch (IOException e) {
-            throw new RuntimeException(e.getMessage(), e);
+            throw new UncheckedIOException(e);
         }
     }
-    
 
     /**
      * Make sure the target directory exists and that is actually a directory.

--- a/tooling/utils/src/main/java/org/apache/karaf/tools/utils/KarafPropertiesFile.java
+++ b/tooling/utils/src/main/java/org/apache/karaf/tools/utils/KarafPropertiesFile.java
@@ -20,9 +20,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.karaf.tools.utils.model.KarafPropertyEdit;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 
 public class KarafPropertiesFile {
 
@@ -52,7 +51,7 @@ public class KarafPropertiesFile {
         if (!propertyFile.exists()) {
             return;
         }
-        properties.load(new FileInputStream(propertyFile));
+        properties.load(Files.newInputStream(propertyFile.toPath()));
     }
 
     public void put(String key, String value) {
@@ -96,8 +95,8 @@ public class KarafPropertiesFile {
     }
 
     public void store(File destinationFile) throws IOException {
-        try (FileOutputStream outputStream = new FileOutputStream(destinationFile)) {
-            properties.store(outputStream, String.format("Modified by %s", getClass().getName()));
+        try (var os = Files.newOutputStream(destinationFile.toPath())) {
+            properties.store(os, String.format("Modified by %s", getClass().getName()));
         }
     }
 

--- a/tooling/utils/src/test/java/org/apache/karaf/tools/utils/KarafPropertiesEditorTest.java
+++ b/tooling/utils/src/test/java/org/apache/karaf/tools/utils/KarafPropertiesEditorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.karaf.tools.utils;
 
 import com.google.common.io.Resources;
@@ -23,7 +22,6 @@ import org.apache.karaf.tools.utils.model.io.stax.KarafPropertyInstructionsModel
 import org.junit.Test;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.FileSystems;
@@ -60,16 +58,14 @@ public class KarafPropertiesEditorTest {
                 .setEdits(edits);
         editor.run();
 
-        File resultConfigProps = new File(outputEtc.toFile(), "config.properties");
         Properties properties = new Properties();
-        try (InputStream resultInputStream = new FileInputStream(resultConfigProps)) {
+        try (var resultInputStream = Files.newInputStream(outputEtc.resolve("config.properties"))) {
             properties.load(resultInputStream);
         }
         assertEquals("equinox", properties.getProperty("karaf.framework"));
         assertEquals("prepended,root,toor", properties.getProperty("karaf.name"));
 
-        resultConfigProps = new File(outputEtc.toFile(), "jre.properties");
-        try (InputStream resultInputStream = new FileInputStream(resultConfigProps)) {
+        try (var resultInputStream = Files.newInputStream(outputEtc.resolve("jre.properties"))) {
             properties.load(resultInputStream);
         }
 

--- a/util/src/main/java/org/apache/karaf/jpm/impl/ProcessImpl.java
+++ b/util/src/main/java/org/apache/karaf/jpm/impl/ProcessImpl.java
@@ -18,9 +18,7 @@ package org.apache.karaf.jpm.impl;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.InterruptedIOException;
 import java.nio.file.Files;
@@ -170,10 +168,8 @@ public class ProcessImpl implements Process {
     }
 
     private static int readPid(File pidFile) throws IOException {
-        try (InputStream is = new FileInputStream(pidFile)) {
-            BufferedReader r = new BufferedReader(new InputStreamReader(is));
-            String pidString = r.readLine();
-            return Integer.valueOf(pidString);
+        try (var reader = Files.newBufferedReader(pidFile.toPath())) {
+            return Integer.valueOf(reader.readLine());
         }
     }
 

--- a/util/src/main/java/org/apache/karaf/jpm/impl/ScriptUtils.java
+++ b/util/src/main/java/org/apache/karaf/jpm/impl/ScriptUtils.java
@@ -17,7 +17,6 @@
 package org.apache.karaf.jpm.impl;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
@@ -64,7 +63,7 @@ public class ScriptUtils {
         try {
             is = ScriptUtils.class.getResourceAsStream(resource);
             // Read it line at a time so that we can use the platform line ending when we write it out.
-            PrintStream out = new PrintStream(new FileOutputStream(outFile));
+            PrintStream out = new PrintStream(Files.newOutputStream(outFile.toPath()));
             try {
                 Scanner scanner = new Scanner(is);
                 while (scanner.hasNextLine() ) {

--- a/util/src/main/java/org/apache/karaf/util/StreamUtils.java
+++ b/util/src/main/java/org/apache/karaf/util/StreamUtils.java
@@ -50,12 +50,9 @@ public class StreamUtils {
         }
     }
 
+    @Deprecated(since = "4.5.0", forRemoval = true)
     public static void copy(final InputStream input, final OutputStream output) throws IOException {
-        byte[] buffer = new byte[1024 * 16];
-        int n;
-        while ((n = input.read(buffer)) > 0) {
-            output.write(buffer, 0, n);
-        }
+        input.transferTo(output);
         output.flush();
     }
 

--- a/util/src/main/java/org/apache/karaf/util/bundles/BundleUtils.java
+++ b/util/src/main/java/org/apache/karaf/util/bundles/BundleUtils.java
@@ -19,7 +19,6 @@ package org.apache.karaf.util.bundles;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -37,7 +36,7 @@ public class BundleUtils {
     public static File fixBundleWithUpdateLocation(InputStream is, String uri) throws IOException {
         File file = Files.createTempFile("update-", ".jar").toFile();
         try (ZipInputStream zis = new ZipInputStream(is);
-             ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(file))) {
+             ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(file.toPath()))) {
 
             byte[] buf = new byte[8192];
             zos.setLevel(0);

--- a/util/src/test/java/org/apache/karaf/util/BundleUtilsTest.java
+++ b/util/src/test/java/org/apache/karaf/util/BundleUtilsTest.java
@@ -20,7 +20,7 @@ import org.apache.karaf.util.bundles.BundleUtils;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.FileInputStream;
+import java.nio.file.Files;
 
 public class BundleUtilsTest {
 
@@ -29,6 +29,7 @@ public class BundleUtilsTest {
         String url = getClass().getClassLoader().getResource("com/sun/mail/util/ASCIIUtility.class").toString();
         url = url.substring("jar:file:".length(), url.indexOf("!/"));
         File file = new File(url);
-        BundleUtils.fixBundleWithUpdateLocation(new FileInputStream(file), "mvn:com.sun.mail/jakarta.mail/1.6.7");
+        BundleUtils.fixBundleWithUpdateLocation(Files.newInputStream(file.toPath()),
+            "mvn:com.sun.mail/jakarta.mail/1.6.7");
     }
 }


### PR DESCRIPTION
These two classes have a finalizer in Java 12, hence they are an
unnecessary burden for GC.

Use:
- Files.newInputStream() instead of FileInputStream
- Files.newBufferedReader() when we end up converting to a Writer
- Files.readAllBytes() if we end up reading the stream
- Files.copy() if we are copying the stream to another stream or file
- Files.writeString() when we are emitting just a plain string
- Files.newOutputStream() instead of FileOutputStream
- Files.newBufferedReader() when we end up conerting to a Writer

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
