### PR TITLE
fix(examples): align the Jakarta REST API version with CXF

### DIFF
--- a/examples/karaf-rest-example/karaf-rest-example-blueprint/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-blueprint/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>4.0.0</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.examples</groupId>

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>jakarta.ws.rs</groupId>
 			<artifactId>jakarta.ws.rs-api</artifactId>
-			<version>4.0.0</version>
+			<version>3.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.karaf.examples</groupId>

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>4.0.0</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/examples/karaf-rest-example/karaf-rest-example-scr/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-scr/pom.xml
@@ -55,6 +55,12 @@
             <artifactId>org.osgi.service.component.annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- pinned ahead of CXF, which compiles against 4.0.0 but imports jakarta.ws.rs [3,4) -->
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>

--- a/examples/karaf-rest-example/karaf-rest-example-whiteboard/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-whiteboard/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>4.0.0</version>
+            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The REST example modules compiled against jakarta.ws.rs-api 4.0.0, so their manifests required jakarta.ws.rs [4.0,5). CXF 4.2.3 imports [3,4), meaning the API bundle it resolves against can never satisfy the example bundles.

Compile against 3.1.0 instead, the version matching CXF 4.x. The SCR module has no declaration of its own and inherited 4.0.0 through CXF, so pin it explicitly.

This PR was created with help from AI.

Two more PRs in the pipeline, requiring 2869 and 2871.