### PR TITLE
Remove deprecated Cookie calls in ProxyServlet

### DIFF
--- a/http/src/main/java/org/apache/karaf/http/core/internal/proxy/ProxyServlet.java
+++ b/http/src/main/java/org/apache/karaf/http/core/internal/proxy/ProxyServlet.java
@@ -326,12 +326,10 @@ public class ProxyServlet extends HttpServlet {
             //set cookie name prefixed w/ a proxy value so it won't collide w/ other cookies
             String proxyCookieName = getCookieNamePrefix() + cookie.getName();
             Cookie servletCookie = new Cookie(proxyCookieName, cookie.getValue());
-            servletCookie.setComment(cookie.getComment());
             servletCookie.setMaxAge((int) cookie.getMaxAge());
             servletCookie.setPath(path); //set to the path of the proxy servlet
             // don't set cookie domain
             servletCookie.setSecure(cookie.getSecure());
-            servletCookie.setVersion(cookie.getVersion());
             servletResponse.addCookie(servletCookie);
         }
     }


### PR DESCRIPTION
`Cookie.setComment(String)` and `Cookie.setVersion(int)` are deprecated for removal in Jakarta Servlet 6.1 and specified as no-ops: `setComment` is ignored and `getComment()` returns null, `setVersion` is ignored and `getVersion()` returns 0.

See documentation
https://jakarta.ee/specifications/servlet/6.1/apidocs/jakarta.servlet/jakarta/servlet/http/cookie

> With the adoption of support for RFC 6265, this method should no longer be used.
>
> If called, this method has no effect.