### PR TITLE
feat(jakarta): Upgrade Pax Web to 11.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <felix.gogo.runtime.version>1.1.6</felix.gogo.runtime.version>
         <felix.gogo.jline.version>1.1.8</felix.gogo.jline.version>
         <felix.httplite.version>0.1.6</felix.httplite.version>
-        <felix.http.version>1.1.10</felix.http.version>
+        <felix.http.version>1.2.0</felix.http.version>
         <felix.inventory.version>2.0.0</felix.inventory.version>
         <felix.maven-bundle-plugin.version>6.0.2</felix.maven-bundle-plugin.version>
         <felix.utils.version>1.11.8</felix.utils.version>
@@ -329,8 +329,8 @@
         <pax.base.version>1.5.1</pax.base.version>
         <pax.swissbox.version>1.9.0</pax.swissbox.version>
         <pax.url.version>3.0.3</pax.url.version>
-        <pax.web.version>11.0.1</pax.web.version>
-        <jetty.version>12.0.23</jetty.version>
+        <pax.web.version>11.1.1</pax.web.version>
+        <jetty.version>12.1.9</jetty.version>
         <pax.tinybundle.version>4.0.1</pax.tinybundle.version>
         <pax.jdbc.version>1.5.7</pax.jdbc.version>
         <pax.jms.version>1.1.3</pax.jms.version>


### PR DESCRIPTION
* Upgrade Pax Web from 11.0.1 to 11.1.1
* Upgrade Jetty from 12.0.23 to 12.1.9
* Upgrade felix http to 1.2.0 (1.2.x is ee10 matching pax web)

---

#2427 upgraded Pax Web to 11.0.1 due to an incompatibility with felix http during runtime:
https://github.com/apache/karaf/pull/2427#issuecomment-4105673195

As felix http jetty12 v1.2.0 has been released compiled against a matching Jetty 12.1.x runtime, we can probably go a head and upgrade as well. Note that there is a release 2.0.0 available as well, but it is ee11, whereas pax web is ee10.

@jbonofre how can I reproduce the issue you encountered? Just try to open the webconsole?