### PR TITLE
Restrict WebConsole plugin getResource() to /res/ paths

### DIFF
--- a/webconsole/features/src/main/java/org/apache/karaf/webconsole/features/FeaturesPlugin.java
+++ b/webconsole/features/src/main/java/org/apache/karaf/webconsole/features/FeaturesPlugin.java
@@ -132,7 +132,7 @@ public class FeaturesPlugin extends AbstractServlet {
     @Override
     protected URL getResource(String path) {
         path = path.substring(NAME.length() + 1);
-        if (path == null || path.isEmpty()) {
+        if (path == null || path.isEmpty() || !path.startsWith("/res/")) {
             return null;
         }
         URL url = this.classLoader.getResource(path);

--- a/webconsole/gogo/src/main/java/org/apache/karaf/webconsole/gogo/GogoPlugin.java
+++ b/webconsole/gogo/src/main/java/org/apache/karaf/webconsole/gogo/GogoPlugin.java
@@ -97,7 +97,7 @@ public class GogoPlugin extends AbstractServlet {
     @Override
     protected URL getResource(String path) {
         path = path.substring(NAME.length() + 1);
-        if (path == null || path.isEmpty()) {
+        if (path == null || path.isEmpty() || !path.startsWith("/res/")) {
             return null;
         }
         URL url = this.getClass().getClassLoader().getResource(path);

--- a/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/HttpPlugin.java
+++ b/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/HttpPlugin.java
@@ -98,7 +98,7 @@ public class HttpPlugin extends AbstractServlet {
     @Override
     protected URL getResource(String path) {
         path = path.substring(NAME.length() + 1);
-        if (path.isEmpty()) {
+        if (path.isEmpty() || !path.startsWith("/res/")) {
             return null;
         }
         URL url = this.classLoader.getResource(path);

--- a/webconsole/instance/src/main/java/org/apache/karaf/webconsole/instance/InstancePlugin.java
+++ b/webconsole/instance/src/main/java/org/apache/karaf/webconsole/instance/InstancePlugin.java
@@ -157,7 +157,7 @@ public class InstancePlugin extends AbstractServlet {
     @Override
     protected URL getResource(String path) {
         path = path.substring(NAME.length() + 1);
-        if (path == null || path.isEmpty()) {
+        if (path == null || path.isEmpty() || !path.startsWith("/res/")) {
             return null;
         }
         URL url = this.classLoader.getResource(path);


### PR DESCRIPTION
## Summary
- `FeaturesPlugin`, `GogoPlugin`, `HttpPlugin` and `InstancePlugin` override `getResource()` and hand the request path directly to `classLoader.getResource()` with no restriction.
- Felix's own `AbstractServlet.getResource()` (org.apache.felix.webconsole) only spools paths whose remainder starts with `/res/`; these four Karaf plugins dropped that check.
- Restores the `/res/` prefix check in all four plugins so only each plugin's own bundled static resources (JS/CSS/images) can be served through this path, matching upstream Felix behavior.

## Test plan
- [x] `mvn -pl webconsole/features,webconsole/gogo,webconsole/http,webconsole/instance -am compile` succeeds
- [x] `mvn -pl webconsole/features,webconsole/gogo,webconsole/http,webconsole/instance -am test` succeeds (existing `InstancePluginTest` passes)
- [ ] Manual verification that `/system/console/features/res/...`, `/system/console/gogo/res/...`, `/system/console/http/res/...`, `/system/console/instance/res/...` still resolve their JS/CSS/image resources correctly in a running instance