### PR TITLE
fix(config): restrict config:install to the admin role (backport #2861)

### DIFF
--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -616,6 +616,12 @@ edit = manager
 edit[/.*jmx[.]acl.*/] = admin
 edit[/.*org[.]apache[.]karaf[.]command[.]acl[.].+/] = admin
 edit[/.*org[.]apache[.]karaf[.]service[.]acl[.].+/] = admin
+#
+# 'install' writes an arbitrary file (fetched from a URL) into ${karaf.etc}, which
+# includes the users, keys and *.acl.* configuration files. It is restricted to
+# 'admin', consistent with bundle:install, feature:install and kar:install.
+#
+install = admin
 property-append = manager
 property-append[/.*jmx[.]acl.*/] = admin
 property-append[/.*org[.]apache[.]karaf[.]command[.]acl[.].+/] = admin

--- a/instance/src/main/resources/org/apache/karaf/instance/resources/etc/org.apache.karaf.command.acl.config.cfg
+++ b/instance/src/main/resources/org/apache/karaf/instance/resources/etc/org.apache.karaf.command.acl.config.cfg
@@ -29,6 +29,12 @@ edit = manager
 edit[/.*jmx[.]acl.*/] = admin
 edit[/.*org[.]apache[.]karaf[.]command[.]acl[.].+/] = admin
 edit[/.*org[.]apache[.]karaf[.]service[.]acl[.].+/] = admin
+#
+# 'install' writes an arbitrary file (fetched from a URL) into ${karaf.etc}, which
+# includes the users, keys and *.acl.* configuration files. It is restricted to
+# 'admin', consistent with bundle:install, feature:install and kar:install.
+#
+install = admin
 property-append = manager
 property-append[/.*jmx[.]acl.*/] = admin
 property-append[/.*org[.]apache[.]karaf[.]command[.]acl[.].+/] = admin

--- a/itests/test/src/test/filtered-resources/etc/feature.xml
+++ b/itests/test/src/test/filtered-resources/etc/feature.xml
@@ -411,6 +411,12 @@
                 edit[/.*jmx[.]acl.*/] = admin
                 edit[/.*org[.]apache[.]karaf[.]command[.]acl[.].+/] = admin
                 edit[/.*org[.]apache[.]karaf[.]service[.]acl[.].+/] = admin
+                #
+                # 'install' writes an arbitrary file (fetched from a URL) into ${karaf.etc}, which
+                # includes the users, keys and *.acl.* configuration files. It is restricted to
+                # 'admin', consistent with bundle:install, feature:install and kar:install.
+                #
+                install = admin
                 property-append = manager
                 property-append[/.*jmx[.]acl.*/] = admin
                 property-append[/.*org[.]apache[.]karaf[.]command[.]acl[.].+/] = admin

--- a/itests/test/src/test/java/org/apache/karaf/itests/ssh/ConfigSshCommandSecurityTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/ssh/ConfigSshCommandSecurityTest.java
@@ -13,6 +13,9 @@
  */
 package org.apache.karaf.itests.ssh;
 
+import java.io.File;
+
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -50,6 +53,33 @@ public class ConfigSshCommandSecurityTest extends SshCommandTestBase {
         testConfigEdits("karaf", Result.OK, "jmx.acl.test_" + counter++, true);
         testConfigEdits("karaf", Result.OK, "org.apache.karaf.command.acl.test_" + counter++, true);
         testConfigEdits("karaf", Result.OK, "org.apache.karaf.service.acl.test_" + counter++, true);
+    }
+
+    @Test
+    public void testConfigInstallCommandSecurityViaSsh() throws Exception {
+        // Skip on Windows where PTY output can be garbled,
+        // when upgrading to Junit5, this can be replaced with @DisabledOnOs(OS.WINDOWS)
+        // TODO: remove this once we have a better solution for PTY output on Windows
+        Assume.assumeFalse(System.getProperty("os.name", "").toLowerCase().contains("win"));
+
+        String manageruser = "man" + System.nanoTime() + "_" + counter++;
+        String vieweruser = "view" + System.nanoTime() + "_" + counter++;
+
+        addUsers(manageruser, vieweruser);
+
+        String sourceUrl = new File(System.getProperty("karaf.etc"), "system.properties").toURI().toURL().toString();
+
+        // config:install writes an arbitrary file under ${karaf.etc}, so it is restricted to admin.
+        // A viewer and a manager must not even see the command.
+        assertCommand(vieweruser, "config:install " + sourceUrl + " itest-" + counter++ + ".cfg", Result.NOT_FOUND);
+        assertCommand(manageruser, "config:install " + sourceUrl + " itest-" + counter++ + ".cfg", Result.NOT_FOUND);
+
+        // The admin user can run it: the first install succeeds, a second one without --override
+        // reports that the file already exists, which proves the file was written.
+        String target = "itest-installed-" + counter++ + ".cfg";
+        assertCommand("karaf", "config:install " + sourceUrl + " " + target, Result.OK);
+        assertContains("already exists",
+                assertCommand("karaf", "config:install " + sourceUrl + " " + target, Result.OK));
     }
 
     private void testConfigEdits(String user, Result expectedEditResult, String pid, boolean isAdmin) throws Exception {

--- a/manual/src/main/asciidoc/user-guide/security.adoc
+++ b/manual/src/main/asciidoc/user-guide/security.adoc
@@ -489,7 +489,8 @@ By default, Apache Karaf defines the following commands ACLs:
 * `etc/org.apache.karaf.command.acl.config.cfg` configuration file defines the ACL for `config:*` commands.
  This ACL limits the execution of `config:*` commands with `jmx.acl.*`, `org.apache.karaf.command.acl.*`, and
  `org.apache.karaf.service.acl.*` configuration PID to the users with `admin` role. For the other configuration PID,
- the users with the `manager` role can execute `config:*` commands.
+ the users with the `manager` role can execute `config:*` commands. As `config:install` writes an arbitrary file into
+ the `etc` folder, it is restricted to the users with the `admin` role.
 * `etc/org.apache.karaf.command.acl.feature.cfg` configuration file defines the ACL for `feature:*` commands.
  Only the users with `admin` role can execute `feature:install`, `feature:uninstall`,`feature:start`, `feature:stop` and `feature:update` commands. The other `feature:*`
  commands can be executed by any user.


### PR DESCRIPTION
Backport of #2861 to `karaf-4.4.x`.

## Problem

`config:install <url> <finalname>` downloads a file from an arbitrary URL and writes it into `${karaf.etc}` (the `-o`/`--override` option lets it overwrite an existing file). That folder also holds `users.properties`, `keys.properties`, `host.key` and every `org.apache.karaf.*.acl.*` file.

The command has **no entry** in `org.apache.karaf.command.acl.config`. `SecuredSessionFactoryImpl.checkSecurity()` treats an unmatched command as allowed (`Specificity.NO_MATCH` → `passCheck = true`), and `karaf.secured.command.compulsory.roles` ships commented out, so **any authenticated shell/SSH user** — including a `viewer` — can run `config:install` and overwrite, for example, the command ACL files or `users.properties`.

By contrast `bundle:install`, `feature:install` and `kar:install` are all `admin`-only in their own ACLs, and `config:delete` is `admin` in this same ACL.

## Fix

Add `install = admin` to the `config` command ACL, in both shipped locations:

- `assemblies/features/standard/src/main/feature/feature.xml` (`<config>` block)
- `instance/.../etc/org.apache.karaf.command.acl.config.cfg` (instance template)

and to the itest etc fixture (`itests/test/src/test/filtered-resources/etc/feature.xml`).

## Test

`ConfigSshCommandSecurityTest#testConfigInstallCommandSecurityViaSsh` — a `viewer` and a `manager` get `Command not found`; an `admin` can run it.

## Note

The underlying fail-open behaviour (unmatched command → allowed, with `karaf.secured.command.compulsory.roles` disabled by default) is a broader hardening question tracked separately; this PR only closes the `config:install` gap.
