### PR TITLE
feat(assemblies): add karaf-light distribution using the simple feature resolver

### DIFF
--- a/assemblies/apache-karaf-light/pom.xml
+++ b/assemblies/apache-karaf-light/pom.xml
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.karaf.assemblies</groupId>
+        <artifactId>assemblies</artifactId>
+        <version>4.5.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.karaf</groupId>
+    <artifactId>apache-karaf-light</artifactId>
+    <packaging>pom</packaging>
+    <name>Apache Karaf :: Assemblies :: Light Distribution</name>
+
+    <properties>
+        <appendedResourcesDirectory>${basedir}/../etc/appended-resources</appendedResourcesDirectory>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>karaf-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>framework</artifactId>
+            <type>kar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>framework</artifactId>
+            <classifier>features</classifier>
+            <type>xml</type>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>standard</artifactId>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>specs</artifactId>
+            <classifier>features</classifier>
+            <type>xml</type>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>spring</artifactId>
+            <classifier>features</classifier>
+            <type>xml</type>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>enterprise</artifactId>
+            <classifier>features</classifier>
+            <type>xml</type>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/../..</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>examples/**/*</include>
+                </includes>
+                <excludes>
+                    <exclude>examples/**/target/**/*</exclude>
+                    <exclude>**/*.iml</exclude>
+                </excludes>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/distribution</directory>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>process-resources</id>
+                        <goals>
+                            <goal>resources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-remote-resources-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>install-kar</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>assembly</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>package</id>
+                        <goals>
+                            <goal>archive</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <installedFeatures>
+                        <feature>wrapper</feature>
+                        <feature>aries-blueprint</feature>
+                        <feature>shell-compat</feature>
+                    </installedFeatures>
+                    <startupFeatures>
+                        <feature>eventadmin</feature>
+                    </startupFeatures>
+                    <bootFeatures>
+                        <feature>wrap</feature>
+                        <feature>classpath</feature>
+                        <feature>shell</feature>
+                        <feature>feature</feature>
+                        <feature>jaas</feature>
+                        <feature>ssh</feature>
+                        <feature>management</feature>
+                        <feature>bundle</feature>
+                        <feature>config</feature>
+                        <feature>deployer</feature>
+                        <feature>diagnostic</feature>
+                        <feature>feature</feature>
+                        <feature>instance</feature>
+                        <feature>kar</feature>
+                        <feature>log</feature>
+                        <feature>package</feature>
+                        <feature>service</feature>
+                        <feature>system</feature>
+                    </bootFeatures>
+                    <libraries>
+                    </libraries>
+                    <javase>17</javase>
+                    <generateConsistencyReport>${project.build.directory}</generateConsistencyReport>
+                    <consistencyReportProjectName>Apache Karaf Light</consistencyReportProjectName>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>use-simple-resolver</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <replace file="${project.build.directory}/assembly/etc/org.apache.karaf.features.cfg"
+                                         token="#resolver=default"
+                                         value="resolver=simple" />
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.karaf.tooling</groupId>
+                        <artifactId>karaf-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>install-kar</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>package</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>use-simple-resolver</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/assemblies/apache-karaf-light/src/main/distribution/LICENSE
+++ b/assemblies/apache-karaf-light/src/main/distribution/LICENSE
@@ -1,0 +1,384 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-----------------------------------------------------------------------------
+
+This product bundles OSGi.
+
+Project URL: https://www.osgi.org/
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+-----------------------------------------------------------------------------
+
+This product bundles istack-common-runtime.
+
+Project URL: https://github.com/eclipse-ee4j/jaxb-istack-commons
+License: Eclipse Distribution License 1.0 - https://www.eclipse.org/org/documents/edl-v10.html
+
+-----------------------------------------------------------------------------
+
+This product bundles JAXB.
+
+Project URL: https://projects.eclipse.org/projects/ee4j.jaxb-impl
+License: Eclipse Distribution License 1.0 - https://www.eclipse.org/org/documents/edl-v10.html
+
+-----------------------------------------------------------------------------
+
+This product bundles javax.annotation-api.
+
+Project URL: https://github.com/javaee/javax.annotation
+License: CDDL 1.1 - http://www.opensource.org/licenses/cddl1.php
+
+-----------------------------------------------------------------------------
+
+This product bundles txw2.
+
+Project URL: https://eclipse-ee4j.github.io/jaxb-ri/
+License: Eclipse Distribution License 1.0 - https://www.eclipse.org/org/documents/edl-v10.html
+
+-----------------------------------------------------------------------------
+
+This product bundles BouncyCastle.
+
+Project URL: https://www.bouncycastle.org/
+License: MIT
+| Copyright (c) 2000 - 2023 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+| 
+| The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----------------------------------------------------------------------------
+
+This product bundles Eclipse Equinox.
+
+Project URL: https://projects.eclipse.org/projects/eclipse.equinox
+License: Eclipse Public License 2.0 - http://www.eclipse.org/legal/epl-2.0
+
+-----------------------------------------------------------------------------
+
+This product bundles Jansi.
+
+Project URL: https://github.com/fusesource/jansi
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+-----------------------------------------------------------------------------
+
+This product bundles JLine.
+
+Project URL: https://github.com/jline/jline3
+License: BSD 3-Clause
+| Copyright (c) 2002-2023, the original author or authors.
+| All rights reserved.
+| 
+| https://opensource.org/licenses/BSD-3-Clause
+| 
+| Redistribution and use in source and binary forms, with or
+| without modification, are permitted provided that the following
+| conditions are met:
+| 
+| Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+| 
+| Redistributions in binary form must reproduce the above copyright
+| notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with
+| the distribution.
+| 
+| Neither the name of JLine nor the names of its contributors
+| may be used to endorse or promote products derived from this
+| software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+| BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+| AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+| EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+| FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+| OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+| PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+| AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+| LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+| IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+| OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----------------------------------------------------------------------------
+
+This product bundles OPS4J PAX JDBC.
+
+Project URL: https://github.com/ops4j/org.ops4j.pax.jdbc
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+-----------------------------------------------------------------------------
+
+This product bundles OPS4J PAX JMS.
+
+Project URL: https://github.com/ops4j/org.ops4j.pax.jms
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+-----------------------------------------------------------------------------
+
+This product bundles OPS4J PAX Logging.
+
+Project URL: https://github.com/ops4j/org.ops4j.pax.logging
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+-----------------------------------------------------------------------------
+
+This product bundles OPS4J PAX Transx.
+
+Project URL: https://github.com/ops4j/org.ops4j.pax.transx
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+-----------------------------------------------------------------------------
+
+This product bundles OPS4J PAX URL.
+
+Project URL: https://github.com/ops4j/org.ops4j.pax.url
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+-----------------------------------------------------------------------------
+
+This product bundles OPS4J PAX Web.
+
+Project URL: https://github.com/ops4j/org.ops4j.pax.web
+License: Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+-----------------------------------------------------------------------------
+
+This product bundles ASM.
+
+Project URL: https://asm.ow2.io/
+License: MIT
+| ASM: a very small and fast Java bytecode manipulation framework
+| Copyright (c) 2000-2011 INRIA, France Telecom
+| All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions
+| are met:
+| 1. Redistributions of source code must retain the above copyright
+|   notice, this list of conditions and the following disclaimer.
+| 2. Redistributions in binary form must reproduce the above copyright
+|   notice, this list of conditions and the following disclaimer in the
+|   documentation and/or other materials provided with the distribution.
+| 3. Neither the name of the copyright holders nor the names of its
+|   contributors may be used to endorse or promote products derived from
+|   this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+| AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+| IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+| ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+| LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+| CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+| SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+| INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+| CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+| ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+| THE POSSIBILITY OF SUCH DAMAGE.
+
+-----------------------------------------------------------------------------

--- a/assemblies/apache-karaf-light/src/main/distribution/NOTICE
+++ b/assemblies/apache-karaf-light/src/main/distribution/NOTICE
@@ -1,0 +1,89 @@
+Apache Karaf
+Copyright 2025 The Apache Software Foundation
+
+-----------------------------------------------------------------------------
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+-----------------------------------------------------------------------------
+
+This product bundles OSGi with the following in its NOTICE:
+| # Notices for osgi
+| 
+| This content is produced and maintained by the OSGi Specification Project.
+| 
+|  * Project home: https://projects.eclipse.org/projects/technology.osgi
+| 
+| ## Trademarks
+| 
+| OSGi and the OSGi Logo are trademarks of the Eclipse Foundation. Eclipse and
+| the Eclipse Logo are registered trademarks of the Eclipse Foundation.
+| 
+| ## Copyright
+| 
+| All content is the property of the respective authors or their employers.
+| For more information regarding authorship of content, please consult the
+| listed source code repository logs.
+| 
+| ## Declared Project Licenses
+| 
+| This program and the accompanying materials are made available under the terms
+| of the Apache License, Version 2.0 which is available at
+| http://www.apache.org/licenses/LICENSE-2.0
+| 
+| SPDX-License-Identifier: Apache-2.0
+| 
+| ## Source Code
+| 
+| The project maintains the following source code repositories:
+| 
+|  * https://github.com/osgi/osgi.git
+| 
+| ## Third-party Content
+| 
+| The Content may include items that have been sourced from third parties as follows:</p>
+| 
+| JUnit
+| 
+|  * License: CPL-1.0 (JUnit 3), EPL-1.0 (JUnit 4), EPL-2.0 (JUnit 5)
+|  * Project: https://junit.org/
+|  * Source: https://github.com/junit-team
+| 
+| Apache Software Foundation
+| 
+|  * License: Apache-2.0
+|  * Project: https://apache.org/
+|  * Source: https://github.com/apache/
+
+-----------------------------------------------------------------------------
+
+This product bundles OPS4J PAX CDI with the following in its NOTICE:
+| OPS4J Pax CDI - Reactor Project
+| Copyright 2012 OPS4J.org
+| 
+| This product includes software developed at
+| OPS4J (http://www.ops4j.org/).
+| Licensed under the Apache License 2.0.
+
+-----------------------------------------------------------------------------
+
+This product bundles OPS4J PAX JDBC with the following in its NOTICE:
+| OPS4J Pax JDBC
+| Copyright 2012 OPS4J.org
+| 
+| This product includes software developed at
+| OPS4J (http://www.ops4j.org/).
+| Licensed under the Apache License 2.0.
+
+-----------------------------------------------------------------------------
+
+This product bundles OPS4J PAX Transx with the following in its NOTICE:
+| OPS4J Pax Transx
+| Copyright 2017 OPS4J.org
+| 
+| This product includes software developed at
+| OPS4J (http://www.ops4j.org/).
+| Licensed under the Apache License 2.0.
+
+-----------------------------------------------------------------------------

--- a/assemblies/apache-karaf-light/src/main/distribution/README.md
+++ b/assemblies/apache-karaf-light/src/main/distribution/README.md
@@ -1,0 +1,69 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# Apache Karaf - Light Distribution
+
+[Apache Karaf](https://karaf.apache.org) is a modulith runtime, supporting several frameworks and programming model (REST/API, web, spring boot, ...).
+It provides turnkey features that you can directly leverage without effort, packaged as mutable or immutable application.
+
+## Overview
+
+* **Hot deployment**: Karaf supports hot deployment of applications (in the deploy directory).
+* **Dynamic configuration**: Karaf uses a central location (etc directory) for configuration
+  (in different format, properties, json) and can be plug on existing configuration backend.
+* **Logging System**: using a centralized logging back end supported by Log4J, Karaf
+  supports a number of different APIs (JDK 1.4, JCL, SLF4J, Avalon, Tomcat, ...)
+* **Provisioning**: Provisioning of libraries or applications can be done through a number of
+  different ways, by which they will be downloaded locally, installed and started. It interacts
+  with the resolver to automatically install the required components.
+* **Extensible Shell console**: Karaf features a nice text console where you can manage the
+  services, install new applications or libraries and manage their state. This shell is easily
+  extensible by deploying new commands dynamically along with new features or applications.
+* **Remote access**: use any SSH client to connect to the kernel and issue commands in the console
+* **Security & ACL** framework based on JAAS providing complete RBAC solution.
+* **Managing instances**: Karaf provides simple commands for managing instances of Karaf.
+  You can easily create, delete, start and stop instances of Karaf through the console.
+* **Enterprise features**: Karaf provides a bunch of enterprise features that you can use in your applications (JDBC, JPA, JTA, JMS, ...).
+* **HTTP Service**: Karaf provides a full features web container, allowing you to deploy your web applications.
+* **REST & Services**: Karaf supports different service frameworks as Apache CXF allowing you to easily implements your services.
+* **Karaf Extensions**: Karaf project is a complete ecosystem. The runtime can be extended by other Karaf subprojects such as Karaf Decanter, Karaf Cellar, Karaf Cave, ...
+* **Third Party Extensions**: Karaf is a supported runtime for a lot of other projects as [Apache Camel](https://camel.apache.org), and much more.
+
+The light distribution provides the same features as the standard distribution, but installs features and
+bundles using the "simple" feature resolver (`resolver=simple` in `etc/org.apache.karaf.features.cfg`) instead
+of the default OSGi resolver. Features and bundles are installed in declaration order, without computing
+requirements/capabilities, which is faster and deterministic at the cost of not resolving feature/service
+requirements, conditional features, and resource repositories. See the provisioning section of the
+[documentation](https://karaf.apache.org/manual/latest/#_feature_and_resolver) for details.
+
+## Prerequisites
+
+Apache Karaf requires a Java SE 11 or higher to run.
+
+## Start
+
+To start the Karaf runtime, run:
+
+```
+bin/karaf
+```
+
+## Documentation
+
+Please take a look on the [documentation](https://karaf.apache.org/manual/latest/) for details.

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -38,6 +38,7 @@
         <module>apache-karaf-minimal</module>
         <module>apache-karaf</module>
         <module>apache-karaf-mix</module>
+        <module>apache-karaf-light</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Summary
- Add a new `apache-karaf-light` assembly (`assemblies/apache-karaf-light`) with the same feature set as the default `apache-karaf` distribution (framework, standard, specs, spring, enterprise features; same startup/boot/installed features).
- The generated `etc/org.apache.karaf.features.cfg` has `resolver=simple` set by default, so features and bundles are installed in declaration order using the simple feature resolver added in #2308, instead of the default OSGi capabilities resolver.
- Register the new module in `assemblies/pom.xml`.

## Test plan
- [x] `mvn -pl assemblies/apache-karaf-light install` builds successfully and produces `apache-karaf-light-<version>.tar.gz` / `.zip`.
- [x] Verified the generated `etc/org.apache.karaf.features.cfg` has `resolver=simple` while `featuresBoot` / `featuresRepositories` are still correctly populated.
- [x] `mvn -pl assemblies/apache-karaf-light install -Ptest` builds successfully (CI profile, matching the other distributions).