### PR TITLE
[4.4.x] Upgrade org.eclipse.osgi from 3.18.0 to 3.18.600

### DIFF
--- a/main/src/main/java/org/apache/karaf/main/Main.java
+++ b/main/src/main/java/org/apache/karaf/main/Main.java
@@ -537,7 +537,14 @@ public class Main {
         if (factoryClass == null) {
             InputStream is = classLoader.getResourceAsStream("META-INF/services/" + FrameworkFactory.class.getName());
             BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
-            factoryClass = br.readLine();
+            String line;
+            while ((line = br.readLine()) != null) {
+                line = line.trim();
+                if (!line.isEmpty() && !line.startsWith("#")) {
+                    factoryClass = line;
+                    break;
+                }
+            }
             br.close();
         }
         FrameworkFactory factory = (FrameworkFactory) classLoader.loadClass(factoryClass).newInstance();

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <easymock.version>5.7.0</easymock.version>
         <equinox.groupId>org.eclipse.platform</equinox.groupId>
         <equinox.artifactId>org.eclipse.osgi</equinox.artifactId>
-        <equinox.version>3.18.0</equinox.version>
+        <equinox.version>3.18.600</equinox.version>
         <equinox.region.version>1.5.800</equinox.region.version>
         <equinox.coordinator.version>1.5.500</equinox.coordinator.version>
 


### PR DESCRIPTION
This PR included the changes to handle comment in  #2303.

This may fix #2731, but not necessarily, as the CVE has no version range specified for the 3.18.x series, or?

@jbonofre I have used 3.18.600 for maximum compatibility, but maybe we should use a later version. Please advise.