### PR TITLE
Remove remaining org.apache.servicemix.specs BOM entries

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -810,41 +810,7 @@
                 <artifactId>easymock</artifactId>
                 <version>${easymock.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.servicemix.specs</groupId>
-                <artifactId>org.apache.servicemix.specs.activator</artifactId>
-                <version>${servicemix-spec.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.servicemix.specs</groupId>
-                <artifactId>org.apache.servicemix.specs.locator</artifactId>
-                <version>2.10</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.servicemix.specs</groupId>
-                <artifactId>org.apache.servicemix.specs.jaxp-api-1.4</artifactId>
-                <version>1.9.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.servicemix.specs</groupId>
-                <artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
-                <version>${servicemix-spec.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.servicemix.specs</groupId>
-                <artifactId>org.apache.servicemix.specs.jaxws-api-2.2</artifactId>
-                <version>${servicemix-spec.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.servicemix.specs</groupId>
-                <artifactId>org.apache.servicemix.specs.saaj-api-1.3</artifactId>
-                <version>${servicemix-spec.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.servicemix.specs</groupId>
-                <artifactId>org.apache.servicemix.specs.stax-api-1.2</artifactId>
-                <version>1.2_1</version>
-            </dependency>
+
             <dependency>
                 <groupId>org.apache.sshd</groupId>
                 <artifactId>sshd-osgi</artifactId>


### PR DESCRIPTION
Remove left over from specs removal in PR #1958.
This fixes Maven 4 build.

Fixes #2641