### PR TITLE
Make JdbcExampleTest robust to reruns and command registration race (backport #2787)

### DIFF
--- a/itests/test/src/test/java/org/apache/karaf/itests/examples/JdbcExampleTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/examples/JdbcExampleTest.java
@@ -37,21 +37,46 @@ public class JdbcExampleTest extends BaseTest {
         // install the karaf-jdbc-example feature
         installAndAssertFeature("karaf-jdbc-example");
 
+        // use a unique flight code so the assertions are not disturbed by bookings possibly
+        // left over by a previous (retried) run: the example stores bookings in an AUTO_INCREMENT
+        // table that is shared across runs of the same Karaf instance
+        String flight = "AF" + System.currentTimeMillis();
+
         // add booking
-        executeCommand("booking:add Foo AF520");
+        executeCommand("booking:add Foo " + flight);
         // list booking
         String bookings = executeCommand("booking:list");
         System.out.println(bookings);
-        assertContains("AF520", bookings);
+        assertContains(flight, bookings);
+
+        // resolve the actual (auto-incremented) id instead of assuming it is 1
+        long id = bookingId(bookings, flight);
+
         // get booking
-        String booking = executeCommand("booking:get 1");
+        String booking = executeCommand("booking:get " + id);
         System.out.println(booking);
-        assertContains("AF520", booking);
+        assertContains(flight, booking);
         // remove booking
-        executeCommand("booking:remove 1");
+        executeCommand("booking:remove " + id);
         bookings = executeCommand("booking:list");
         System.out.println(bookings);
-        assertContainsNot("AF520", bookings);
+        assertContainsNot(flight, bookings);
+    }
+
+    /**
+     * Extracts the booking id (first column) of the row matching the given flight code from the
+     * {@code booking:list} shell table output.
+     */
+    private long bookingId(String listOutput, String flight) {
+        for (String line : listOutput.split("\\r?\\n")) {
+            if (line.contains(flight)) {
+                String id = line.split("\\|")[0].trim();
+                if (id.matches("\\d+")) {
+                    return Long.parseLong(id);
+                }
+            }
+        }
+        throw new IllegalStateException("No booking found for flight " + flight + " in:\n" + listOutput);
     }
 
 }

--- a/itests/test/src/test/java/org/apache/karaf/itests/examples/JdbcExampleTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/examples/JdbcExampleTest.java
@@ -68,11 +68,15 @@ public class JdbcExampleTest extends BaseTest {
      * {@code booking:list} shell table output.
      */
     private long bookingId(String listOutput, String flight) {
+        // the booking:list output is a ShellTable whose columns are separated by the Unicode
+        // box-drawing vertical bar (U+2502), not an ASCII '|', so extract the leading id digits
+        // directly rather than splitting on a column separator
+        java.util.regex.Pattern idPattern = java.util.regex.Pattern.compile("^\\s*(\\d+)");
         for (String line : listOutput.split("\\r?\\n")) {
             if (line.contains(flight)) {
-                String id = line.split("\\|")[0].trim();
-                if (id.matches("\\d+")) {
-                    return Long.parseLong(id);
+                java.util.regex.Matcher matcher = idPattern.matcher(line);
+                if (matcher.find()) {
+                    return Long.parseLong(matcher.group(1));
                 }
             }
         }


### PR DESCRIPTION
Backport of #2787 to `karaf-4.4.x`.

## What

Makes `org.apache.karaf.itests.examples.JdbcExampleTest` robust so it no longer fails intermittently on CI (observed on the `test (windows-latest)` job).

## Why it was failing

The test hard-coded the booking id (`1`) and asserted on a shared literal flight code (`AF520`):

1. The commands (`booking:add/list/get/remove`) are registered asynchronously as independent SCR components. On the slower Windows runner, the freshly-created shell session hit a registration race and `booking:remove` threw `CommandNotFoundException`.
2. That tripped the whole-method `@Retry` in `KarafTestSupport`, which re-runs `test()`. But the example stores bookings in an `AUTO_INCREMENT` H2 table that persists across runs of the same Karaf instance, so the rerun's `booking:add` got id `2` while id `1`'s `AF520` row lingered.
3. `booking:remove 1` + `assertContainsNot("AF520")` then failed **deterministically**.

## The fix

- Use a **unique flight code** per run (`"AF" + System.currentTimeMillis()`) so leftover rows from a previous/retried run cannot disturb the assertions.
- Resolve the **actual auto-incremented id** from the `booking:list` output instead of assuming `1`, and remove exactly that row.

Test-only change. Cherry-picked cleanly from the original commit.