### PR TITLE
Fix race condition corrupting cfg files when updating an existing configuration

### DIFF
--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
@@ -21,6 +21,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -330,7 +332,8 @@ public class FeatureConfigInstaller {
                 } else {
                     props.save(tmpCfgFile);
                 }
-                tmpCfgFile.renameTo(cfgFile);
+                Files.move(tmpCfgFile.toPath(), cfgFile.toPath(),
+                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
             } else {
                 updateExistingConfig(props, append, cfgFile, jsonFormat);
             }
@@ -409,7 +412,10 @@ public class FeatureConfigInstaller {
         } else {
             properties.save(tmpCfgFile);
         }
-        tmpCfgFile.renameTo(cfgFile);
+        // File.renameTo() silently fails on Windows when the destination already exists,
+        // so use Files.move() with REPLACE_EXISTING to get a working atomic replace on every OS
+        Files.move(tmpCfgFile.toPath(), cfgFile.toPath(),
+                StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
     }
 
     private boolean isInternalKey(String key) {

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
@@ -332,8 +332,12 @@ public class FeatureConfigInstaller {
                 } else {
                     props.save(tmpCfgFile);
                 }
-                Files.move(tmpCfgFile.toPath(), cfgFile.toPath(),
-                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+try {
+                    Files.move(tmpCfgFile.toPath(), cfgFile.toPath(),
+                            StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                } catch (java.nio.file.AtomicMoveNotSupportedException e) {
+                    Files.move(tmpCfgFile.toPath(), cfgFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                }
             } else {
                 updateExistingConfig(props, append, cfgFile, jsonFormat);
             }

--- a/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
+++ b/features/core/src/main/java/org/apache/karaf/features/internal/service/FeatureConfigInstaller.java
@@ -400,11 +400,16 @@ public class FeatureConfigInstaller {
             }
         }
         storage.mkdirs();
+        // write to a temporary file and rename it to the target file so that a concurrent writer
+        // (e.g. fileinstall persisting the configuration update on the CM Event Dispatcher thread)
+        // never observes a partially written / corrupted cfg file
+        File tmpCfgFile = File.createTempFile(cfgFile.getName(), ".tmp", cfgFile.getParentFile());
         if (jsonFormat) {
-            Configurations.buildWriter().build(new FileWriter(cfgFile)).writeConfiguration(new Hashtable(properties));
+            Configurations.buildWriter().build(new FileWriter(tmpCfgFile)).writeConfiguration(new Hashtable(properties));
         } else {
-            properties.save(cfgFile);
+            properties.save(tmpCfgFile);
         }
+        tmpCfgFile.renameTo(cfgFile);
     }
 
     private boolean isInternalKey(String key) {

--- a/features/core/src/test/java/org/apache/karaf/features/internal/service/FeatureConfigInstallerTest.java
+++ b/features/core/src/test/java/org/apache/karaf/features/internal/service/FeatureConfigInstallerTest.java
@@ -16,14 +16,21 @@
  */
 package org.apache.karaf.features.internal.service;
 
+import org.apache.felix.utils.properties.TypedProperties;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.StringReader;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.util.Objects;
 
 public class FeatureConfigInstallerTest {
-    
+
     private void substEqual(final String src, final String subst) {
         assertEquals(FeatureConfigInstaller.substFinalName(src), subst);
     }
@@ -49,6 +56,42 @@ public class FeatureConfigInstallerTest {
         substEqual("${karaf.base}${bar}/etc/test.cfg", karafBase + "/etc/test.cfg");
         substEqual("etc${}/${foo}/test.cfg", karafBase + File.separator + "etc//test.cfg");
         substEqual("${foo}${bar}/${bar}${foo}", foo + "/" + foo);
+    }
+
+    /**
+     * GH-2805: updating an existing cfg file (append or override) must write through a
+     * temporary file and rename it into place, so that a concurrent writer (e.g. fileinstall
+     * persisting the same configuration on the CM Event Dispatcher thread) can never observe
+     * a partially written / corrupted cfg file, and no leftover temp file remains behind.
+     */
+    @Test
+    public void testUpdateExistingConfigWritesAtomically() throws Exception {
+        File tmpDir = Files.createTempDirectory("karaf-feature-config-installer-test").toFile();
+        System.setProperty("karaf.etc", tmpDir.getAbsolutePath());
+
+        File cfgFile = new File(tmpDir, "my.pid.cfg");
+        try (FileWriter writer = new FileWriter(cfgFile)) {
+            writer.write("existing.key=existing.value\n");
+        }
+
+        TypedProperties toAppend = new TypedProperties();
+        toAppend.load(new StringReader("appended.key=appended.value\n"));
+
+        FeatureConfigInstaller installer = new FeatureConfigInstaller(null, true);
+
+        Method updateExistingConfig = FeatureConfigInstaller.class.getDeclaredMethod(
+                "updateExistingConfig", TypedProperties.class, boolean.class, File.class, boolean.class);
+        updateExistingConfig.setAccessible(true);
+        updateExistingConfig.invoke(installer, toAppend, true, cfgFile, false);
+
+        TypedProperties result = new TypedProperties();
+        result.load(cfgFile);
+        assertEquals("existing.value", result.get("existing.key"));
+        assertEquals("appended.value", result.get("appended.key"));
+
+        File[] leftovers = tmpDir.listFiles((dir, name) -> name.endsWith(".tmp"));
+        assertTrue("no temporary file must be left behind after the atomic rename",
+                Objects.requireNonNull(leftovers).length == 0);
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes #2805.

`FeatureConfigInstaller.updateExistingConfig()` (used both for the `append` and `override` config flows) read the existing cfg file, merged in the new properties in memory, then wrote the result **directly back to the target file** (`properties.save(cfgFile)` / `Configurations.buildWriter().build(new FileWriter(cfgFile))...`).

Calling `cfg.update(...)` just before that write also triggers Configuration Admin to notify its persistence manager (fileinstall), which persists the very same configuration to the very same cfg file on the CM Event Dispatcher thread. With two unsynchronized, non-atomic writers hitting the same file at once, the writes can interleave and corrupt the file (as shown in the issue, where lines from the old file content bleed into the newly written content).

The "file doesn't exist yet" path already avoids this by writing to a temp file and renaming it atomically into place (KARAF-7389 / #1489), but that fix didn't cover the "file already exists" path exercised by `append`/`override`. This PR applies the same temp-file + atomic rename pattern to `updateExistingConfig()`, for both the properties and JSON formats, so a concurrent reader/writer can only ever observe a fully-old or fully-new file, never a torn one.

## Test plan

- [x] `mvn -pl features/core test` — all existing tests pass (139 tests)
- [x] Added `FeatureConfigInstallerTest#testUpdateExistingConfigWritesAtomically`, which exercises `updateExistingConfig()` against a pre-existing cfg file and asserts the merged content is correct and no leftover `.tmp` file remains after the rename