### PR TITLE
[4.4.x] fix(itests): Speed up JVM teardown by using TCP communication instead of stdio 

### DIFF
--- a/examples/karaf-itest-example/pom.xml
+++ b/examples/karaf-itest-example/pom.xml
@@ -128,6 +128,9 @@
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
+                    <!-- Use SurefireForkNodeFactory to switch to TCP communication to JVM instead of stdin/stdout
+                         to avoid interfering with pax exam leading to 30sec timeouts during shutdown -->
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                     <systemPropertyVariables>
                         <my.system.property>foo</my.system.property>
                     </systemPropertyVariables>

--- a/itests/test/pom.xml
+++ b/itests/test/pom.xml
@@ -310,6 +310,9 @@
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
+                    <!-- Use SurefireForkNodeFactory to switch to TCP communication to JVM instead of stdin/stdout
+                         to avoid interfering with pax exam leading to 30sec timeouts during shutdown -->
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                     <systemPropertyVariables>
                         <org.ops4j.pax.logging.DefaultServiceLog.level>INFO</org.ops4j.pax.logging.DefaultServiceLog.level>
                         <spring31.version>${spring31.version}</spring31.version>
@@ -375,6 +378,9 @@
                             <excludes>
                                 <exclude>MavenTest</exclude>
                             </excludes>
+                            <!-- Use SurefireForkNodeFactory to switch to TCP communication to JVM instead of stdin/stdout
+                                to avoid interfering with pax exam leading to 30sec timeouts during shutdown -->
+                            <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                             <systemPropertyVariables>
                                 <org.ops4j.pax.url.mvn.localRepository>${maven.repo.local}</org.ops4j.pax.url.mvn.localRepository>
                                 <org.ops4j.pax.logging.DefaultServiceLog.level>INFO</org.ops4j.pax.logging.DefaultServiceLog.level>


### PR DESCRIPTION
This is a backport of #2815 to 4.4.x.
It seems we are still going for 4.4.x releases for a while.