### PR TITLE
Upgrade cxf from 3.6.10 to 3.6.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <bouncycastle.version>1.85</bouncycastle.version>
         <camel.version>4.18.2</camel.version>
         <cglib.version>3.2.9</cglib.version>
-        <cxf.version>3.6.10</cxf.version>
+        <cxf.version>3.6.12</cxf.version>
         <jackson.annotations.version>2.22</jackson.annotations.version>
         <jackson.version>2.22.1</jackson.version>
         <jna.version>5.19.1</jna.version>


### PR DESCRIPTION
As long as we do not upgrade main branch to cxf4, we should keep 3.6.x at latest patch level.
Dependabot somehow raised this PR only for 4.4.x branch, maybe due to previous ignore commands.

Note that cxf related versions in examples are not in sync!