### PR TITLE
fix(examples): use the Jakarta REST variants of the Jackson JSON provider

### DIFF
--- a/examples/karaf-rest-example/karaf-rest-example-blueprint/src/main/resources/OSGI-INF/blueprint/rest.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-blueprint/src/main/resources/OSGI-INF/blueprint/rest.xml
@@ -37,7 +37,7 @@
             <ref component-id="bookingBean" />
         </jaxrs:serviceBeans>
         <jaxrs:providers>
-            <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
+            <bean class="com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider"/>
         </jaxrs:providers>
     </jaxrs:server>
 

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/pom.xml
@@ -51,8 +51,8 @@
             <version>4.0.0</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson.version}</version>
         </dependency>
         <dependency>

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/AddBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/AddBookingCommand.java
@@ -16,7 +16,7 @@
  */
 package org.apache.karaf.examples.rest.client.jersey;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 import org.apache.karaf.examples.rest.api.Booking;
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.Argument;

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/ListBookingCommand.java
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/src/main/java/org/apache/karaf/examples/rest/client/jersey/ListBookingCommand.java
@@ -16,7 +16,7 @@
  */
 package org.apache.karaf.examples.rest.client.jersey;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 import org.apache.karaf.examples.rest.api.Booking;
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.Command;

--- a/examples/karaf-rest-example/karaf-rest-example-features/src/main/feature/feature.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-features/src/main/feature/feature.xml
@@ -33,8 +33,8 @@
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.annotations.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${jackson.version}</bundle>
         <bundle>mvn:org.apache.karaf.examples/karaf-rest-example-blueprint/${project.version}</bundle>
     </feature>
 
@@ -69,9 +69,9 @@
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.annotations.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${jackson.version}</bundle>
         <bundle>mvn:org.apache.karaf.examples/karaf-rest-example-scr/${project.version}</bundle>
     </feature>
 


### PR DESCRIPTION
The com.fasterxml.jackson.jaxrs artifacts implement JAX-RS 2.x and import javax.ws.rs; jackson-module-jaxb-annotations likewise imports javax.xml.bind. Karaf 4.5 ships neither package, so the REST example bundles referencing them cannot resolve.

Switch the remaining references to the jakarta.rs and jakarta-xmlbind variants. The SCR and CXF client modules already used them; this covers the Jersey client, the Blueprint provider bean and the feature.