### PR TITLE
Drop guava 23

### DIFF
--- a/itests/test/pom.xml
+++ b/itests/test/pom.xml
@@ -191,13 +191,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>jetty-websocket-jetty-client</artifactId>
             <version>${jetty.version}</version>

--- a/itests/test/src/test/java/org/apache/karaf/itests/ssh/SshKeyFormatTest.java
+++ b/itests/test/src/test/java/org/apache/karaf/itests/ssh/SshKeyFormatTest.java
@@ -20,9 +20,6 @@
 
 package org.apache.karaf.itests.ssh;
 
-import com.google.common.io.ByteSource;
-import com.google.common.io.Resources;
-
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.future.ConnectFuture;
 import org.apache.sshd.client.keyverifier.RequiredServerKeyVerifier;
@@ -39,7 +36,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.util.EnumSet;
@@ -59,8 +55,7 @@ public class SshKeyFormatTest extends SshCommandTestBase {
         return options(composite(super.config()),
                 editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "hostKey", keyFile.getAbsolutePath()),
                 bundle("mvn:org.bouncycastle/bcprov-jdk15on/1.66"),
-                bundle("mvn:org.bouncycastle/bcpkix-jdk15on/1.66"),
-                bundle("mvn:com.google.guava/guava/16.0.1")
+                bundle("mvn:org.bouncycastle/bcpkix-jdk15on/1.66")
                 );
     }
 
@@ -68,9 +63,7 @@ public class SshKeyFormatTest extends SshCommandTestBase {
     @Test
     public void usePemKey() throws Exception {
         SshClient client = SshClient.setUpDefaultClient();
-        URL testPemURL = Resources.getResource(SshKeyFormatTest.class, "test.pem");
-        ByteSource source = Resources.asByteSource(testPemURL);
-        KeyPair keyPair = getKeyPair(source.openStream());
+        KeyPair keyPair = getKeyPair(SshKeyFormatTest.class.getResourceAsStream("test.pem"));
 
         String sshPort = getSshPort();
 

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,6 @@
 
         <openjpa.version>3.2.2</openjpa.version>
         <geronimo.transaction.manager.version>3.1.3</geronimo.transaction.manager.version>
-        <guava.version>23.0</guava.version>
         <narayana.version>5.13.1.Final</narayana.version>
         <hibernate.ejb.version>3.4.0.GA</hibernate.ejb.version>
         <hibernate.version>7.4.7.Final</hibernate.version>

--- a/tooling/utils/pom.xml
+++ b/tooling/utils/pom.xml
@@ -49,12 +49,6 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/tooling/utils/src/test/java/org/apache/karaf/tools/utils/KarafPropertiesEditorTest.java
+++ b/tooling/utils/src/test/java/org/apache/karaf/tools/utils/KarafPropertiesEditorTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.karaf.tools.utils;
 
-import com.google.common.io.Resources;
 import org.apache.karaf.tools.utils.model.KarafPropertyEdits;
 import org.apache.karaf.tools.utils.model.io.stax.KarafPropertyInstructionsModelStaxReader;
 import org.junit.Test;
@@ -25,7 +24,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.net.URL;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,9 +42,8 @@ public class KarafPropertiesEditorTest {
     @Test
     public void onceOver() throws Exception {
         KarafPropertyInstructionsModelStaxReader kipmsr = new KarafPropertyInstructionsModelStaxReader();
-        URL editsUrl = Resources.getResource(KarafPropertiesEditorTest.class, "test-edits.xml");
         KarafPropertyEdits edits;
-        try (InputStream editsStream = Resources.asByteSource(editsUrl).openStream()) {
+        try (InputStream editsStream = KarafPropertiesEditorTest.class.getResourceAsStream("test-edits.xml")) {
             edits = kipmsr.read(editsStream, true);
         }
 


### PR DESCRIPTION
Remove outdated guava version from Karaf. The only use was in itests and could be replaced by JDK methods.