### PR TITLE
Upgrade bouncy castle / bcprov from 1.85 to 1.85.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <asm.version>9.10.1</asm.version>
         <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
         <awaitility.version>4.3.0</awaitility.version>
-        <bouncycastle.version>1.85</bouncycastle.version>
+        <bouncycastle.version>1.85.2</bouncycastle.version>
         <camel.version>4.18.2</camel.version>
         <cglib.version>3.2.9</cglib.version>
         <cxf.version>4.2.3</cxf.version>


### PR DESCRIPTION
Patch-level bug-fix release:

https://www.bouncycastle.org/download/bouncy-castle-java/?filter=java%3Drelease-1-85-2