### PR TITLE
Upgrade jackson legacy version to LTS 2.18.8

### DIFF
--- a/assemblies/features/specs/src/main/feature/feature.xml
+++ b/assemblies/features/specs/src/main/feature/feature.xml
@@ -74,24 +74,24 @@
         <bundle start-level="10" dependency="true">mvn:jakarta.mail/jakarta.mail-api/${spec.mail.version}</bundle>
     </feature>
 
-    <!-- jackson 2.18 -->
-    <feature name="jackson" version="2.18.3">
-        <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-core/2.18.3</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-annotations/2.18.3</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-databind/2.18.3</bundle>
+    <!-- jackson 2.18 (old LTS) -->
+    <feature name="jackson" version="2.18.8">
+        <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-core/2.18.8</bundle>
+        <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-annotations/2.18.8</bundle>
+        <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-databind/2.18.8</bundle>
     </feature>
 
-    <feature name="jackson-jaxrs" version="2.18.3">
+    <feature name="jackson-jaxrs" version="2.18.8">
         <feature>jackson</feature>
         <feature>jaxrs</feature>
         <feature>jakarta.annotation</feature>
         <bundle start-level="35">mvn:org.yaml/snakeyaml/2.5</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.3</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.18.3</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.18.3</bundle>
+        <bundle start-level="35">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.8</bundle>
+        <bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.18.8</bundle>
+        <bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.18.8</bundle>
     </feature>
 
-    <!-- jackson 2.20 -->
+    <!-- jackson 2.21 (current version) -->
     <feature name="jackson" version="${jackson.version}">
         <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
         <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.annotations.version}</bundle>


### PR DESCRIPTION
We currently keep 2.21.x and 2.18.x in `feature.xml` for convenience.
This PR upgrades old 2.18.3 to recent 2.18.8.

As long as we do not migrate to Jackson 3, we should keep this up to date....