### PR TITLE
[4.4.x] Upgrade bouncycastle from 1.85 to 1.86

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <asm.version>9.10.1</asm.version>
         <javax.annotation.version>1.3.2</javax.annotation.version>
         <awaitility.version>3.1.6</awaitility.version>
-        <bouncycastle.version>1.85</bouncycastle.version>
+        <bouncycastle.version>1.86</bouncycastle.version>
         <camel.version>3.22.4</camel.version>
         <cglib.bundle.version>3.2.9_1</cglib.bundle.version>
         <cxf.version>3.6.12</cxf.version>


### PR DESCRIPTION
Changelog:
https://github.com/bcgit/bc-java/blob/main/docs/releasenotes.md