### PR TITLE
[karaf-4.4.x] Restrict feature:repo-add -i and feature:repo-remove -u to admin role

### DIFF
--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -151,6 +151,8 @@ install = admin
 uninstall = admin
 start = admin
 stop = admin
+repo-add[/.*[-][i].*/] = admin
+repo-remove[/.*[-][u].*/] = admin
             </config>
             <bundle start-level="30">mvn:org.apache.karaf.features/org.apache.karaf.features.command/${project.version}</bundle>
         </conditional>

--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -152,7 +152,9 @@ uninstall = admin
 start = admin
 stop = admin
 repo-add[/.*[-][i].*/] = admin
+repo-add = viewer
 repo-remove[/.*[-][u].*/] = admin
+repo-remove = viewer
             </config>
             <bundle start-level="30">mvn:org.apache.karaf.features/org.apache.karaf.features.command/${project.version}</bundle>
         </conditional>

--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -151,6 +151,13 @@ install = admin
 uninstall = admin
 start = admin
 stop = admin
+#
+# repo-add/repo-remove stay open to the viewer role (the plain form only reads/lists
+# a repository), but installing/uninstalling every feature in it via -i/-u requires
+# admin. The bare "= viewer" fallback is required: a command with a regex-only ACL
+# entry and no fallback is treated as admin-only for *every* invocation, because the
+# command guard decides visibility before it knows the actual arguments.
+#
 repo-add[/.*[-][i].*/] = admin
 repo-add = viewer
 repo-remove[/.*[-][u].*/] = admin

--- a/instance/src/main/resources/org/apache/karaf/instance/resources/etc/org.apache.karaf.command.acl.feature.cfg
+++ b/instance/src/main/resources/org/apache/karaf/instance/resources/etc/org.apache.karaf.command.acl.feature.cfg
@@ -24,3 +24,5 @@ install = admin
 uninstall = admin
 start = admin
 stop = admin
+repo-add[/.*[-][i].*/] = admin
+repo-remove[/.*[-][u].*/] = admin

--- a/instance/src/main/resources/org/apache/karaf/instance/resources/etc/org.apache.karaf.command.acl.feature.cfg
+++ b/instance/src/main/resources/org/apache/karaf/instance/resources/etc/org.apache.karaf.command.acl.feature.cfg
@@ -25,4 +25,6 @@ uninstall = admin
 start = admin
 stop = admin
 repo-add[/.*[-][i].*/] = admin
+repo-add = viewer
 repo-remove[/.*[-][u].*/] = admin
+repo-remove = viewer

--- a/instance/src/main/resources/org/apache/karaf/instance/resources/etc/org.apache.karaf.command.acl.feature.cfg
+++ b/instance/src/main/resources/org/apache/karaf/instance/resources/etc/org.apache.karaf.command.acl.feature.cfg
@@ -24,6 +24,13 @@ install = admin
 uninstall = admin
 start = admin
 stop = admin
+#
+# repo-add/repo-remove stay open to the viewer role (the plain form only reads/lists
+# a repository), but installing/uninstalling every feature in it via -i/-u requires
+# admin. The bare "= viewer" fallback is required: a command with a regex-only ACL
+# entry and no fallback is treated as admin-only for *every* invocation, because the
+# command guard decides visibility before it knows the actual arguments.
+#
 repo-add[/.*[-][i].*/] = admin
 repo-add = viewer
 repo-remove[/.*[-][u].*/] = admin

--- a/itests/test/src/test/filtered-resources/etc/feature.xml
+++ b/itests/test/src/test/filtered-resources/etc/feature.xml
@@ -111,7 +111,9 @@
                 start = admin
                 stop = admin
                 repo-add[/.*[-][i].*/] = admin
+                repo-add = viewer
                 repo-remove[/.*[-][u].*/] = admin
+                repo-remove = viewer
             </config>
             <bundle start-level="30">mvn:org.apache.karaf.features/org.apache.karaf.features.command/${project.version}</bundle>
         </conditional>

--- a/itests/test/src/test/filtered-resources/etc/feature.xml
+++ b/itests/test/src/test/filtered-resources/etc/feature.xml
@@ -110,6 +110,8 @@
                 uninstall = admin
                 start = admin
                 stop = admin
+                repo-add[/.*[-][i].*/] = admin
+                repo-remove[/.*[-][u].*/] = admin
             </config>
             <bundle start-level="30">mvn:org.apache.karaf.features/org.apache.karaf.features.command/${project.version}</bundle>
         </conditional>

--- a/itests/test/src/test/java/org/apache/karaf/itests/FeatureTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/FeatureTest.java
@@ -77,7 +77,7 @@ public class FeatureTest extends BaseTest {
 
     @Test
     public void listCommandFromRepository() {
-        executeCommand("feature:repo-add mvn:org.apache.karaf.cellar/apache-karaf-cellar/3.0.0/xml/features");
+        executeCommand("feature:repo-add mvn:org.apache.karaf.cellar/apache-karaf-cellar/3.0.0/xml/features", new RolePrincipal("viewer"));
         String repositoryName = "karaf-cellar-3.0.0";
         String featureListOutput = executeCommand("feature:list --repository " + repositoryName);
         assertFalse(featureListOutput.isEmpty());
@@ -151,17 +151,17 @@ public class FeatureTest extends BaseTest {
 
     @Test
     public void repoAddRemoveCommand() throws Exception {
-        System.out.println(executeCommand("feature:repo-add mvn:org.apache.karaf.cellar/apache-karaf-cellar/3.0.0/xml/features"));
+        System.out.println(executeCommand("feature:repo-add mvn:org.apache.karaf.cellar/apache-karaf-cellar/3.0.0/xml/features", new RolePrincipal("viewer")));
         assertContains("apache-karaf-cellar", executeCommand("feature:repo-list"));
-        System.out.println(executeCommand("feature:repo-remove mvn:org.apache.karaf.cellar/apache-karaf-cellar/3.0.0/xml/features"));
+        System.out.println(executeCommand("feature:repo-remove mvn:org.apache.karaf.cellar/apache-karaf-cellar/3.0.0/xml/features", new RolePrincipal("viewer")));
         assertContainsNot("apache-karaf-cellar", executeCommand("feature:repo-list"));
     }
 
     @Test
     public void repoAddRemoveCommandWithRegex() throws Exception {
-        System.out.println(executeCommand("feature:repo-add mvn:org.apache.karaf.cellar/apache-karaf-cellar/3.0.0/xml/features"));
+        System.out.println(executeCommand("feature:repo-add mvn:org.apache.karaf.cellar/apache-karaf-cellar/3.0.0/xml/features", new RolePrincipal("viewer")));
         assertContains("apache-karaf-cellar", executeCommand("feature:repo-list"));
-        System.out.println(executeCommand("feature:repo-remove '.*apache-karaf-cellar.*'"));
+        System.out.println(executeCommand("feature:repo-remove '.*apache-karaf-cellar.*'", new RolePrincipal("viewer")));
         assertContainsNot("apache-karaf-cellar", executeCommand("feature:repo-list"));
     }
 

--- a/itests/test/src/test/java/org/apache/karaf/itests/ssh/FeatureSshCommandSecurityTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/ssh/FeatureSshCommandSecurityTest.java
@@ -55,4 +55,29 @@ public class FeatureSshCommandSecurityTest extends SshCommandTestBase {
         Assert.assertFalse(feature + " feature should have been uninstalled",
                 r5.contains(feature));
     }
+
+    @Test
+    public void testFeatureRepoCommandSecurityViaSsh() throws Exception {
+        String vieweruser = "viewer" + System.nanoTime() + "_repos";
+        // Deliberately non-existent so repo-add/repo-remove never actually add, install, remove
+        // or uninstall anything; this test only cares about the ACL decision, not the outcome of
+        // the underlying operation.
+        // Note: the ACL regex matches against the whole argument list, so this URL must not
+        // itself contain "-i" or "-u" or it would coincidentally match the option-specific rules.
+        String bogusUrl = "file:///nonexistent/karaf-test-repo-features.xml";
+
+        addViewer(vieweruser);
+
+        // repo-add/repo-remove without options are not gated by any role, same as before this ACL
+        // was introduced: only the -i/-u options (which install/uninstall every feature in the
+        // repository) must require admin.
+        assertCommand(vieweruser, "feature:repo-add " + bogusUrl, Result.OK);
+        assertCommand(vieweruser, "feature:repo-remove " + bogusUrl, Result.OK);
+
+        assertCommand(vieweruser, "feature:repo-add -i " + bogusUrl, Result.NO_CREDENTIALS);
+        assertCommand(vieweruser, "feature:repo-remove -u " + bogusUrl, Result.NO_CREDENTIALS);
+
+        assertCommand("karaf", "feature:repo-add -i " + bogusUrl, Result.OK);
+        assertCommand("karaf", "feature:repo-remove -u " + bogusUrl, Result.OK);
+    }
 }

--- a/manual/src/main/asciidoc/user-guide/security.adoc
+++ b/manual/src/main/asciidoc/user-guide/security.adoc
@@ -491,8 +491,9 @@ By default, Apache Karaf defines the following commands ACLs:
  `org.apache.karaf.service.acl.*` configuration PID to the users with `admin` role. For the other configuration PID,
  the users with the `manager` role can execute `config:*` commands.
 * `etc/org.apache.karaf.command.acl.feature.cfg` configuration file defines the ACL for `feature:*` commands.
- Only the users with `admin` role can execute `feature:install`, `feature:uninstall`,`feature:start`, `feature:stop` and `feature:update` commands. The other `feature:*`
- commands can be executed by any user.
+ Only the users with `admin` role can execute `feature:install`, `feature:uninstall`,`feature:start`, `feature:stop` and `feature:update` commands. `feature:repo-add`
+ and `feature:repo-remove` require the `admin` role only when used with the `-i`/`--install` or `-u`/`--uninstall` option, which installs or uninstalls every
+ feature in the repository; otherwise they only require the `viewer` role. The other `feature:*` commands can be executed by any user.
 * `etc/org.apache.karaf.command.acl.jaas.cfg` configuration file defines the ACL for `jaas:*` commands.
  Only the users with `admin` role can execute `jaas:update` command. The other `jaas:*` commands can be executed by any
  user.


### PR DESCRIPTION
## Summary
Backport of #2883 to `karaf-4.4.x`.

- `feature:repo-add -i <url>` and `feature:repo-remove -u <url>` call `FeaturesServiceImpl.addRepository()`/`removeRepository()` with the install/uninstall flag set, which installs (and starts) or uninstalls every feature in the given repository.
- Neither `repo-add` nor `repo-remove` had an entry in the `feature` scope's command ACL, so any SSH user holding only the `viewer` role could reach them and have Karaf install/start an arbitrary attacker-supplied features repository — bypassing the admin-only ACL already enforced on `feature:install`/`feature:uninstall`.
- Adds option-specific ACL rules, mirroring the existing pattern used for `bundle:refresh -f` and similar bundle-scope commands: only the `-i`/`-u` option variants now require `admin`; plain `repo-add`/`repo-remove` (which don't install/uninstall anything) remain open as before, so there's no behavior change beyond closing the escalation path.
- Applied identically in the three places the `feature` ACL is defined on this branch: the standard assembly `feature.xml`, the `instance` `etc` template, and the itest config fixture.
- Adds a regression test (`FeatureSshCommandSecurityTest#testFeatureRepoCommandSecurityViaSsh`) exercising the ACL boundary for both a viewer and an admin user, using a non-existent repository URL so nothing is actually installed/removed.

## Test plan
- [x] `mvn -pl itests/test test-compile` passes
- [ ] Full PaxExam SSH itest suite (`itests/test`) run in CI