### PR TITLE
Add retry on wrapper resources download (karaf-4.4.x)

### DIFF
--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -113,78 +113,78 @@
                         <configuration>
                             <target>
                                 <!-- AIX PPC 32 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-aix-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar.gz" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-aix-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
                                 <gunzip src="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar" />
                                 <untar src="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar" dest="${project.build.directory}" />
                                 <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc32" />
                                 <copy file="${project.build.directory}/wrapper-aix-ppc-32-3.2.3/lib/libwrapper.a" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc32/libwrapper.a" />
                                 <copy file="${project.build.directory}/wrapper-aix-ppc-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc32/karaf-wrapper" />
                                 <!-- AIX PPC 64 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-aix-ppc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar.gz" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-aix-ppc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
                                 <gunzip src="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar" />
                                 <untar src="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar" dest="${project.build.directory}" />
                                 <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc64" />
                                 <copy file="${project.build.directory}/wrapper-aix-ppc-64-3.2.3/lib/libwrapper.a" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc64/libwrapper.a" />
                                 <copy file="${project.build.directory}/wrapper-aix-ppc-64-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc64/karaf-wrapper" />
                                 <!-- HPUX PARISC 64 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-hpux-parisc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar.gz" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-hpux-parisc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
                                 <gunzip src="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar" />
                                 <untar src="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar" dest="${project.build.directory}" />
                                 <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/hpux/parisc64" />
                                 <copy file="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3/lib/libwrapper.sl" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/hpux/parisc64/libwrapper.sl" />
                                 <copy file="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/hpux/parisc64/karaf-wrapper" />
                                 <!-- Linux x86 32 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-linux-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar.gz" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-linux-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
                                 <gunzip src="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar" />
                                 <untar src="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar" dest="${project.build.directory}" />
                                 <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux" />
                                 <copy file="${project.build.directory}/wrapper-linux-x86-32-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux/libwrapper.so" />
                                 <copy file="${project.build.directory}/wrapper-linux-x86-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux/karaf-wrapper" />
                                 <!-- Linux x86 64 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-linux-x86-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar.gz" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-linux-x86-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
                                 <gunzip src="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar" />
                                 <untar src="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar" dest="${project.build.directory}" />
                                 <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux64" />
                                 <copy file="${project.build.directory}/wrapper-linux-x86-64-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux64/libwrapper.so" />
                                 <copy file="${project.build.directory}/wrapper-linux-x86-64-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux64/karaf-wrapper" />
                                 <!-- MacOS X -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-macosx-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar.gz" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-macosx-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
                                 <gunzip src="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar" />
                                 <untar src="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar" dest="${project.build.directory}" />
                                 <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/macosx" />
                                 <copy file="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3/lib/libwrapper.jnilib" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/macosx/libwrapper.jnilib" />
                                 <copy file="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/macosx/karaf-wrapper" />
                                 <!-- Solaris SPARC 32 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-solaris-sparc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar.gz" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-solaris-sparc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
                                 <gunzip src="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar" />
                                 <untar src="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar" dest="${project.build.directory}" />
                                 <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc32" />
                                 <copy file="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc32/libwrapper.so" />
                                 <copy file="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc32/karaf-wrapper" />
                                 <!-- Solaris SPARC 64 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-solaris-sparc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar.gz" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-solaris-sparc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
                                 <gunzip src="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar" />
                                 <untar src="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar" dest="${project.build.directory}" />
                                 <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc64" />
                                 <copy file="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc64/libwrapper.so" />
                                 <copy file="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc64/karaf-wrapper" />
                                 <!-- Solaris x86 32 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-solaris-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar.gz" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-solaris-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
                                 <gunzip src="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar" />
                                 <untar src="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar" dest="${project.build.directory}" />
                                 <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/x86" />
                                 <copy file="${project.build.directory}/wrapper-solaris-x86-32-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/x86/libwrapper.so" />
-                                <copy file="${project.build.directory}/wrapper-solaris-x86-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/x86/karaf-wrapper" />                            
-                                <!-- Windows x86 32 --> 
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-windows-x86-32-3.2.3.zip" dest="${project.build.directory}/wrapper-windows-x86-32-3.2.3.zip" />
+                                <copy file="${project.build.directory}/wrapper-solaris-x86-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/x86/karaf-wrapper" />
+                                <!-- Windows x86 32 -->
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-windows-x86-32-3.2.3.zip" dest="${project.build.directory}/wrapper-windows-x86-32-3.2.3.zip" skipexisting="true" retries="5" maxtime="300" />
                                 <unzip src="${project.build.directory}/wrapper-windows-x86-32-3.2.3.zip" dest="${project.build.directory}" />
                                 <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows" />
                                 <copy file="${project.build.directory}/wrapper-windows-x86-32-3.2.3/lib/wrapper.dll" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows/wrapper.dll" />
-                                <copy file="${project.build.directory}/wrapper-windows-x86-32-3.2.3/bin/wrapper.exe" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows/wrapper.exe" />                            
+                                <copy file="${project.build.directory}/wrapper-windows-x86-32-3.2.3/bin/wrapper.exe" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows/wrapper.exe" />
                                 <!-- Windows x86 64 -->
                                 <mkdir dir="${project.build.directory}/windows64" />
-                                <get src="https://downloads.apache.org/karaf/wrapper/windows64/karaf-wrapper.exe" dest="${project.build.directory}/windows64/karaf-wrapper.exe" />
-                                <get src="https://downloads.apache.org/karaf/wrapper/windows64/wrapper.dll" dest="${project.build.directory}/windows64/wrapper.dll" />
+                                <get src="https://downloads.apache.org/karaf/wrapper/windows64/karaf-wrapper.exe" dest="${project.build.directory}/windows64/karaf-wrapper.exe" skipexisting="true" retries="5" maxtime="300" />
+                                <get src="https://downloads.apache.org/karaf/wrapper/windows64/wrapper.dll" dest="${project.build.directory}/windows64/wrapper.dll" skipexisting="true" retries="5" maxtime="300" />
                                 <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows64" />
                                 <copy file="${project.build.directory}/windows64/karaf-wrapper.exe" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows64/karaf-wrapper.exe" />
                                 <copy file="${project.build.directory}/windows64/wrapper.dll" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows64/wrapper.dll" />

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -112,79 +112,135 @@
                         </goals>
                         <configuration>
                             <target>
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
+                                <!-- The Tanuki native libraries below are fetched from download.tanukisoftware.com,
+                                     which intermittently rejects CI/cloud egress IPs (HTTP 403). Each download is
+                                     made non-fatal (ignoreerrors) and its extraction guarded by <available>, so a
+                                     blocked archive is skipped with a warning instead of failing the whole build.
+                                     The resulting bundle then omits the native libs that could not be downloaded. -->
                                 <!-- AIX PPC 32 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-aix-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
-                                <gunzip src="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar" />
-                                <untar src="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar" dest="${project.build.directory}" />
-                                <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc32" />
-                                <copy file="${project.build.directory}/wrapper-aix-ppc-32-3.2.3/lib/libwrapper.a" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc32/libwrapper.a" />
-                                <copy file="${project.build.directory}/wrapper-aix-ppc-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc32/karaf-wrapper" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-aix-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar.gz" retries="5" skipexisting="true" maxtime="300" ignoreerrors="true" />
+                                <if>
+                                    <available file="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar.gz" />
+                                    <then>
+                                        <gunzip src="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar" />
+                                        <untar src="${project.build.directory}/wrapper-aix-ppc-32-3.2.3.tar" dest="${project.build.directory}" />
+                                        <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc32" />
+                                        <copy file="${project.build.directory}/wrapper-aix-ppc-32-3.2.3/lib/libwrapper.a" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc32/libwrapper.a" />
+                                        <copy file="${project.build.directory}/wrapper-aix-ppc-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc32/karaf-wrapper" />
+                                    </then>
+                                </if>
                                 <!-- AIX PPC 64 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-aix-ppc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
-                                <gunzip src="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar" />
-                                <untar src="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar" dest="${project.build.directory}" />
-                                <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc64" />
-                                <copy file="${project.build.directory}/wrapper-aix-ppc-64-3.2.3/lib/libwrapper.a" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc64/libwrapper.a" />
-                                <copy file="${project.build.directory}/wrapper-aix-ppc-64-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc64/karaf-wrapper" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-aix-ppc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar.gz" retries="5" skipexisting="true" maxtime="300" ignoreerrors="true" />
+                                <if>
+                                    <available file="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar.gz" />
+                                    <then>
+                                        <gunzip src="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar" />
+                                        <untar src="${project.build.directory}/wrapper-aix-ppc-64-3.2.3.tar" dest="${project.build.directory}" />
+                                        <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc64" />
+                                        <copy file="${project.build.directory}/wrapper-aix-ppc-64-3.2.3/lib/libwrapper.a" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc64/libwrapper.a" />
+                                        <copy file="${project.build.directory}/wrapper-aix-ppc-64-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/aix/ppc64/karaf-wrapper" />
+                                    </then>
+                                </if>
                                 <!-- HPUX PARISC 64 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-hpux-parisc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
-                                <gunzip src="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar" />
-                                <untar src="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar" dest="${project.build.directory}" />
-                                <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/hpux/parisc64" />
-                                <copy file="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3/lib/libwrapper.sl" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/hpux/parisc64/libwrapper.sl" />
-                                <copy file="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/hpux/parisc64/karaf-wrapper" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-hpux-parisc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar.gz" retries="5" skipexisting="true" maxtime="300" ignoreerrors="true" />
+                                <if>
+                                    <available file="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar.gz" />
+                                    <then>
+                                        <gunzip src="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar" />
+                                        <untar src="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3.tar" dest="${project.build.directory}" />
+                                        <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/hpux/parisc64" />
+                                        <copy file="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3/lib/libwrapper.sl" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/hpux/parisc64/libwrapper.sl" />
+                                        <copy file="${project.build.directory}/wrapper-hpux-parisc-64-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/hpux/parisc64/karaf-wrapper" />
+                                    </then>
+                                </if>
                                 <!-- Linux x86 32 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-linux-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
-                                <gunzip src="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar" />
-                                <untar src="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar" dest="${project.build.directory}" />
-                                <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux" />
-                                <copy file="${project.build.directory}/wrapper-linux-x86-32-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux/libwrapper.so" />
-                                <copy file="${project.build.directory}/wrapper-linux-x86-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux/karaf-wrapper" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-linux-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar.gz" retries="5" skipexisting="true" maxtime="300" ignoreerrors="true" />
+                                <if>
+                                    <available file="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar.gz" />
+                                    <then>
+                                        <gunzip src="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar" />
+                                        <untar src="${project.build.directory}/wrapper-linux-x86-32-3.2.3.tar" dest="${project.build.directory}" />
+                                        <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux" />
+                                        <copy file="${project.build.directory}/wrapper-linux-x86-32-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux/libwrapper.so" />
+                                        <copy file="${project.build.directory}/wrapper-linux-x86-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux/karaf-wrapper" />
+                                    </then>
+                                </if>
                                 <!-- Linux x86 64 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-linux-x86-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
-                                <gunzip src="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar" />
-                                <untar src="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar" dest="${project.build.directory}" />
-                                <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux64" />
-                                <copy file="${project.build.directory}/wrapper-linux-x86-64-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux64/libwrapper.so" />
-                                <copy file="${project.build.directory}/wrapper-linux-x86-64-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux64/karaf-wrapper" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-linux-x86-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar.gz" retries="5" skipexisting="true" maxtime="300" ignoreerrors="true" />
+                                <if>
+                                    <available file="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar.gz" />
+                                    <then>
+                                        <gunzip src="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar" />
+                                        <untar src="${project.build.directory}/wrapper-linux-x86-64-3.2.3.tar" dest="${project.build.directory}" />
+                                        <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux64" />
+                                        <copy file="${project.build.directory}/wrapper-linux-x86-64-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux64/libwrapper.so" />
+                                        <copy file="${project.build.directory}/wrapper-linux-x86-64-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/linux64/karaf-wrapper" />
+                                    </then>
+                                </if>
                                 <!-- MacOS X -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-macosx-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
-                                <gunzip src="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar" />
-                                <untar src="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar" dest="${project.build.directory}" />
-                                <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/macosx" />
-                                <copy file="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3/lib/libwrapper.jnilib" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/macosx/libwrapper.jnilib" />
-                                <copy file="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/macosx/karaf-wrapper" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-macosx-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar.gz" retries="5" skipexisting="true" maxtime="300" ignoreerrors="true" />
+                                <if>
+                                    <available file="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar.gz" />
+                                    <then>
+                                        <gunzip src="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar" />
+                                        <untar src="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3.tar" dest="${project.build.directory}" />
+                                        <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/macosx" />
+                                        <copy file="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3/lib/libwrapper.jnilib" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/macosx/libwrapper.jnilib" />
+                                        <copy file="${project.build.directory}/wrapper-macosx-ppc-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/macosx/karaf-wrapper" />
+                                    </then>
+                                </if>
                                 <!-- Solaris SPARC 32 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-solaris-sparc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
-                                <gunzip src="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar" />
-                                <untar src="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar" dest="${project.build.directory}" />
-                                <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc32" />
-                                <copy file="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc32/libwrapper.so" />
-                                <copy file="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc32/karaf-wrapper" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-solaris-sparc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar.gz" retries="5" skipexisting="true" maxtime="300" ignoreerrors="true" />
+                                <if>
+                                    <available file="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar.gz" />
+                                    <then>
+                                        <gunzip src="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar" />
+                                        <untar src="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3.tar" dest="${project.build.directory}" />
+                                        <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc32" />
+                                        <copy file="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc32/libwrapper.so" />
+                                        <copy file="${project.build.directory}/wrapper-solaris-sparc-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc32/karaf-wrapper" />
+                                    </then>
+                                </if>
                                 <!-- Solaris SPARC 64 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-solaris-sparc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
-                                <gunzip src="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar" />
-                                <untar src="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar" dest="${project.build.directory}" />
-                                <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc64" />
-                                <copy file="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc64/libwrapper.so" />
-                                <copy file="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc64/karaf-wrapper" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-solaris-sparc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar.gz" retries="5" skipexisting="true" maxtime="300" ignoreerrors="true" />
+                                <if>
+                                    <available file="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar.gz" />
+                                    <then>
+                                        <gunzip src="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar" />
+                                        <untar src="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3.tar" dest="${project.build.directory}" />
+                                        <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc64" />
+                                        <copy file="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc64/libwrapper.so" />
+                                        <copy file="${project.build.directory}/wrapper-solaris-sparc-64-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/sparc64/karaf-wrapper" />
+                                    </then>
+                                </if>
                                 <!-- Solaris x86 32 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-solaris-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar.gz" skipexisting="true" retries="5" maxtime="300" />
-                                <gunzip src="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar" />
-                                <untar src="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar" dest="${project.build.directory}" />
-                                <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/x86" />
-                                <copy file="${project.build.directory}/wrapper-solaris-x86-32-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/x86/libwrapper.so" />
-                                <copy file="${project.build.directory}/wrapper-solaris-x86-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/x86/karaf-wrapper" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-solaris-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar.gz" retries="5" skipexisting="true" maxtime="300" ignoreerrors="true" />
+                                <if>
+                                    <available file="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar.gz" />
+                                    <then>
+                                        <gunzip src="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar.gz" dest="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar" />
+                                        <untar src="${project.build.directory}/wrapper-solaris-x86-32-3.2.3.tar" dest="${project.build.directory}" />
+                                        <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/x86" />
+                                        <copy file="${project.build.directory}/wrapper-solaris-x86-32-3.2.3/lib/libwrapper.so" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/x86/libwrapper.so" />
+                                        <copy file="${project.build.directory}/wrapper-solaris-x86-32-3.2.3/bin/wrapper" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/solaris/x86/karaf-wrapper" />
+                                    </then>
+                                </if>
                                 <!-- Windows x86 32 -->
-                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-windows-x86-32-3.2.3.zip" dest="${project.build.directory}/wrapper-windows-x86-32-3.2.3.zip" skipexisting="true" retries="5" maxtime="300" />
-                                <unzip src="${project.build.directory}/wrapper-windows-x86-32-3.2.3.zip" dest="${project.build.directory}" />
-                                <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows" />
-                                <copy file="${project.build.directory}/wrapper-windows-x86-32-3.2.3/lib/wrapper.dll" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows/wrapper.dll" />
-                                <copy file="${project.build.directory}/wrapper-windows-x86-32-3.2.3/bin/wrapper.exe" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows/wrapper.exe" />
+                                <get src="https://download.tanukisoftware.com/wrapper/3.2.3/wrapper-windows-x86-32-3.2.3.zip" dest="${project.build.directory}/wrapper-windows-x86-32-3.2.3.zip" retries="5" skipexisting="true" maxtime="300" ignoreerrors="true" />
+                                <if>
+                                    <available file="${project.build.directory}/wrapper-windows-x86-32-3.2.3.zip" />
+                                    <then>
+                                        <unzip src="${project.build.directory}/wrapper-windows-x86-32-3.2.3.zip" dest="${project.build.directory}" />
+                                        <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows" />
+                                        <copy file="${project.build.directory}/wrapper-windows-x86-32-3.2.3/lib/wrapper.dll" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows/wrapper.dll" />
+                                        <copy file="${project.build.directory}/wrapper-windows-x86-32-3.2.3/bin/wrapper.exe" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows/wrapper.exe" />
+                                    </then>
+                                </if>
                                 <!-- Windows x86 64 -->
                                 <mkdir dir="${project.build.directory}/windows64" />
-                                <get src="https://downloads.apache.org/karaf/wrapper/windows64/karaf-wrapper.exe" dest="${project.build.directory}/windows64/karaf-wrapper.exe" skipexisting="true" retries="5" maxtime="300" />
-                                <get src="https://downloads.apache.org/karaf/wrapper/windows64/wrapper.dll" dest="${project.build.directory}/windows64/wrapper.dll" skipexisting="true" retries="5" maxtime="300" />
+                                <get src="https://downloads.apache.org/karaf/wrapper/windows64/karaf-wrapper.exe" dest="${project.build.directory}/windows64/karaf-wrapper.exe" />
+                                <get src="https://downloads.apache.org/karaf/wrapper/windows64/wrapper.dll" dest="${project.build.directory}/windows64/wrapper.dll" />
                                 <mkdir dir="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows64" />
                                 <copy file="${project.build.directory}/windows64/karaf-wrapper.exe" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows64/karaf-wrapper.exe" />
                                 <copy file="${project.build.directory}/windows64/wrapper.dll" tofile="${project.build.directory}/classes/org/apache/karaf/wrapper/internal/windows64/wrapper.dll" />


### PR DESCRIPTION
Backport of #2728 to `karaf-4.4.x`.

Two commits applied cleanly (only `wrapper/pom.xml` is touched):

- Add retry on wrapper resources download
- Make wrapper native library downloads non-fatal when unreachable

`download.tanukisoftware.com` intermittently rejects CI/cloud egress IPs with HTTP 403, which retries alone cannot recover since the error is not transient. Each Tanuki download is marked `ignoreerrors` and its extraction is guarded with `<available>` (ant-contrib `<if>`), so a blocked archive is skipped with a warning instead of aborting the `wrapper.core` build. The bundle then omits only the native libraries that could not be downloaded.