### PR TITLE
Escape %u/%dn/%fqdn substitutions in LDAP search filters

### DIFF
--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPBackingEngine.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPBackingEngine.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -74,8 +75,7 @@ public class LDAPBackingEngine implements BackingEngine {
             }
 
             String filter = options.getUserFilter();
-            filter = filter.replaceAll(Pattern.quote("%u"), username);
-            filter = filter.replace("\\", "\\\\");
+            filter = filter.replaceAll(Pattern.quote("%u"), Matcher.quoteReplacement(Util.doRFC2254Encoding(username)));
 
             LOGGER.debug("Looking for user {} in LDAP with", username);
             LOGGER.debug("   base DN: {}", options.getUserBaseDn());

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPCache.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPCache.java
@@ -196,8 +196,7 @@ public class LDAPCache implements Closeable, NamespaceChangeListener, ObjectChan
         }
 
         String filter = options.getUserFilter();
-        filter = filter.replaceAll(Pattern.quote("%u"), Matcher.quoteReplacement(user));
-        filter = filter.replace("\\", "\\\\");
+        filter = filter.replaceAll(Pattern.quote("%u"), Matcher.quoteReplacement(Util.doRFC2254Encoding(user)));
 
         LOGGER.debug("Looking for the user in LDAP with ");
         LOGGER.debug("  base DN: " + options.getUserBaseDn());
@@ -297,10 +296,9 @@ public class LDAPCache implements Closeable, NamespaceChangeListener, ObjectChan
 
         String filter = options.getRoleFilter();
         if (filter != null) {
-            filter = filter.replaceAll(Pattern.quote("%u"), Matcher.quoteReplacement(user));
-            filter = filter.replaceAll(Pattern.quote("%dn"), Matcher.quoteReplacement(userDn));
-            filter = filter.replaceAll(Pattern.quote("%fqdn"), Matcher.quoteReplacement(userDnNamespace));
-            filter = filter.replace("\\", "\\\\");
+            filter = filter.replaceAll(Pattern.quote("%u"), Matcher.quoteReplacement(Util.doRFC2254Encoding(user)));
+            filter = filter.replaceAll(Pattern.quote("%dn"), Matcher.quoteReplacement(Util.doRFC2254Encoding(userDn)));
+            filter = filter.replaceAll(Pattern.quote("%fqdn"), Matcher.quoteReplacement(Util.doRFC2254Encoding(userDnNamespace)));
 
             LOGGER.debug("Looking for the user roles in LDAP with ");
             LOGGER.debug("  base DN: {}", options.getRoleBaseDn());

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPLoginModule.java
@@ -70,7 +70,7 @@ public class LDAPLoginModule extends AbstractKarafLoginModule {
             throw new LoginException(unsupportedCallbackException.getMessage() + " not available to obtain information from user.");
         }
 
-        user = Util.doRFC2254Encoding(((NameCallback) callbacks[0]).getName());
+        user = ((NameCallback) callbacks[0]).getName();
 
         char[] tmpPassword = ((PasswordCallback) callbacks[1]).getPassword();
 

--- a/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPPubkeyLoginModule.java
+++ b/jaas/modules/src/main/java/org/apache/karaf/jaas/modules/ldap/LDAPPubkeyLoginModule.java
@@ -69,7 +69,7 @@ public class LDAPPubkeyLoginModule extends AbstractKarafLoginModule {
             throw new LoginException(unsupportedCallbackException.getMessage() + " not available to obtain information from user.");
         }
 
-        user = Util.doRFC2254Encoding(((NameCallback) callbacks[0]).getName());
+        user = ((NameCallback) callbacks[0]).getName();
 
         PublicKey remotePubkey = ((PublickeyCallback) callbacks[1]).getPublicKey();
 

--- a/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapCacheTest.java
+++ b/jaas/modules/src/test/java/org/apache/karaf/jaas/modules/ldap/LdapCacheTest.java
@@ -19,6 +19,7 @@ import static org.apache.karaf.jaas.modules.PrincipalHelper.names;
 import static org.apache.karaf.jaas.modules.ldap.LdapPropsUpdater.ldapProps;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -118,6 +119,22 @@ public class LdapCacheTest extends AbstractLdapTestUnit {
                 }
             }
         }
+    }
+
+    @Test
+    public void testUserFilterInjectionDoesNotWidenSearch() throws Exception {
+        // "*" would widen (uid=%u) to (uid=*), matching any existing user, unless
+        // the substituted value is properly filter-escaped (CWE-90).
+        Properties options = ldapLoginModuleOptions();
+        LDAPCache cache = LDAPCache.getCache(new LDAPOptions(options));
+        assertNull(cache.getUserDnAndNamespace("*"));
+    }
+
+    @Test
+    public void testBackingEngineUserFilterInjectionDoesNotWidenSearch() throws Exception {
+        Properties options = ldapLoginModuleOptions();
+        LDAPBackingEngine engine = new LDAPBackingEngine(options);
+        assertNull(engine.lookupUser("*"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `LDAPCache` and `LDAPBackingEngine.lookupUser` built LDAP search filters by substituting `%u`/`%dn`/`%fqdn` and only doubling backslashes, which does not escape `*`, `(`, `)`, or NUL. A username containing filter metacharacters (e.g. `*`) could widen a search filter to match an unintended directory entry instead of failing lookup, and could similarly widen role-search filters.
- `LDAPLoginModule`/`LDAPPubkeyLoginModule` masked this for their own callers by pre-escaping the username before it reached the cache, but `GSSAPILdapLoginModule` and `LDAPBackingEngine.lookupUser` did not escape at all.
- This centralizes proper RFC 4515 filter escaping (via the existing `Util.doRFC2254Encoding` helper) at the point filters are actually built in `LDAPCache`/`LDAPBackingEngine`, and removes the now-redundant pre-escaping in `LDAPLoginModule`/`LDAPPubkeyLoginModule` so escaping happens exactly once. `GSSAPILdapLoginModule` needed no change since it now goes through the fixed `LDAPCache` path.

## Test plan
- [x] Added `LdapCacheTest.testUserFilterInjectionDoesNotWidenSearch` and `testBackingEngineUserFilterInjectionDoesNotWidenSearch`, which call `LDAPCache.getUserDnAndNamespace("*")` / `LDAPBackingEngine.lookupUser("*")` and assert no match.
- [x] Verified both new tests fail against the pre-fix code (a `"*"` username matched an unrelated real user) and pass with the fix.
- [x] Full existing LDAP JAAS test suite (`LdapLoginModuleTest`, `LdapLoginModuleWithEscapesTest`, `LdapCacheTest`, `LDAPPubkeyLoginModuleTest`, `GSSAPILdapLoginModuleTest`, `LdapCaseInsensitiveDNTest`, `LdapPoolingTest`, `LdapSpecialCharsInPasswordTest`) passes, including the DN-special-character and `%fqdn` role-mapping tests.