### PR TITLE
Added option to configure dynamic imports

### DIFF
--- a/bundle/core/src/main/java/org/apache/karaf/bundle/command/DynamicImport.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/command/DynamicImport.java
@@ -16,26 +16,54 @@
  */
 package org.apache.karaf.bundle.command;
 
+import java.util.List;
+import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.osgi.framework.Bundle;
 
 /**
- * Command for enabling/disabling debug logging on a bundle and calculating the difference in
+ * Command for enabling/disabling dynamic imports on a bundle and calculating the difference in
  * wired imports.
  */
 @Command(scope = "bundle", name = "dynamic-import", description = "Enables/disables dynamic-import for a given bundle.")
 @Service
 public class DynamicImport extends BundleCommand {
 
+    @Argument(index = 1, name = "packages", description = "Bundle URLs separated by whitespaces", required = false, multiValued = true)
+    List<String> packages;
+
+    @Option(name = "--enable", aliases = {"-e"}, description = "Forces the command to execute", required = false, multiValued = false)
+    boolean enable;
+
+    @Option(name = "--disable", aliases = {"-d"}, description = "Forces the command to execute", required = false, multiValued = false)
+    boolean disable;
+
     @Override
     protected Object doExecute(Bundle bundle) throws Exception {
-        if (bundleService.isDynamicImport(bundle)) {
+        if (enable && disable) {
+            throw new IllegalArgumentException("Cannot 'enable' and 'disable' at the same time");
+        }
+        if ((enable || disable) && (packages != null && !packages.isEmpty())) {
+            throw new IllegalArgumentException("Options are incompatible with providing package list");
+        }
+        if (enable) {
+            System.out.printf("Enabling dynamic imports on bundle %s%n", bundle);
+            bundleService.setDynamicImports(bundle, List.of("*"));
+        } else if (disable) {
             System.out.printf("Disabling dynamic imports on bundle %s%n", bundle);
-            bundleService.disableDynamicImports(bundle);
+            bundleService.setDynamicImports(bundle, List.of());
+        } else if (packages != null && !packages.isEmpty()) {
+            System.out.printf("Enabling dynamic imports for [%s] on bundle %s%n",
+                String.join(", ",packages), bundle);
+            bundleService.setDynamicImports(bundle, packages);
+        } else if (bundleService.isDynamicImport(bundle)) {
+            System.out.printf("Disabling dynamic imports on bundle %s%n", bundle);
+            bundleService.setDynamicImports(bundle, List.of());
         } else {
             System.out.printf("Enabling dynamic imports on bundle %s%n", bundle);
-            bundleService.enableDynamicImports(bundle);
+            bundleService.setDynamicImports(bundle, List.of("*"));
         }
         return null;
     }

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/core/BundleService.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/core/BundleService.java
@@ -44,9 +44,7 @@ public interface BundleService {
     
     boolean isDynamicImport(Bundle bundle);
 
-    void enableDynamicImports(Bundle bundle);
-
-    void disableDynamicImports(Bundle bundle);
+    void setDynamicImports(Bundle bundle, List<String> packages);
 
     int getSystemBundleThreshold();
 

--- a/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/BundleServiceImpl.java
+++ b/bundle/core/src/main/java/org/apache/karaf/bundle/core/internal/BundleServiceImpl.java
@@ -18,11 +18,13 @@ package org.apache.karaf.bundle.core.internal;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -223,18 +225,27 @@ public class BundleServiceImpl implements BundleService {
         return false;
     }
 
+    public void setDynamicImports(Bundle bundle, List<String> packages) {
+        if (packages == null || packages.isEmpty()) {
+            disableDynamicImports(bundle);
+        } else {
+            enableDynamicImports(bundle, String.join(",", packages));
+        }
+    }
+
     /*
      * Enable DynamicImport=* on the bundle
      */
-    public void enableDynamicImports(Bundle bundle) {
+    private void enableDynamicImports(Bundle bundle, String packageString) {
         String location =
                 String.format("wrap:%s$" +
                         "Bundle-UpdateLocation=%s&" +
-                        "DynamicImport-Package=*&" +
+                        "DynamicImport-Package=%s&" +
                         "%s=%s&" +
                         "overwrite=merge",
                         bundle.getLocation(),
                         bundle.getLocation(),
+                        packageString,
                         ORIGINAL_WIRES,
                         explode(getWiredBundles(bundle).keySet()));
         LOG.debug(format("Updating %s with URL %s", bundle, location));
@@ -254,11 +265,15 @@ public class BundleServiceImpl implements BundleService {
      * At this time, we will also calculate the difference in package wiring for the bundle compared to
      * when we enabled the DynamicImport
      */
-    public void disableDynamicImports(Bundle bundle) {
+    private void disableDynamicImports(Bundle bundle) {
         Set<String> current = getWiredBundles(bundle).keySet();
-        for (String original : bundle.getHeaders().get(ORIGINAL_WIRES).split(",")) {
-            current.remove(original);
-        }
+        Optional.of(bundle)
+            .map(Bundle::getHeaders)
+            .map(dict -> dict.get(ORIGINAL_WIRES))
+            .map(wires -> wires.split(","))
+            .stream()
+            .flatMap(Arrays::stream)
+            .forEach(current::remove);
 
         if (current.isEmpty()) {
             LOG.debug("No additional packages have been wired since dynamic import was enabled");


### PR DESCRIPTION
Current `bundle:dynamic-imports` command only allows toggling of dynamic imports. This PR adds an option to configure which packages are imported dynamically, instead of setting all-or-nothing, as well as adds option to explicitly set or unset the option.